### PR TITLE
[Fix] tighten sub-agent permissions and chat fallbacks

### DIFF
--- a/packages/core/resources/presets/sydney.yml
+++ b/packages/core/resources/presets/sydney.yml
@@ -1,7 +1,5 @@
 keywords:
   - sydney
-  - chatgpt
-  - gpt
 
 prompts:
   - role: system

--- a/packages/core/src/llm-core/chat/app.ts
+++ b/packages/core/src/llm-core/chat/app.ts
@@ -487,11 +487,22 @@ async function autoSummarizeTitle(
         `Assistant: ${aiContent}`
 
     try {
-        const result = await wrapper.model.invoke([new HumanMessage(prompt)])
+        const result = await wrapper.model.invoke([new HumanMessage(prompt)], {
+            configurable: {
+                id: conversationId
+            },
+            id: conversationId,
+            variables_hide: {
+                built: {
+                    conversationId
+                }
+            }
+        })
         const title = getMessageContent(result.content).trim().slice(0, 20)
 
         await chatluna.conversation.touchConversation(conversationId, {
-            title
+            title,
+            autoTitle: false
         })
     } catch (error) {
         logger.error(error)

--- a/packages/core/src/llm-core/chat/app.ts
+++ b/packages/core/src/llm-core/chat/app.ts
@@ -500,6 +500,10 @@ async function autoSummarizeTitle(
         })
         const title = getMessageContent(result.content).trim().slice(0, 20)
 
+        if (!title) {
+            return
+        }
+
         await chatluna.conversation.touchConversation(conversationId, {
             title,
             autoTitle: false

--- a/packages/core/src/llm-core/chat/helper.ts
+++ b/packages/core/src/llm-core/chat/helper.ts
@@ -6,13 +6,18 @@ import { emptyEmbeddings } from 'koishi-plugin-chatluna/llm-core/model/in_memory
 import {
     PlatformEmbeddingsClient,
     PlatformModelAndEmbeddingsClient,
-    PlatformModelClient
+    PlatformModelClient,
+    PlatformModelEmbeddingsAndRerankerClient
 } from 'koishi-plugin-chatluna/llm-core/platform/client'
-import { ChatLunaChatModel } from 'koishi-plugin-chatluna/llm-core/platform/model'
+import {
+    ChatLunaBaseEmbeddings,
+    ChatLunaChatModel
+} from 'koishi-plugin-chatluna/llm-core/platform/model'
 import { PlatformService } from 'koishi-plugin-chatluna/llm-core/platform/service'
 import {
     ModelCapabilities,
-    ModelInfo
+    ModelInfo,
+    ModelType
 } from 'koishi-plugin-chatluna/llm-core/platform/types'
 import { parseRawModelName } from 'koishi-plugin-chatluna/llm-core/utils/count_tokens'
 import {
@@ -48,37 +53,70 @@ export async function initEmbeddings(
         return computed(() => emptyEmbeddings)
     }
 
+    if (platform == null || modelName == null) {
+        logger.warn(
+            `Embeddings model ${model} is invalid, falling back to empty embeddings`
+        )
+        return computed(() => emptyEmbeddings)
+    }
+
     const clientRef = await service.getClient(platform)
+    const info = service.findModel(platform, modelName)
 
     return computed<Embeddings>(() => {
         const client = clientRef.value
 
         logger.info(`Init embeddings for %c`, model)
 
-        if (client == null || client instanceof PlatformModelClient) {
+        if (info.value == null) {
             logger.warn(
-                `Platform ${platform} is not supported, falling back to fake embeddings`
+                `Embeddings model ${modelName} not found, falling back to empty embeddings`
             )
             return emptyEmbeddings
         }
 
-        if (client instanceof PlatformEmbeddingsClient) {
-            return client.createModel(modelName)
+        if (info.value.type !== ModelType.embeddings) {
+            logger.warn(
+                `Model ${modelName} is not an embeddings model, falling back to empty embeddings`
+            )
+            return emptyEmbeddings
         }
 
-        if (client instanceof PlatformModelAndEmbeddingsClient) {
-            const ref = client.createModel(modelName)
+        if (client == null || client instanceof PlatformModelClient) {
+            logger.warn(
+                `Platform ${platform} is not supported, falling back to empty embeddings`
+            )
+            return emptyEmbeddings
+        }
 
-            if (ref instanceof ChatLunaChatModel) {
+        if (
+            client instanceof PlatformEmbeddingsClient ||
+            client instanceof PlatformModelAndEmbeddingsClient ||
+            client instanceof PlatformModelEmbeddingsAndRerankerClient
+        ) {
+            try {
+                const ref = client.createModel(modelName)
+
+                if (ref instanceof ChatLunaBaseEmbeddings) {
+                    return ref
+                }
+
                 logger.warn(
-                    `Model ${modelName} is not an embeddings model, falling back to fake embeddings`
+                    `Model ${modelName} is not an embeddings model, falling back to empty embeddings`
+                )
+                return emptyEmbeddings
+            } catch (error) {
+                logger.warn(
+                    `Embeddings model ${modelName} not found, falling back to empty embeddings`,
+                    error
                 )
                 return emptyEmbeddings
             }
-
-            return ref
         }
 
+        logger.warn(
+            `Platform ${platform} is not supported, falling back to empty embeddings`
+        )
         return emptyEmbeddings
     })
 }

--- a/packages/core/src/locales/en-US.yml
+++ b/packages/core/src/locales/en-US.yml
@@ -553,6 +553,7 @@ chatluna:
             broken: 'broken'
         messages:
             unavailable: 'The model {0} for this conversation is unavailable. Please contact an administrator to configure the API.'
+            preset_unavailable: 'The preset {0} for this conversation is unavailable. Please contact an administrator to configure the preset.'
             new_success: 'Created conversation: {0}'
             new_forbidden: 'Creating new conversations is disabled in the current route.'
             admin_required: 'Conversation management requires administrator permission in the current route.'

--- a/packages/core/src/locales/zh-CN.yml
+++ b/packages/core/src/locales/zh-CN.yml
@@ -552,6 +552,7 @@ chatluna:
             broken: '已损坏'
         messages:
             unavailable: '当前会话对应的模型 {0} 不可用，请联系管理员配置 API。'
+            preset_unavailable: '当前会话对应的预设 {0} 不可用，请联系管理员配置预设。'
             new_success: '已创建会话：{0}'
             new_forbidden: '当前路由已禁止创建新会话。'
             admin_required: '当前路由要求管理员权限才能管理会话。'

--- a/packages/core/src/middlewares/model/resolve_model.ts
+++ b/packages/core/src/middlewares/model/resolve_model.ts
@@ -33,8 +33,17 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                     ctx.chatluna.preset.getPreset(presetName, false).value !=
                         null
 
+                if (!presetExists) {
+                    await context.send(
+                        session.text(
+                            'chatluna.conversation.messages.preset_unavailable',
+                            [presetName]
+                        )
+                    )
+                    return ChainMiddlewareRunStatus.STOP
+                }
+
                 if (
-                    !presetExists ||
                     modelName.trim().length < 1 ||
                     modelName === '无' ||
                     modelName === 'empty'

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -333,15 +333,37 @@ export class ChatLunaService extends Service<Config> {
             ;[platformName, modelName] = parseRawModelName(platformName)
         }
 
+        if (
+            platformName == null ||
+            modelName == null ||
+            modelName.length < 1 ||
+            modelName === '无'
+        ) {
+            return computed(() => emptyEmbeddings)
+        }
+
         const client = await service.getClient(platformName)
+        const info = service.findModel(platformName, modelName)
 
         return computed(() => {
+            if (info.value == null) {
+                this.ctx.logger.warn(
+                    `The embeddings model ${modelName} not found, return empty embeddings`
+                )
+                return emptyEmbeddings
+            }
+
+            if (info.value.type !== ModelType.embeddings) {
+                this.ctx.logger.warn(
+                    `The model ${modelName} is not embeddings, return empty embeddings`
+                )
+                return emptyEmbeddings
+            }
+
             if (client.value == null) {
-                if (platformName !== '无') {
-                    this.ctx.logger.warn(
-                        `The platform ${platformName} no available`
-                    )
-                }
+                this.ctx.logger.warn(
+                    `The platform ${platformName} no available, return empty embeddings`
+                )
                 return emptyEmbeddings
             }
 
@@ -353,6 +375,7 @@ export class ChatLunaService extends Service<Config> {
                 }
             } catch (error) {
                 this.ctx.logger.warn(`The model ${modelName} not found`, error)
+                return emptyEmbeddings
             }
 
             this.ctx.logger.warn(

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -264,7 +264,7 @@ export class ChatLunaService extends Service<Config> {
             this.ctx,
             {
                 chatMode: conversation.chatMode,
-                autoTitle: conversation.autoTitle ?? true,
+                autoTitle: conversation.autoTitle === true,
                 botName: config.botNames[0],
                 preset: this.preset.getPreset(conversation.preset),
                 model: conversation.model,

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-agent",
     "description": "Agent framework for ChatLuna",
-    "version": "1.0.25",
+    "version": "1.0.26",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-agent/src/config/defaults.ts
+++ b/packages/extension-agent/src/config/defaults.ts
@@ -300,9 +300,9 @@ export function createDefaultSubAgentConfig(): SubAgentConfig {
         },
         presetAgents: {},
         defaults: {
-            skills: createPermissionRule('allow'),
-            mcp: createPermissionRule('inherit'),
-            tools: createPermissionRule('inherit'),
+            skills: createPermissionRule('deny'),
+            mcp: createPermissionRule('deny'),
+            tools: createPermissionRule('deny'),
             computer: createPermissionRule('allow')
         }
     }

--- a/packages/extension-agent/src/service/mcp.ts
+++ b/packages/extension-agent/src/service/mcp.ts
@@ -396,6 +396,7 @@ export class ChatLunaAgentMcpService {
         const serverCfg = this.config.mcp.mcpServers[serverName]
         if (!serverCfg) return
 
+        this.ctx.chatluna_agent?.permission.invalidateCache()
         this._disposeTools(serverName)
 
         const names = new Set<string>()
@@ -483,6 +484,8 @@ export class ChatLunaAgentMcpService {
                 delete this._tools[toolName]
             }
         }
+
+        this.ctx.chatluna_agent?.permission.invalidateCache()
     }
 
     private async _drop(name: string, clearTools = true) {
@@ -506,6 +509,8 @@ export class ChatLunaAgentMcpService {
                 }
             }
         }
+
+        this.ctx.chatluna_agent?.permission.invalidateCache()
     }
 
     private async _remove(name: string) {

--- a/packages/extension-agent/src/service/permissions.ts
+++ b/packages/extension-agent/src/service/permissions.ts
@@ -419,15 +419,12 @@ export class ChatLunaAgentPermissionService {
             return false
         }
 
-        if (
-            !matchRule(
-                name,
-                this.mergeRule(
-                    info.permissions.tools,
-                    this.config.subAgent.defaults.tools
-                )
-            )
-        ) {
+        const rule = this.mergeRule(
+            info.permissions.tools,
+            this.config.subAgent.defaults.tools
+        )
+
+        if (!matchRule(name, rule)) {
             return false
         }
 

--- a/packages/extension-agent/src/sub-agent/run.ts
+++ b/packages/extension-agent/src/sub-agent/run.ts
@@ -179,10 +179,10 @@ function createTools(
     permission: ChatLunaAgentPermissionService,
     info: SubAgentInfo
 ): ComputedRef<ChatLunaTool[]> {
+    const tools = ctx.chatluna.platform.getTools()
+
     return computed(() =>
-        permission
-            .listTools()
-            .map((item) => item.name)
+        tools.value
             .filter((name) => permission.canUseTool(info, name))
             .map((name) => ctx.chatluna.platform.getTool(name))
     )

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -66,8 +66,8 @@
         "@types/turndown": "^5.0.6",
         "atsc": "^2.1.0",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna-agent": "^1.0.25",
-        "koishi-plugin-adapter-onebot": "^6.8.0"
+        "koishi-plugin-adapter-onebot": "^6.8.0",
+        "koishi-plugin-chatluna-agent": "^1.0.25"
     },
     "peerDependencies": {
         "koishi": "^4.18.9",


### PR DESCRIPTION
This pr fixes sub-agent tool access, conversation preset errors, embeddings initialization, and auto-title updates so unavailable resources fail safely and conversation state stays consistent.

## New Features

None

## Bug fixes

- Default sub-agent skills, MCP, and tools permissions now deny access unless explicitly allowed.
- Invalidate permission caches when MCP servers or tools are updated, disposed, or dropped.
- Build sub-agent tool lists from the live platform tool registry so MCP tool changes are visible.
- Apply merged tool permission rules consistently before exposing a tool to sub-agents.
- Report unavailable conversation presets with dedicated localized messages instead of treating them like missing models.
- Validate embeddings model existence and type before initialization, returning empty embeddings when the platform or model is unavailable.
- Support model clients that provide embeddings and reranker models when initializing embeddings.
- Pass conversation context when generating auto titles and disable `autoTitle` after the title is written.
- Treat conversations as auto-title enabled only when `autoTitle` is explicitly true.
- Skip auto-title conversation updates when the generated title is empty.

## Other Changes

- Bump `koishi-plugin-chatluna-agent` from `1.0.25` to `1.0.26`.
- Remove broad `chatgpt` and `gpt` keywords from the Sydney preset.
- Sort `extension-tools` development dependencies consistently.