### PR TITLE
[Fix] validate routing and stabilize skill reloads

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -46,7 +46,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.36",
+        "@chatluna/v1-shared-adapter": "^1.0.37",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -47,7 +47,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.36",
+        "@chatluna/v1-shared-adapter": "^1.0.37",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.36",
+        "@chatluna/v1-shared-adapter": "^1.0.37",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.36",
+        "@chatluna/v1-shared-adapter": "^1.0.37",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -63,7 +63,7 @@
     ],
     "dependencies": {
         "@anatine/zod-openapi": "^2.2.8",
-        "@chatluna/v1-shared-adapter": "^1.0.36",
+        "@chatluna/v1-shared-adapter": "^1.0.37",
         "@langchain/core": "^0.3.80",
         "openapi3-ts": "^4.5.0",
         "zod": "3.25.76",

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.36",
+        "@chatluna/v1-shared-adapter": "^1.0.37",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.36",
+        "@chatluna/v1-shared-adapter": "^1.0.37",
         "@langchain/core": "^0.3.80"
     },
     "devDependencies": {

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-like-adapter",
     "description": "openai style api adapter for chatluna",
-    "version": "1.4.0-alpha.4",
+    "version": "1.4.0-alpha.5",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.36",
+        "@chatluna/v1-shared-adapter": "^1.0.37",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-adapter",
     "description": "openai adapter for chatluna",
-    "version": "1.4.0-alpha.4",
+    "version": "1.4.0-alpha.5",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.36",
+        "@chatluna/v1-shared-adapter": "^1.0.37",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.36",
+        "@chatluna/v1-shared-adapter": "^1.0.37",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-qwen-adapter",
     "description": "qwen adapter for chatluna",
-    "version": "1.4.0-alpha.1",
+    "version": "1.4.0-alpha.2",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "1.0.36",
+        "@chatluna/v1-shared-adapter": "1.0.37",
         "@langchain/core": "^0.3.80",
         "zod-to-json-schema": "3.23.5"
     },

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -61,7 +61,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.36",
+        "@chatluna/v1-shared-adapter": "^1.0.37",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.36",
+        "@chatluna/v1-shared-adapter": "^1.0.37",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.36",
+        "@chatluna/v1-shared-adapter": "^1.0.37",
         "@langchain/core": "^0.3.80",
         "jsonwebtoken": "^9.0.2",
         "zod": "3.25.76",

--- a/packages/core/src/locales/en-US.yml
+++ b/packages/core/src/locales/en-US.yml
@@ -568,6 +568,7 @@ chatluna:
             fixed_model: 'The current route fixes the model to {0}.'
             fixed_preset: 'The current route fixes the preset to {0}.'
             fixed_chat_mode: 'The current route fixes the chat mode to {0}.'
+            invalid_chat_mode: 'Chat mode {0} is unavailable. Check the input and try again.'
             switch_success: 'Switched to: {0}'
             switch_failed: 'Failed to switch conversation: {0}'
             list_header: 'Conversations in the current route:'

--- a/packages/core/src/locales/zh-CN.yml
+++ b/packages/core/src/locales/zh-CN.yml
@@ -567,6 +567,7 @@ chatluna:
             fixed_model: '当前路由已将模型固定为 {0}。'
             fixed_preset: '当前路由已将预设固定为 {0}。'
             fixed_chat_mode: '当前路由已将聊天模式固定为 {0}。'
+            invalid_chat_mode: '聊天模式 {0} 不可用，请检查输入是否正确。'
             switch_success: '已切换到：{0}'
             switch_failed: '切换会话失败：{0}'
             list_header: '当前路由下的会话列表：'

--- a/packages/core/src/middlewares/system/conversation_manage.ts
+++ b/packages/core/src/middlewares/system/conversation_manage.ts
@@ -979,6 +979,14 @@ function formatConversationError(
         ])
     }
 
+    const invalidMode = error.message.match(/^Chat mode (.+) not found\.$/)
+    if (invalidMode) {
+        return session.text(
+            'chatluna.conversation.messages.invalid_chat_mode',
+            [invalidMode[1]]
+        )
+    }
+
     if (action != null) {
         return session.text('chatluna.conversation.messages.action_failed', [
             session.text(`chatluna.conversation.action.${action}`),

--- a/packages/core/src/services/conversation.ts
+++ b/packages/core/src/services/conversation.ts
@@ -605,6 +605,8 @@ export class ConversationService {
             setActive?: boolean
         }
     ) {
+        this.checkChatMode(options.chatMode)
+
         return runLock(this._bindingLocks, options.bindingKey, async () => {
             const now = new Date()
             const conversation: ConversationRecord = {
@@ -1561,6 +1563,8 @@ export class ConversationService {
             throw new Error('Conversation update is locked by constraint.')
         }
 
+        this.checkChatMode(options.chatMode)
+
         const updated = await this.touchConversation(conversation.id, {
             model: options.model,
             preset: options.preset,
@@ -1690,6 +1694,9 @@ export class ConversationService {
         session: Session,
         patch: Partial<ConstraintRecord>
     ) {
+        this.checkChatMode(patch.defaultChatMode)
+        this.checkChatMode(patch.fixedChatMode)
+
         const current = await this.getManagedConstraint(session)
         const now = new Date()
         const route = session.isDirect
@@ -1744,6 +1751,17 @@ export class ConversationService {
         }
 
         return this.config.defaultGroupRouteMode ?? 'shared'
+    }
+
+    private checkChatMode(mode?: string | null) {
+        if (
+            mode != null &&
+            !this.ctx.chatluna.platform.chatChains.value.some(
+                (chain) => chain.name === mode
+            )
+        ) {
+            throw new Error(`Chat mode ${mode} not found.`)
+        }
     }
 
     private async allocateConversationSeq(bindingKey: string) {

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-agent",
     "description": "Agent framework for ChatLuna",
-    "version": "1.0.26",
+    "version": "1.0.27",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-agent/src/service/trigger.ts
+++ b/packages/extension-agent/src/service/trigger.ts
@@ -571,6 +571,7 @@ export class ChatLunaAgentTriggerService {
             ...task.wakeupTemplate,
             ...override,
             target,
+            bindingKey: override?.bindingKey ?? task.bindingKey,
             requestId,
             conversationId: override?.conversationId ?? task.conversationId,
             presetLane: override?.presetLane ?? task.presetLane,
@@ -924,11 +925,19 @@ export class ChatLunaAgentTriggerService {
         }
         const next = await provider.prepare?.({ input: merged, task })
 
-        return {
+        const result: Partial<TriggerTask> = {
             ...patch,
             ...next,
             params: { ...(patch.params ?? {}), ...(next?.params ?? {}) }
         }
+
+        if (patch.bindingKey != null && patch.bindingKey !== task.bindingKey) {
+            result.conversationId = null
+        } else if (patch.conversationId !== undefined) {
+            result.conversationId = patch.conversationId
+        }
+
+        return result
     }
 }
 

--- a/packages/extension-agent/src/skills/builtin.ts
+++ b/packages/extension-agent/src/skills/builtin.ts
@@ -1,7 +1,7 @@
 /** @module skills/builtin */
 
-import { cp, mkdir, readdir, readFile, rm, stat, writeFile } from 'fs/promises'
-import { join } from 'path'
+import { copyFile, mkdir, readdir, readFile, rm, stat } from 'fs/promises'
+import { dirname, join, relative } from 'path'
 import { Context } from 'koishi'
 import { AGENTCLI_SKILL_NAME } from '../computer/materialize'
 import { getSkillsRootPath } from '../config/path'
@@ -41,29 +41,65 @@ export async function syncBundledSkills(ctx: Context) {
             continue
         }
 
-        let preservedConfig: Buffer | undefined
-        let backupPath: string | undefined
-        if (force && current?.isFile()) {
-            const configPath = join(to, 'config.json')
-            preservedConfig = await readFile(configPath).catch(() => undefined)
-            if (preservedConfig) {
-                backupPath = join(dest, `${entry.name}.config.json.bak`)
-                await writeFile(backupPath, preservedConfig).catch(() => {})
-            }
-        }
+        const synced = await syncSkillDir(from, to, force && current?.isFile())
 
-        await rm(to, { recursive: true, force: true })
-        await cp(from, to, { recursive: true })
-
-        if (preservedConfig) {
-            await writeFile(join(to, 'config.json'), preservedConfig)
-            if (backupPath) {
-                await rm(backupPath, { force: true })
-            }
-        }
+        if (!synced && force && current?.isFile()) continue
 
         ctx.logger[force && current?.isFile() ? 'debug' : 'info'](
-            `${force && current?.isFile() ? 'Refreshed' : 'Copied'} bundled skill '${entry.name}' to ${to}${preservedConfig ? ' (preserved config.json)' : ''}`
+            `${force && current?.isFile() ? 'Refreshed' : 'Copied'} bundled skill '${entry.name}' to ${to}`
         )
     }
+}
+
+async function syncSkillDir(from: string, to: string, preserveConfig: boolean) {
+    const files = await collectFiles(from)
+    const current = await collectFiles(to).catch(() => [])
+    const source = new Set(files)
+    let changed = false
+
+    for (const file of files) {
+        if (preserveConfig && file === 'config.json') continue
+
+        const src = join(from, file)
+        const dest = join(to, file)
+        const data = await readFile(src)
+        const old = await readFile(dest).catch(() => undefined)
+        if (old?.equals(data)) continue
+
+        await mkdir(dirname(dest), { recursive: true })
+        await copyFile(src, dest)
+        changed = true
+    }
+
+    for (const file of current) {
+        if (source.has(file)) continue
+        if (preserveConfig && file === 'config.json') continue
+
+        await rm(join(to, file), { force: true })
+        changed = true
+    }
+
+    return changed
+}
+
+async function collectFiles(dir: string) {
+    const files: string[] = []
+    const dirs = [dir]
+
+    while (dirs.length) {
+        const current = dirs.shift()!
+        const entries = await readdir(current, { withFileTypes: true })
+
+        for (const entry of entries) {
+            const path = join(current, entry.name)
+            if (entry.isDirectory()) {
+                dirs.push(path)
+                continue
+            }
+
+            if (entry.isFile()) files.push(relative(dir, path))
+        }
+    }
+
+    return files.sort((a, b) => a.localeCompare(b))
 }

--- a/packages/extension-agent/src/skills/watch.ts
+++ b/packages/extension-agent/src/skills/watch.ts
@@ -24,16 +24,34 @@ export async function watchSkillFiles(
     const watchers: FSWatcher[] = []
     let timer: NodeJS.Timeout | undefined
     let closed = false
+    let reloading = false
+    let pending = false
 
     const schedule = () => {
         if (closed) return
+        if (reloading) {
+            pending = true
+            return
+        }
         clearTimeout(timer)
         timer = setTimeout(async () => {
             timer = undefined
+            if (reloading) {
+                pending = true
+                return
+            }
+
+            reloading = true
             try {
                 await reload()
             } catch (err) {
                 ctx.logger.error('Failed to hot reload skills', err)
+            } finally {
+                reloading = false
+                if (pending) {
+                    pending = false
+                    schedule()
+                }
             }
         }, 100)
     }

--- a/packages/extension-agent/src/skills/watch.ts
+++ b/packages/extension-agent/src/skills/watch.ts
@@ -36,11 +36,6 @@ export async function watchSkillFiles(
         clearTimeout(timer)
         timer = setTimeout(async () => {
             timer = undefined
-            if (reloading) {
-                pending = true
-                return
-            }
-
             reloading = true
             try {
                 await reload()

--- a/packages/extension-agent/src/trigger/executor.ts
+++ b/packages/extension-agent/src/trigger/executor.ts
@@ -88,17 +88,8 @@ export class ChatLunaAgentTriggerExecutor {
                 ])
             }
 
-            if (
-                action.newConversation === true &&
-                action.conversationId != null
-            ) {
-                this.ctx.logger.debug(
-                    'Ignore conversationId because newConversation takes priority.'
-                )
-            }
-
             const resolved =
-                action.newConversation === true
+                action.newConversation === true && action.conversationId == null
                     ? await this._createFreshConversation(routed, action)
                     : await this.ctx.chatluna.conversation.resolveConversation(
                           routed.session,

--- a/packages/extension-agent/src/utils/runtime_sync.ts
+++ b/packages/extension-agent/src/utils/runtime_sync.ts
@@ -250,9 +250,11 @@ async function collectSyncFiles(
 ) {
     const files: RuntimeSyncFile[] = []
     const remoteFiles = await listRemoteFiles(session, remoteRoot)
-    logger?.debug(
-        `collectSyncFiles kind=${kind} backend=${session.backend} remoteRoot=${remoteRoot} files=${remoteFiles.length} localRoots=${localRoots.length}`
-    )
+    if (remoteFiles.length > 0) {
+        logger?.debug(
+            `collectSyncFiles kind=${kind} backend=${session.backend} remoteRoot=${remoteRoot} files=${remoteFiles.length} localRoots=${localRoots.length}`
+        )
+    }
 
     for (const file of remoteFiles) {
         const sourcePath = posix.join(remoteRoot, file)
@@ -282,9 +284,11 @@ async function collectSyncFiles(
         }
     }
 
-    logger?.debug(
-        `collectSyncFiles kind=${kind} pending=${files.length} (${files.map((f) => f.targetPath).join(', ') || 'none'})`
-    )
+    if (files.length > 0) {
+        logger?.debug(
+            `collectSyncFiles kind=${kind} pending=${files.length} (${files.map((f) => f.targetPath).join(', ')})`
+        )
+    }
 
     return files
 }

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -67,12 +67,12 @@
         "atsc": "^2.1.0",
         "koishi": "^4.18.9",
         "koishi-plugin-adapter-onebot": "^6.8.0",
-        "koishi-plugin-chatluna-agent": "^1.0.25"
+        "koishi-plugin-chatluna-agent": "^1.0.27"
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
         "koishi-plugin-chatluna": "^1.4.0-alpha.14",
-        "koishi-plugin-chatluna-agent": "^1.0.25",
+        "koishi-plugin-chatluna-agent": "^1.0.27",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@chatluna/v1-shared-adapter",
     "description": "chatluna shared adapter",
-    "version": "1.0.36",
+    "version": "1.0.37",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -885,7 +885,7 @@ export function convertDeltaToMessageChunk(
                 const toolCall = {
                     name: rawToolCall.function?.name,
                     args: rawToolCall.function?.arguments,
-                    id: rawToolCall.id,
+                    id: rawToolCall.id === '' ? undefined : rawToolCall.id,
                     index: rawToolCall.index
                 }
 


### PR DESCRIPTION
This pr fixes conversation chat mode validation, trigger conversation routing, empty tool-call IDs, and bundled skill reload behavior so invalid configuration fails clearly and skill updates avoid unnecessary reload loops.

Fixes #858
Fixes #860

## New Features

None

## Bug fixes

- Validate chat modes when creating conversations, updating conversations, and updating route constraints.
- Add localized user-facing messages for invalid conversation chat modes.
- Preserve trigger binding keys when building wakeup tasks.
- Reset trigger conversation IDs when the binding key changes.
- Only create a fresh trigger conversation when `newConversation` is true and no conversation ID is already provided.
- Treat empty streaming tool-call IDs as missing IDs instead of passing empty strings through.
- Sync bundled skill files only when file contents changed, while preserving existing `config.json` files.
- Avoid overlapping skill hot reloads by queuing a pending reload while one is already running.

## Other Changes

None