### PR TITLE
fix(agent): merge config defaults via deepAssign on agentcli sync

### DIFF
--- a/packages/extension-agent/src/config/read.ts
+++ b/packages/extension-agent/src/config/read.ts
@@ -2,6 +2,7 @@
 
 import { Context } from 'koishi'
 import { readFile } from 'fs/promises'
+import { deepAssign } from 'koishi-plugin-chatluna/utils/object'
 import {
     AgentConfig,
     createToolDefaultAvailability,
@@ -68,14 +69,9 @@ export async function readConfig(ctx: Context): Promise<AgentConfig> {
                     )
                 )
             },
-            trigger: {
-                ...base.trigger,
-                ...(cfg.trigger ?? {}),
-                providers: {
-                    ...(base.trigger?.providers ?? {}),
-                    ...(cfg.trigger?.providers ?? {})
-                }
-            }
+            trigger: deepAssign({}, base.trigger, cfg.trigger ?? {}),
+            computer: deepAssign({}, base.computer, cfg.computer ?? {}),
+            subAgent: deepAssign({}, base.subAgent, cfg.subAgent ?? {})
         }
     } catch {
         return getDefaultConfig()

--- a/packages/extension-agent/src/utils/agentcli_sync.ts
+++ b/packages/extension-agent/src/utils/agentcli_sync.ts
@@ -81,7 +81,7 @@ export async function syncAgentcliConfig(
 
     const next = JSON.parse(chosen.content) as AgentConfig
     await writeConfig(agent.ctx, next)
-    await agent.reload(next)
+    await agent.reload()
     messages.push(`applied from ${sources.join(', ')}`)
 
     return {


### PR DESCRIPTION
## Summary

- `syncAgentcliConfig` now calls `agent.reload()` without arguments, so the partial config written to disk passes through `readConfig` and gets merged with defaults instead of being assigned raw
- `readConfig` uses `deepAssign` (from `koishi-plugin-chatluna/utils/object`) to deep-merge `trigger`, `computer`, and `subAgent` against defaults, so partial saved sections (e.g. `computer: {}` or missing `trigger`) no longer wipe out nested defaults

## Problem

When the agentcli sandbox writes a partial `config.json` (e.g. only `mcp` changes, with `"computer": {}` or missing `trigger`), and the user runs `chatluna.agent sync`:

1. `syncAgentcliConfig` previously passed the raw JSON directly to `agent.reload(next)`
2. `reload` skipped `readConfig` because `cfg` was already provided
3. `_setConfig` assigned the incomplete config — `this.trigger.config = cfg.trigger` became `undefined`
4. Every subsequent chat request crashed with `TypeError: Cannot read properties of undefined (reading 'providers')` in `isProviderEnabled`
5. Similar crash for `computer.local.enabled` in `buildStatus` when `computer: {}`

The root cause is that the sync path bypassed `readConfig` entirely. Routing it back through `readConfig` (and making `readConfig` itself deep-merge defaults for `computer`/`subAgent`, not just `trigger`) fixes both the sync flow and any independent path that may have written a partial config to disk.

## Test plan

- [ ] Create a `config.json` with only `{ "mcp": { "mcpServers": {} } }` (missing computer, trigger, subAgent details)
- [ ] Run `chatluna.agent sync` — should load without errors
- [ ] Verify trigger providers (cron, activity, keyword) are enabled by default
- [ ] Verify computer backends have correct default structure
- [ ] Verify builtin sub-agents (plan, general, explore) have descriptions populated
- [ ] Send a chat message — should not crash with TypeError