### PR TITLE
fix(agent): refine MCP proxy handling

### DIFF
--- a/packages/extension-agent/src/computer/backends/open_terminal.ts
+++ b/packages/extension-agent/src/computer/backends/open_terminal.ts
@@ -529,7 +529,7 @@ exit
             proxyAgent: '',
             headers: this.headers(),
             params: { path: target },
-            responseType: 'stream',
+            responseType: 'arraybuffer',
             validateStatus: () => true
         })
 
@@ -541,7 +541,7 @@ exit
         const fallback = mimeTypes.lookup(target)
         const size = Number(result.headers.get('content-length') ?? '')
         return {
-            stream: Readable.fromWeb(result.data),
+            stream: Readable.from(Buffer.from(result.data)),
             size: Number.isFinite(size) ? size : undefined,
             mimeType: mimeType ?? (fallback === false ? undefined : fallback)
         }

--- a/packages/extension-agent/src/computer/backends/open_terminal.ts
+++ b/packages/extension-agent/src/computer/backends/open_terminal.ts
@@ -5,6 +5,7 @@ import { Buffer } from 'node:buffer'
 import { posix } from 'path'
 import { Readable } from 'node:stream'
 import { Context } from 'koishi'
+import type {} from '@koishijs/plugin-proxy-agent'
 import mimeTypes from 'mime-types'
 import { quoteShell } from './types'
 import { OpenTerminalBackendConfig } from '../../types'
@@ -52,6 +53,7 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
         const current = readOpenTerminalData<OpenTerminalCwdData>(
             await this.ctx.http(this.url('/files/cwd'), {
                 method: 'GET',
+                proxyAgent: '',
                 headers: this.headers()
             })
         )
@@ -71,6 +73,7 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
                 const result = readOpenTerminalData<OpenTerminalListData>(
                     await this.ctx.http(this.url('/files/list'), {
                         method: 'GET',
+                        proxyAgent: '',
                         headers: this.headers(),
                         params: {
                             directory: this.options.cwd
@@ -110,6 +113,7 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
             >(
                 await this.ctx.http(this.url('/files/list'), {
                     method: 'GET',
+                    proxyAgent: '',
                     headers: this.headers(),
                     params: {
                         directory: target
@@ -151,6 +155,7 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
         }>(
             await this.ctx.http(this.url(`/files/read?${params.toString()}`), {
                 method: 'GET',
+                proxyAgent: '',
                 headers: this.headers()
             })
         )
@@ -214,6 +219,7 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
                 content
             },
             {
+                proxyAgent: '',
                 headers: {
                     ...this.headers(),
                     'content-type': 'application/json'
@@ -269,6 +275,7 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
                 ]
             },
             {
+                proxyAgent: '',
                 headers: {
                     ...this.headers(),
                     'content-type': 'application/json'
@@ -311,6 +318,7 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
         }>(
             await this.ctx.http(this.url(`/files/grep?${params.toString()}`), {
                 method: 'GET',
+                proxyAgent: '',
                 headers: this.headers()
             })
         )
@@ -343,6 +351,7 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
         }>(
             await this.ctx.http(this.url(`/files/glob?${params.toString()}`), {
                 method: 'GET',
+                proxyAgent: '',
                 headers: this.headers()
             })
         )
@@ -515,13 +524,16 @@ exit
 
     async openAsset(filePath: string) {
         const target = this.resolvePath(filePath)
-        const url = new URL(this.url('/files/view'))
-        url.searchParams.set('path', target)
-        const result = await fetch(url, {
-            headers: this.headers()
+        const result = await this.ctx.http(this.url('/files/view'), {
+            method: 'GET',
+            proxyAgent: '',
+            headers: this.headers(),
+            params: { path: target },
+            responseType: 'stream',
+            validateStatus: () => true
         })
 
-        if (!result.ok || result.body == null) {
+        if (result.status < 200 || result.status >= 300) {
             throw new Error(`Failed to open asset: ${result.status}`)
         }
 
@@ -529,7 +541,7 @@ exit
         const fallback = mimeTypes.lookup(target)
         const size = Number(result.headers.get('content-length') ?? '')
         return {
-            stream: Readable.fromWeb(result.body),
+            stream: Readable.fromWeb(result.data),
             size: Number.isFinite(size) ? size : undefined,
             mimeType: mimeType ?? (fallback === false ? undefined : fallback)
         }
@@ -727,6 +739,7 @@ async function openOpenTerminal(
 ) {
     const result = readOpenTerminalData<OpenTerminalTerminalData>(
         await ctx.http.post(options.url('/api/terminals'), undefined, {
+            proxyAgent: '',
             headers: options.headers
         })
     )
@@ -737,6 +750,7 @@ async function openOpenTerminal(
     const ws = ctx.http.ws(
         toWebSocketUrl(options.url(`/api/terminals/${result.id}`)),
         {
+            proxyAgent: '',
             headers: options.headers
         }
     )
@@ -802,6 +816,7 @@ async function openOpenTerminal(
         }
         await ctx.http
             .delete(options.url(`/api/terminals/${result.id}`), {
+                proxyAgent: '',
                 headers: options.headers
             })
             .catch(() => undefined)
@@ -818,6 +833,7 @@ async function openOpenTerminal(
             }
             await ctx.http
                 .delete(options.url(`/api/terminals/${result.id}`), {
+                    proxyAgent: '',
                     headers: options.headers
                 })
                 .catch(() => undefined)

--- a/packages/extension-agent/src/mcp/transport.ts
+++ b/packages/extension-agent/src/mcp/transport.ts
@@ -10,11 +10,13 @@ import {
     SSEClientTransportOptions
 } from '@modelcontextprotocol/sdk/client/sse.js'
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { McpServerConfig } from '../types'
 
 export function createTransport(
     name: string,
-    config: McpServerConfig
+    config: McpServerConfig,
+    plugin: ChatLunaPlugin
 ): Transport {
     const type = config.type ?? 'stdio'
     const requestInit =
@@ -23,12 +25,22 @@ export function createTransport(
     for (const [k, v] of Object.entries(config.headers ?? {})) {
         headers.set(k, v)
     }
+
+    const proxyFetch: typeof fetch = (url, init) => {
+        return plugin.fetch(
+            url as Parameters<typeof plugin.fetch>[0],
+            init as Parameters<typeof plugin.fetch>[1],
+            config.proxy
+        ) as unknown as ReturnType<typeof fetch>
+    }
+
     const transportConfig = {
         ...config,
         requestInit: {
             ...requestInit,
             headers
-        }
+        },
+        fetch: proxyFetch
     }
 
     if (type === 'stdio') {

--- a/packages/extension-agent/src/mcp/transport.ts
+++ b/packages/extension-agent/src/mcp/transport.ts
@@ -9,7 +9,10 @@ import {
     SSEClientTransport,
     SSEClientTransportOptions
 } from '@modelcontextprotocol/sdk/client/sse.js'
-import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import type {
+    FetchLike,
+    Transport
+} from '@modelcontextprotocol/sdk/shared/transport.js'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { McpServerConfig } from '../types'
 
@@ -19,29 +22,6 @@ export function createTransport(
     plugin: ChatLunaPlugin
 ): Transport {
     const type = config.type ?? 'stdio'
-    const requestInit =
-        (config as StreamableHTTPClientTransportOptions).requestInit ?? {}
-    const headers = new Headers(requestInit.headers)
-    for (const [k, v] of Object.entries(config.headers ?? {})) {
-        headers.set(k, v)
-    }
-
-    const proxyFetch: typeof fetch = (url, init) => {
-        return plugin.fetch(
-            url as Parameters<typeof plugin.fetch>[0],
-            init as Parameters<typeof plugin.fetch>[1],
-            config.proxy
-        ) as unknown as ReturnType<typeof fetch>
-    }
-
-    const transportConfig = {
-        ...config,
-        requestInit: {
-            ...requestInit,
-            headers
-        },
-        fetch: proxyFetch
-    }
 
     if (type === 'stdio') {
         return new StdioClientTransport({
@@ -51,6 +31,30 @@ export function createTransport(
             cwd: config.cwd,
             stderr: 'pipe'
         })
+    }
+
+    const requestInit =
+        (config as StreamableHTTPClientTransportOptions).requestInit ?? {}
+    const headers = new Headers(requestInit.headers)
+    for (const [k, v] of Object.entries(config.headers ?? {})) {
+        headers.set(k, v)
+    }
+
+    const proxyFetch: FetchLike = (url, init) => {
+        return plugin.fetch(
+            url as Parameters<typeof plugin.fetch>[0],
+            init as Parameters<typeof plugin.fetch>[1],
+            config.proxy
+        ) as unknown as ReturnType<FetchLike>
+    }
+
+    const transportConfig = {
+        ...config,
+        requestInit: {
+            ...requestInit,
+            headers
+        },
+        fetch: proxyFetch
     }
 
     if (type === 'sse') {

--- a/packages/extension-agent/src/service/mcp.ts
+++ b/packages/extension-agent/src/service/mcp.ts
@@ -251,7 +251,7 @@ export class ChatLunaAgentMcpService {
             try {
                 await this._drop(name, false)
 
-                const transport = createTransport(name, cfg)
+                const transport = createTransport(name, cfg, this.plugin)
                 const client = new Client({
                     name: 'ChatLuna',
                     version: '1.0.0',
@@ -423,12 +423,12 @@ export class ChatLunaAgentMcpService {
             }
 
             const langChainTool = tool(
-                async (input: Record<string, unknown>) => {
+                async (input: unknown) => {
                     return await callTool(
                         serverName,
                         mcpTool.name,
                         client,
-                        input,
+                        input as Record<string, unknown>,
                         { timeout: t.timeout },
                         undefined,
                         this.ctx,

--- a/packages/extension-agent/src/skills/import.ts
+++ b/packages/extension-agent/src/skills/import.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'crypto'
 import { unzipSync } from 'fflate'
 import { cp, mkdir, rm, stat, writeFile } from 'fs/promises'
 import { Context } from 'koishi'
+import type {} from '@koishijs/plugin-proxy-agent'
 import { basename, dirname, join, resolve } from 'path'
 import { getSkillsRootPath } from '../config/path'
 import {
@@ -631,6 +632,7 @@ async function requestGithub<T>(
     try {
         return (await ctx.http(url, {
             method: 'get',
+            proxyAgent: '',
             headers: githubHeaders(ctx),
             responseType: options.responseType
         })) as unknown as { data: T }

--- a/packages/extension-agent/src/skills/import.ts
+++ b/packages/extension-agent/src/skills/import.ts
@@ -4,7 +4,6 @@ import { randomUUID } from 'crypto'
 import { unzipSync } from 'fflate'
 import { cp, mkdir, rm, stat, writeFile } from 'fs/promises'
 import { Context } from 'koishi'
-import type {} from '@koishijs/plugin-proxy-agent'
 import { basename, dirname, join, resolve } from 'path'
 import { getSkillsRootPath } from '../config/path'
 import {
@@ -632,10 +631,9 @@ async function requestGithub<T>(
     try {
         return (await ctx.http(url, {
             method: 'get',
-            proxyAgent: '',
             headers: githubHeaders(ctx),
             responseType: options.responseType
-        })) as unknown as { data: T }
+        } as never)) as unknown as { data: T }
     } catch (err) {
         throw new Error(getGithubError(err))
     }


### PR DESCRIPTION
## Summary
- route MCP HTTP/SSE transports through plugin.fetch with per-server proxy support
- keep stdio transport untouched
- force extension-agent ctx.http and ctx.http.ws calls to bypass Koishi proxy via proxyAgent: ''

## Verification
- yarn fast-build extension-agent