### PR TITLE
[Fix] 稳定 prompt pick 选择结果

### DIFF
--- a/packages/core/src/services/prompt_renderer.ts
+++ b/packages/core/src/services/prompt_renderer.ts
@@ -4,7 +4,7 @@ import {
     HumanMessage,
     SystemMessage
 } from '@langchain/core/messages'
-import { Time } from 'koishi'
+import { type Session, Time } from 'koishi'
 import { logger } from 'koishi-plugin-chatluna'
 import { PresetTemplate } from 'koishi-plugin-chatluna/llm-core/prompt'
 import {
@@ -95,8 +95,25 @@ export class ChatLunaPromptRenderService {
             return selectFromList(args.join(','), false)
         })
 
-        this.registerFunctionProvider('pick', (args) => {
-            return selectFromList(args.join(','), true)
+        this.registerFunctionProvider('pick', (args, variables, cfg) => {
+            const session = cfg.session as Session
+            const built = variables.built as { conversationId?: string }
+
+            return selectFromList(
+                args.join(','),
+                true,
+                [
+                    cfg.conversationId,
+                    built?.conversationId,
+                    session?.platform,
+                    session?.selfId,
+                    session?.guildId,
+                    session?.channelId,
+                    session?.userId
+                ]
+                    .filter(Boolean)
+                    .join(':')
+            )
         })
 
         this.registerFunctionProvider('roll', (args) => {

--- a/packages/core/src/services/prompt_renderer.ts
+++ b/packages/core/src/services/prompt_renderer.ts
@@ -99,7 +99,7 @@ export class ChatLunaPromptRenderService {
             return selectFromList(
                 args.join(','),
                 true,
-                String(cfg?.conversationId ?? '')
+                cfg?.conversationId ?? ''
             )
         })
 

--- a/packages/core/src/services/prompt_renderer.ts
+++ b/packages/core/src/services/prompt_renderer.ts
@@ -4,7 +4,7 @@ import {
     HumanMessage,
     SystemMessage
 } from '@langchain/core/messages'
-import { type Session, Time } from 'koishi'
+import { Time } from 'koishi'
 import { logger } from 'koishi-plugin-chatluna'
 import { PresetTemplate } from 'koishi-plugin-chatluna/llm-core/prompt'
 import {
@@ -95,24 +95,11 @@ export class ChatLunaPromptRenderService {
             return selectFromList(args.join(','), false)
         })
 
-        this.registerFunctionProvider('pick', (args, variables, cfg) => {
-            const session = cfg?.session as Session
-            const built = variables?.built as { conversationId?: string }
-
+        this.registerFunctionProvider('pick', (args, _variables, cfg) => {
             return selectFromList(
                 args.join(','),
                 true,
-                [
-                    cfg?.conversationId,
-                    built?.conversationId,
-                    session?.platform,
-                    session?.selfId,
-                    session?.guildId,
-                    session?.channelId,
-                    session?.userId
-                ]
-                    .filter(Boolean)
-                    .join(':')
+                String(cfg?.conversationId ?? '')
             )
         })
 

--- a/packages/core/src/services/prompt_renderer.ts
+++ b/packages/core/src/services/prompt_renderer.ts
@@ -96,14 +96,14 @@ export class ChatLunaPromptRenderService {
         })
 
         this.registerFunctionProvider('pick', (args, variables, cfg) => {
-            const session = cfg.session as Session
-            const built = variables.built as { conversationId?: string }
+            const session = cfg?.session as Session
+            const built = variables?.built as { conversationId?: string }
 
             return selectFromList(
                 args.join(','),
                 true,
                 [
-                    cfg.conversationId,
+                    cfg?.conversationId,
                     built?.conversationId,
                     session?.platform,
                     session?.selfId,

--- a/packages/core/src/utils/string.ts
+++ b/packages/core/src/utils/string.ts
@@ -320,7 +320,7 @@ export const getTimeDiff = (time1: string, time2: string): string => {
 export const selectFromList = (
     args: string,
     isPick: boolean,
-    seed: unknown = ''
+    seed: string = ''
 ): string => {
     const items = args.split(',').map((item) => item.trim())
     if (isPick) {

--- a/packages/core/src/utils/string.ts
+++ b/packages/core/src/utils/string.ts
@@ -320,7 +320,7 @@ export const getTimeDiff = (time1: string, time2: string): string => {
 export const selectFromList = (
     args: string,
     isPick: boolean,
-    seed: string = ''
+    seed: unknown = ''
 ): string => {
     const items = args.split(',').map((item) => item.trim())
     if (isPick) {

--- a/packages/core/src/utils/string.ts
+++ b/packages/core/src/utils/string.ts
@@ -317,11 +317,18 @@ export const getTimeDiff = (time1: string, time2: string): string => {
     )
 }
 
-export const selectFromList = (args: string, isPick: boolean): string => {
+export const selectFromList = (
+    args: string,
+    isPick: boolean,
+    seed: string = ''
+): string => {
     const items = args.split(',').map((item) => item.trim())
     if (isPick) {
-        // TODO: Implement stable selection for 'pick'
-        return items[Math.floor(Math.random() * items.length)]
+        const hash = crypto
+            .createHash('sha1')
+            .update(`${seed}:${args}`)
+            .digest()
+        return items[hash.readUInt32BE(0) % items.length]
     }
     return items[Math.floor(Math.random() * items.length)]
 }

--- a/packages/core/tests/conversation-utils.spec.ts
+++ b/packages/core/tests/conversation-utils.spec.ts
@@ -17,6 +17,7 @@ import {
     computeBaseBindingKey
 } from '../src/types'
 import { usageSourceFromStack } from '../src/utils/usage_source'
+import { selectFromList } from '../src/utils/string'
 import {
     createMessage,
     type BindingSessionShape,
@@ -189,6 +190,15 @@ it('usageSourceFromStack reads package names instead of folder names', () => {
                 '(node:internal/process/task_queues:105:5)'
         ),
         'unknown'
+    )
+})
+
+it('selectFromList keeps pick stable for a seed', () => {
+    assert.equal(selectFromList('red,green,blue', true, 'stable'), 'blue')
+    assert.equal(selectFromList('red,green,blue', true, 'stable'), 'blue')
+    assert.equal(
+        selectFromList('red,green,blue', true, 'conversation-b'),
+        'green'
     )
 })
 

--- a/packages/core/tests/conversation-utils.spec.ts
+++ b/packages/core/tests/conversation-utils.spec.ts
@@ -12,6 +12,7 @@ import {
     getMessageContent,
     parsePresetLaneInput
 } from '../src/utils/message_content'
+import { ChatLunaPromptRenderService } from '../src/services/prompt_renderer'
 import {
     applyPresetLane,
     computeBaseBindingKey
@@ -200,6 +201,13 @@ it('selectFromList keeps pick stable for a seed', () => {
         selectFromList('red,green,blue', true, 'conversation-b'),
         'green'
     )
+})
+
+it('prompt pick renders without configurable options', async () => {
+    const service = new ChatLunaPromptRenderService()
+    const result = await service.renderTemplate('{pick("red","green","blue")}')
+
+    assert.equal(result.text, 'green')
 })
 
 it('getMessageContent flattens structured text parts', () => {

--- a/packages/core/tests/conversation-utils.spec.ts
+++ b/packages/core/tests/conversation-utils.spec.ts
@@ -210,6 +210,21 @@ it('prompt pick renders without configurable options', async () => {
     assert.equal(result.text, 'green')
 })
 
+it('prompt pick uses conversation id as stable seed', async () => {
+    const service = new ChatLunaPromptRenderService()
+    const result = await service.renderTemplate(
+        '{pick("red","green","blue")}',
+        {},
+        {
+            configurable: {
+                conversationId: 'conversation-b'
+            }
+        }
+    )
+
+    assert.equal(result.text, 'green')
+})
+
 it('getMessageContent flattens structured text parts', () => {
     assert.equal(
         getMessageContent([


### PR DESCRIPTION
## 关联 Issue

Fixes #877

## 问题

`{pick(...)}` 之前和 `{random(...)}` 一样每次渲染都走 `Math.random()`，同一会话中的系统提示、作者注记或用户提示可能在连续请求里选到不同分支，导致角色语气、称呼或提示词约束漂移。

## 修复内容

- 为 `selectFromList` 增加稳定种子参数。
- `pick` 使用会话/对话上下文和候选列表生成 SHA-1 哈希，稳定映射到同一个候选值。
- 保持 `random` 原有随机行为不变。
- 增加 `selectFromList` 的稳定选择测试。

## 验证

- `COREPACK_HOME=/tmp/corepack corepack yarn fast-build shared-prompt-renderer`
- `COREPACK_HOME=/tmp/corepack corepack yarn fast-build core`
- `COREPACK_HOME=/tmp/corepack corepack yarn mocha -r tsconfig-paths/register -r esbuild-register -r yml-register --exit packages/core/tests/conversation-utils.spec.ts`
- `COREPACK_HOME=/tmp/corepack corepack yarn eslint packages/core/src/services/prompt_renderer.ts packages/core/src/utils/string.ts`

补充说明：全量 `COREPACK_HOME=/tmp/corepack corepack yarn test` 当前有 10 个既有失败，失败点在归档、回滚、测试桩和缺失的 extension-agent 文件路径；本次新增的 `selectFromList` 用例在全量输出和单文件测试中均通过。