### PR TITLE
[Fix] filter tool call capability for non-LLM models

### DIFF
--- a/packages/adapter-deepseek/src/client.ts
+++ b/packages/adapter-deepseek/src/client.ts
@@ -73,12 +73,17 @@ export class DeepseekClient extends PlatformModelAndEmbeddingsClient<ClientConfi
                 )
 
                 .map((model) => {
+                    const type = model.includes('deepseek')
+                        ? ModelType.llm
+                        : ModelType.embeddings
+
                     return {
                         name: model,
-                        type: model.includes('deepseek')
-                            ? ModelType.llm
-                            : ModelType.embeddings,
-                        capabilities: [ModelCapabilities.ToolCall]
+                        type,
+                        capabilities:
+                            type === ModelType.llm
+                                ? [ModelCapabilities.ToolCall]
+                                : []
                     } as ModelInfo
                 })
         } catch (e) {

--- a/packages/adapter-doubao/src/client.ts
+++ b/packages/adapter-doubao/src/client.ts
@@ -119,10 +119,9 @@ export class DouBaoClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
                 type,
                 maxTokens: token,
                 capabilities: [
-                    type !== ModelType.llm ||
-                    unsupportedFunctionCallModels.includes(model)
-                        ? undefined
-                        : ModelCapabilities.ToolCall,
+                    type === ModelType.llm &&
+                        !unsupportedFunctionCallModels.includes(model) &&
+                        ModelCapabilities.ToolCall,
                     imageInputSupportModels.some((pattern) =>
                         model.match(pattern)
                     )

--- a/packages/adapter-doubao/src/client.ts
+++ b/packages/adapter-doubao/src/client.ts
@@ -110,13 +110,16 @@ export class DouBaoClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
         })
 
         return expandedModels.map(([model, token]) => {
+            const type = model.includes('embedding')
+                ? ModelType.embeddings
+                : ModelType.llm
+
             return {
                 name: model,
-                type: model.includes('embedding')
-                    ? ModelType.embeddings
-                    : ModelType.llm,
+                type,
                 maxTokens: token,
                 capabilities: [
+                    type !== ModelType.llm ||
                     unsupportedFunctionCallModels.includes(model)
                         ? undefined
                         : ModelCapabilities.ToolCall,

--- a/packages/adapter-hunyuan/src/client.ts
+++ b/packages/adapter-hunyuan/src/client.ts
@@ -61,13 +61,16 @@ export class HunyuanClient extends PlatformModelAndEmbeddingsClient<ClientConfig
         ] as [string, number][]
 
         return rawModels.map(([model, token]) => {
+            const type = model.includes('embedding')
+                ? ModelType.embeddings
+                : ModelType.llm
+
             return {
                 name: model,
-                type: model.includes('embedding')
-                    ? ModelType.embeddings
-                    : ModelType.llm,
+                type,
                 maxTokens: token,
-                capabilities: [ModelCapabilities.ToolCall]
+                capabilities:
+                    type === ModelType.llm ? [ModelCapabilities.ToolCall] : []
             } as ModelInfo
         })
     }

--- a/packages/adapter-openai-like/src/client.ts
+++ b/packages/adapter-openai-like/src/client.ts
@@ -59,18 +59,27 @@ export class OpenAIClient extends PlatformModelEmbeddingsAndRerankerClient {
                 : []
 
             const additionalModels = this._config.additionalModels.map(
-                ({ model, modelType, contextSize, modelCapabilities }) =>
-                    ({
+                ({ model, modelType, contextSize, modelCapabilities }) => {
+                    const type =
+                        modelType === 'Embeddings 嵌入模型'
+                            ? ModelType.embeddings
+                            : modelType === 'Reranker 重排序模型'
+                              ? ModelType.reranker
+                              : ModelType.llm
+
+                    return {
                         name: model,
-                        type:
-                            modelType === 'Embeddings 嵌入模型'
-                                ? ModelType.embeddings
-                                : modelType === 'Reranker 重排序模型'
-                                  ? ModelType.reranker
-                                  : ModelType.llm,
-                        capabilities: modelCapabilities,
+                        type,
+                        capabilities:
+                            type === ModelType.llm
+                                ? modelCapabilities
+                                : modelCapabilities.filter(
+                                      (cap) =>
+                                          cap !== ModelCapabilities.ToolCall
+                                  ),
                         maxTokens: contextSize ?? 4096
-                    }) as ModelInfo
+                    } as ModelInfo
+                }
             )
 
             const filteredModels = rawModels.filter(
@@ -109,18 +118,21 @@ export class OpenAIClient extends PlatformModelEmbeddingsAndRerankerClient {
                     const id = model.toLowerCase()
                     return !blacklist.some((keyword) => id.includes(keyword))
                 })
-                .map(
-                    (model) =>
-                        ({
-                            name: model,
-                            type: isRerankerModel(model)
-                                ? ModelType.reranker
-                                : isEmbeddingModel(model)
-                                  ? ModelType.embeddings
-                                  : ModelType.llm,
-                            ...supportToolCalling(model)
-                        }) as ModelInfo
-                )
+                .map((model) => {
+                    const type = isRerankerModel(model)
+                        ? ModelType.reranker
+                        : isEmbeddingModel(model)
+                          ? ModelType.embeddings
+                          : ModelType.llm
+
+                    return {
+                        name: model,
+                        type,
+                        ...(type === ModelType.llm
+                            ? supportToolCalling(model)
+                            : { capabilities: [] })
+                    } as ModelInfo
+                })
 
             return additionalModels.concat(
                 formattedModels.filter(

--- a/packages/adapter-openai/src/client.ts
+++ b/packages/adapter-openai/src/client.ts
@@ -85,15 +85,12 @@ export class OpenAIClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
                         name: model,
                         type,
                         capabilities: [
-                            type === ModelType.llm
-                                ? ModelCapabilities.ToolCall
-                                : undefined,
-                            supportImageInput(model)
-                                ? ModelCapabilities.ImageInput
-                                : undefined,
-                            supportAudioInput(model)
-                                ? ModelCapabilities.AudioInput
-                                : undefined
+                            type === ModelType.llm &&
+                                ModelCapabilities.ToolCall,
+                            supportImageInput(model) &&
+                                ModelCapabilities.ImageInput,
+                            supportAudioInput(model) &&
+                                ModelCapabilities.AudioInput
                         ].filter(Boolean)
                     } as ModelInfo
                 })

--- a/packages/adapter-openai/src/client.ts
+++ b/packages/adapter-openai/src/client.ts
@@ -77,13 +77,17 @@ export class OpenAIClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
                         )
                 )
                 .map((model) => {
+                    const type = model.includes('embedding')
+                        ? ModelType.embeddings
+                        : ModelType.llm
+
                     return {
                         name: model,
-                        type: model.includes('embedding')
-                            ? ModelType.embeddings
-                            : ModelType.llm,
+                        type,
                         capabilities: [
-                            ModelCapabilities.ToolCall,
+                            type === ModelType.llm
+                                ? ModelCapabilities.ToolCall
+                                : undefined,
                             supportImageInput(model)
                                 ? ModelCapabilities.ImageInput
                                 : undefined,

--- a/packages/adapter-qwen/src/client.ts
+++ b/packages/adapter-qwen/src/client.ts
@@ -141,35 +141,46 @@ export class QWenClient extends PlatformModelAndEmbeddingsClient {
         })
 
         const additionalModels = this._config.additionalModels.map(
-            ({ model, modelType, contextSize, modelCapabilities }) =>
-                ({
+            ({ model, modelType, contextSize, modelCapabilities }) => {
+                const type =
+                    modelType === 'Embeddings 嵌入模型'
+                        ? ModelType.embeddings
+                        : ModelType.llm
+
+                return {
                     name: model,
-                    type:
-                        modelType === 'Embeddings 嵌入模型'
-                            ? ModelType.embeddings
-                            : ModelType.llm,
-                    capabilities: modelCapabilities,
+                    type,
+                    capabilities:
+                        type === ModelType.llm
+                            ? modelCapabilities
+                            : modelCapabilities.filter(
+                                  (cap) => cap !== ModelCapabilities.ToolCall
+                              ),
                     maxTokens: contextSize ?? 4096
-                }) as ModelInfo
+                } as ModelInfo
+            }
         )
 
         return expandedModels
             .map(([model, token]) => {
+                const type = model.includes('embedding')
+                    ? ModelType.embeddings
+                    : ModelType.llm
+
                 return {
                     name: model,
-                    type: model.includes('embedding')
-                        ? ModelType.embeddings
-                        : ModelType.llm,
+                    type,
                     maxTokens: token,
                     capabilities: [
-                        (model.includes('qwen-plus') ||
-                            model.includes('qwen-max') ||
-                            model.includes('qwen-turbo') ||
-                            model.includes('qwen3') ||
-                            model.includes('qwen2.5') ||
-                            model.includes('omni') ||
-                            model.includes('Kimi-K2') ||
-                            model.includes('deepseek')) &&
+                        type === ModelType.llm &&
+                            (model.includes('qwen-plus') ||
+                                model.includes('qwen-max') ||
+                                model.includes('qwen-turbo') ||
+                                model.includes('qwen3') ||
+                                model.includes('qwen2.5') ||
+                                model.includes('omni') ||
+                                model.includes('Kimi-K2') ||
+                                model.includes('deepseek')) &&
                             ModelCapabilities.ToolCall,
                         imageInputSupportModels.some((pattern) =>
                             model.includes(pattern)

--- a/packages/core/src/llm-core/platform/client.ts
+++ b/packages/core/src/llm-core/platform/client.ts
@@ -13,7 +13,6 @@ import {
     FileHandlingConfig,
     ModelCapabilities,
     ModelInfo,
-    ModelType,
     PlatformClientNames
 } from 'koishi-plugin-chatluna/llm-core/platform/types'
 import { ObjectLock } from 'koishi-plugin-chatluna/utils/lock'
@@ -143,15 +142,6 @@ export abstract class BasePlatformClient<
             this._modelInfos = {}
 
             for (const model of models) {
-                if (
-                    model.type === ModelType.embeddings ||
-                    model.type === ModelType.reranker
-                ) {
-                    model.capabilities = model.capabilities.filter(
-                        (cap) => cap !== ModelCapabilities.ToolCall
-                    )
-                }
-
                 model.capabilities = model.capabilities.includes(
                     ModelCapabilities.ImageGeneration
                 )

--- a/packages/core/src/llm-core/platform/client.ts
+++ b/packages/core/src/llm-core/platform/client.ts
@@ -13,6 +13,7 @@ import {
     FileHandlingConfig,
     ModelCapabilities,
     ModelInfo,
+    ModelType,
     PlatformClientNames
 } from 'koishi-plugin-chatluna/llm-core/platform/types'
 import { ObjectLock } from 'koishi-plugin-chatluna/utils/lock'
@@ -142,6 +143,15 @@ export abstract class BasePlatformClient<
             this._modelInfos = {}
 
             for (const model of models) {
+                if (
+                    model.type === ModelType.embeddings ||
+                    model.type === ModelType.reranker
+                ) {
+                    model.capabilities = model.capabilities.filter(
+                        (cap) => cap !== ModelCapabilities.ToolCall
+                    )
+                }
+
                 model.capabilities = model.capabilities.includes(
                     ModelCapabilities.ImageGeneration
                 )


### PR DESCRIPTION
## Summary

- Filter `ToolCall` from embedding and reranker model capabilities in `BasePlatformClient.getModels()`.
- Keep the existing `ImageGeneration` handling and `TextInput` capability normalization unchanged.
- Ensure adapter-provided metadata cannot expose non-LLM models as tool-call capable through the platform registry.

## Motivation

Some adapters can return embedding or reranker models with `ModelCapabilities.ToolCall`. Since model metadata is exposed through `listAllModels()` and `listPlatformModels()`, downstream UIs and plugins may incorrectly treat non-LLM models as supporting tool calls.

This fixes the issue at the core registry boundary instead of relying on UI-side filtering.

## Validation

- `yarn fast-build core`
- `yarn lint`
