### PR TITLE
[Fix] 修复 1.4 alpha conversation 回归

### DIFF
--- a/packages/core/src/middlewares/chat/rollback_chat.ts
+++ b/packages/core/src/middlewares/chat/rollback_chat.ts
@@ -21,13 +21,6 @@ function getTargetConversation(context: ChainMiddlewareContext) {
     )
 }
 
-function getConversationId(context: ChainMiddlewareContext) {
-    return (
-        context.options.conversation?.conversationId ??
-        context.options.conversation?.conversation?.id
-    )
-}
-
 export function apply(ctx: Context, config: Config, chain: ChatChain) {
     chain
         .middleware('rollback_chat', async (session, context) => {
@@ -37,30 +30,18 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
 
             const rollbackRound = context.options.rollback_round ?? 1
             const targetConversation = getTargetConversation(context)
-            const conversationId =
-                targetConversation == null
-                    ? getConversationId(context)
-                    : undefined
-            const current = context.options.conversation
             const resolved =
-                targetConversation == null &&
-                current?.conversation != null &&
-                current.conversationId != null &&
-                current.bindingKey != null &&
-                current.constraint != null
-                    ? current
+                targetConversation == null
+                    ? context.options.conversation
                     : await ctx.chatluna.conversation.resolveConversation(
                           session,
                           {
                               targetConversation,
-                              conversationId,
                               presetLane: context.options.presetLane,
                               allPresetLanes: context.options.allPresetLanes,
                               permission: 'manage',
                               useRoutePresetLane:
-                                  context.options.presetLane == null &&
-                                  targetConversation == null &&
-                                  conversationId == null,
+                                  context.options.presetLane == null,
                               mode: 'target'
                           }
                       )

--- a/packages/core/src/middlewares/chat/rollback_chat.ts
+++ b/packages/core/src/middlewares/chat/rollback_chat.ts
@@ -41,19 +41,28 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 targetConversation == null
                     ? getConversationId(context)
                     : undefined
+            const current = context.options.conversation
             const resolved =
-                await ctx.chatluna.conversation.resolveConversation(session, {
-                    targetConversation,
-                    conversationId,
-                    presetLane: context.options.presetLane,
-                    allPresetLanes: context.options.allPresetLanes,
-                    permission: 'manage',
-                    useRoutePresetLane:
-                        context.options.presetLane == null &&
-                        targetConversation == null &&
-                        conversationId == null,
-                    mode: 'target'
-                })
+                current?.conversation != null &&
+                current.conversationId != null &&
+                current.bindingKey != null &&
+                current.constraint != null
+                    ? current
+                    : await ctx.chatluna.conversation.resolveConversation(
+                          session,
+                          {
+                              targetConversation,
+                              conversationId,
+                              presetLane: context.options.presetLane,
+                              allPresetLanes: context.options.allPresetLanes,
+                              permission: 'manage',
+                              useRoutePresetLane:
+                                  context.options.presetLane == null &&
+                                  targetConversation == null &&
+                                  conversationId == null,
+                              mode: 'target'
+                          }
+                      )
             const conversation = resolved.conversation
 
             if (conversation == null) {

--- a/packages/core/src/middlewares/chat/rollback_chat.ts
+++ b/packages/core/src/middlewares/chat/rollback_chat.ts
@@ -43,6 +43,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                     : undefined
             const current = context.options.conversation
             const resolved =
+                targetConversation == null &&
                 current?.conversation != null &&
                 current.conversationId != null &&
                 current.bindingKey != null &&

--- a/packages/core/src/middlewares/chat/stop_chat.ts
+++ b/packages/core/src/middlewares/chat/stop_chat.ts
@@ -24,6 +24,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             const targetConversation = getTargetConversation(context)
             const current = context.options.conversation
             const resolved =
+                targetConversation == null &&
                 current?.conversation != null &&
                 current.conversationId != null &&
                 current.bindingKey != null &&

--- a/packages/core/src/middlewares/chat/stop_chat.ts
+++ b/packages/core/src/middlewares/chat/stop_chat.ts
@@ -22,14 +22,9 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             if (command !== 'stop_chat') return ChainMiddlewareRunStatus.SKIPPED
 
             const targetConversation = getTargetConversation(context)
-            const current = context.options.conversation
             const resolved =
-                targetConversation == null &&
-                current?.conversation != null &&
-                current.conversationId != null &&
-                current.bindingKey != null &&
-                current.constraint != null
-                    ? current
+                targetConversation == null
+                    ? context.options.conversation
                     : await ctx.chatluna.conversation.resolveConversation(
                           session,
                           {
@@ -38,8 +33,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                               allPresetLanes: context.options.allPresetLanes,
                               permission: 'manage',
                               useRoutePresetLane:
-                                  context.options.presetLane == null &&
-                                  targetConversation == null,
+                                  context.options.presetLane == null,
                               mode: 'target'
                           }
                       )

--- a/packages/core/src/middlewares/chat/stop_chat.ts
+++ b/packages/core/src/middlewares/chat/stop_chat.ts
@@ -22,17 +22,26 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             if (command !== 'stop_chat') return ChainMiddlewareRunStatus.SKIPPED
 
             const targetConversation = getTargetConversation(context)
+            const current = context.options.conversation
             const resolved =
-                await ctx.chatluna.conversation.resolveConversation(session, {
-                    targetConversation,
-                    presetLane: context.options.presetLane,
-                    allPresetLanes: context.options.allPresetLanes,
-                    permission: 'manage',
-                    useRoutePresetLane:
-                        context.options.presetLane == null &&
-                        targetConversation == null,
-                    mode: 'target'
-                })
+                current?.conversation != null &&
+                current.conversationId != null &&
+                current.bindingKey != null &&
+                current.constraint != null
+                    ? current
+                    : await ctx.chatluna.conversation.resolveConversation(
+                          session,
+                          {
+                              targetConversation,
+                              presetLane: context.options.presetLane,
+                              allPresetLanes: context.options.allPresetLanes,
+                              permission: 'manage',
+                              useRoutePresetLane:
+                                  context.options.presetLane == null &&
+                                  targetConversation == null,
+                              mode: 'target'
+                          }
+                      )
             const conversation = resolved.conversation
 
             if (conversation == null) {

--- a/packages/core/src/services/conversation.ts
+++ b/packages/core/src/services/conversation.ts
@@ -706,12 +706,12 @@ export class ConversationService {
         const merged = new Set(filtered.map((c) => c.bindingKey)).size > 1
 
         return filtered.sort((a, b) => {
+            const seq = (a.seq ?? 0) - (b.seq ?? 0)
+            if (seq !== 0) return seq
             if (merged) {
                 const key = a.bindingKey.localeCompare(b.bindingKey)
                 if (key !== 0) return key
             }
-            const seq = (a.seq ?? 0) - (b.seq ?? 0)
-            if (seq !== 0) return seq
             const created = a.createdAt.getTime() - b.createdAt.getTime()
             if (created !== 0) return created
             return a.id.localeCompare(b.id)
@@ -2038,7 +2038,10 @@ function formatToolCalls(toolCalls: unknown[]): string[] {
 }
 
 async function formatMessage(message: MessageRecord) {
-    const content = JSON.parse(await gzipDecode(message.content))
+    const content =
+        message.content == null
+            ? null
+            : JSON.parse(await gzipDecode(message.content))
 
     const text =
         content == null

--- a/packages/core/tests/conversation-runtime.spec.ts
+++ b/packages/core/tests/conversation-runtime.spec.ts
@@ -53,6 +53,7 @@ it('ConversationRuntime chat preserves additional kwargs metadata', async () => 
                 }
             })
         },
+        resolveCallbacks: async (input) => input.callbacks,
         ctx: {
             root: {
                 parallel: async () => {}

--- a/packages/core/tests/conversation-service.spec.ts
+++ b/packages/core/tests/conversation-service.spec.ts
@@ -1660,11 +1660,13 @@ it('ConversationService emits conversation lifecycle events for switch archive r
         events.map((item) => item.name),
         [
             'chatluna/before-conversation-switch',
+            'chatluna/after-binding-update',
             'chatluna/after-conversation-switch',
             'chatluna/conversation-compressed',
             'chatluna/before-conversation-archive',
             'chatluna/after-conversation-archive',
             'chatluna/before-conversation-restore',
+            'chatluna/after-binding-update',
             'chatluna/after-conversation-restore',
             'chatluna/before-conversation-delete',
             'chatluna/after-conversation-delete'

--- a/packages/core/tests/conversation-source.spec.ts
+++ b/packages/core/tests/conversation-source.spec.ts
@@ -28,7 +28,6 @@ it('conversation cleanup listeners in downstream packages use conversation lifec
             '../../extension-long-memory/src/service/memory.ts'
         ),
         path.resolve(__dirname, '../../extension-agent/src/service/skills.ts'),
-        path.resolve(__dirname, '../../extension-agent/src/cli/service.ts'),
         path.resolve(__dirname, '../../extension-tools/src/plugins/todos.ts')
     ]
 

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -181,6 +181,24 @@ export class FakeDatabase {
         }
     }
 
+    async set(
+        table: string,
+        query: Record<string, unknown>,
+        update: Record<string, unknown>
+    ) {
+        const target = (this.tables[table] ??= [])
+
+        for (let idx = 0; idx < target.length; idx += 1) {
+            if (
+                Object.entries(query).every(
+                    ([key, expected]) => target[idx][key] === expected
+                )
+            ) {
+                target[idx] = { ...target[idx], ...update }
+            }
+        }
+    }
+
     async remove(table: string, query: Record<string, unknown>) {
         const target = (this.tables[table] ??= [])
         this.tables[table] = target.filter(
@@ -384,6 +402,7 @@ export async function createMemoryService(
     app.plugin(memory)
     app.plugin(ChatLunaService, createConfig(options.config))
     await app.start()
+    app.chatluna.platform.registerChatChain('plugin', {}, () => ({}) as never)
     ;(
         app.chatluna.platform as unknown as {
             _models: Record<string, unknown[]>

--- a/packages/core/tests/rollback-chat.spec.ts
+++ b/packages/core/tests/rollback-chat.spec.ts
@@ -214,7 +214,10 @@ it('stop_chat re-resolves when conversation state is partial', async () => {
         let resolveOpts: any
         let stoppedId: string | undefined
 
-        ctx.chatluna.conversation.resolveConversation = async (_session, opts) => {
+        ctx.chatluna.conversation.resolveConversation = async (
+            _session,
+            opts
+        ) => {
             resolveCalls += 1
             resolveOpts = opts
             return {
@@ -352,6 +355,134 @@ it('rollback_chat does not fall back to current conversation for an explicit mis
                 })
             )[0].latestMessageId,
             'message-current'
+        )
+    } finally {
+        await app.stop()
+    }
+})
+
+it('rollback_chat resolves explicit target over pre-resolved conversation', async () => {
+    const current = createConversation({
+        id: 'conversation-current-explicit',
+        latestMessageId: 'message-current-explicit'
+    })
+    const target = createConversation({
+        id: 'conversation-target-explicit',
+        seq: 2,
+        latestMessageId: 'message-target-explicit'
+    })
+    const { app, database, ctx } = await createMemoryService({
+        tables: {
+            chatluna_conversation: [
+                current as unknown as TableRow,
+                target as unknown as TableRow
+            ],
+            chatluna_message: [
+                createMessage({
+                    id: 'message-current-explicit',
+                    conversationId: current.id,
+                    text: 'current',
+                    content: null
+                }) as unknown as TableRow,
+                createMessage({
+                    id: 'message-target-explicit',
+                    conversationId: target.id,
+                    text: 'target',
+                    content: null
+                }) as unknown as TableRow
+            ]
+        }
+    })
+
+    try {
+        const session = createSession() as any
+        const resolve = ctx.chatluna.conversation.resolveConversation.bind(
+            ctx.chatluna.conversation
+        )
+        let run:
+            | ((
+                  session: any,
+                  context: any
+              ) => Promise<ChainMiddlewareRunStatus>)
+            | undefined
+        const resolveOpts: unknown[] = []
+
+        ctx.chatluna.conversation.resolveConversation = async (
+            currentSession,
+            opts
+        ) => {
+            resolveOpts.push(opts)
+            return resolve(currentSession, opts)
+        }
+        ctx.chatluna.messageTransformer.transform = async () => 'target'
+        session.text = (key, params) =>
+            key === '.rollback_success' ? `${key}:${params?.[0]}` : key
+        session.send = async () => {}
+
+        apply(
+            ctx as never,
+            {
+                includeQuoteReply: false
+            } as never,
+            {
+                middleware: (_name, fn) => {
+                    run = fn as never
+                    return {
+                        after() {
+                            return this
+                        },
+                        before() {
+                            return this
+                        }
+                    }
+                }
+            } as never
+        )
+
+        const status = await run!(session, {
+            command: 'rollback',
+            message: '',
+            options: {
+                rollback_round: 1,
+                targetConversation: target.id,
+                conversation: {
+                    bindingKey: current.bindingKey,
+                    constraint: {
+                        manageMode: 'anyone',
+                        lockConversation: false
+                    },
+                    effectiveModel: 'test-platform/test-model',
+                    effectivePreset: 'default-preset',
+                    effectiveChatMode: 'plugin',
+                    conversationId: current.id,
+                    conversation: current,
+                    mode: 'target'
+                }
+            }
+        })
+
+        assert.equal(status, ChainMiddlewareRunStatus.CONTINUE)
+        assert.equal(
+            resolveOpts.some(
+                (opts) => (opts as any).targetConversation === target.id
+            ),
+            true
+        )
+        assert.equal(
+            (
+                await database.get('chatluna_conversation', {
+                    id: current.id
+                })
+            )[0].latestMessageId,
+            'message-current-explicit'
+        )
+        assert.equal(
+            (
+                await database.get('chatluna_conversation', {
+                    id: target.id
+                })
+            )[0].latestMessageId,
+            null
         )
     } finally {
         await app.stop()
@@ -615,6 +746,101 @@ it('rollback_chat falls back to the active preset lane conversation', async () =
             1
         )
         assert.deepEqual(sent, ['.rollback_success:1'])
+    } finally {
+        await app.stop()
+    }
+})
+
+it('stop_chat resolves explicit target over pre-resolved conversation', async () => {
+    const current = createConversation({
+        id: 'conversation-current-stop-explicit'
+    })
+    const target = createConversation({
+        id: 'conversation-target-stop-explicit',
+        seq: 2
+    })
+    const { app, ctx } = await createMemoryService({
+        tables: {
+            chatluna_conversation: [
+                current as unknown as TableRow,
+                target as unknown as TableRow
+            ]
+        }
+    })
+
+    try {
+        const session = createSession() as any
+        const resolve = ctx.chatluna.conversation.resolveConversation.bind(
+            ctx.chatluna.conversation
+        )
+        let run:
+            | ((
+                  session: any,
+                  context: any
+              ) => Promise<ChainMiddlewareRunStatus>)
+            | undefined
+        const resolveOpts: unknown[] = []
+        let stoppedId: string | undefined
+
+        ctx.chatluna.conversation.resolveConversation = async (
+            currentSession,
+            opts
+        ) => {
+            resolveOpts.push(opts)
+            return resolve(currentSession, opts)
+        }
+        ctx.chatluna.conversationRuntime.stopConversationRequest = (id) => {
+            stoppedId = id
+            return true
+        }
+        session.text = (key) => key
+
+        applyStop(
+            ctx as never,
+            {} as never,
+            {
+                middleware: (_name, fn) => {
+                    run = fn as never
+                    return {
+                        after() {
+                            return this
+                        },
+                        before() {
+                            return this
+                        }
+                    }
+                }
+            } as never
+        )
+
+        const status = await run!(session, {
+            command: 'stop_chat',
+            options: {
+                targetConversation: target.id,
+                conversation: {
+                    bindingKey: current.bindingKey,
+                    constraint: {
+                        manageMode: 'anyone',
+                        lockConversation: false
+                    },
+                    effectiveModel: 'test-platform/test-model',
+                    effectivePreset: 'default-preset',
+                    effectiveChatMode: 'plugin',
+                    conversationId: current.id,
+                    conversation: current,
+                    mode: 'target'
+                }
+            }
+        })
+
+        assert.equal(status, ChainMiddlewareRunStatus.STOP)
+        assert.equal(
+            resolveOpts.some(
+                (opts) => (opts as any).targetConversation === target.id
+            ),
+            true
+        )
+        assert.equal(stoppedId, target.id)
     } finally {
         await app.stop()
     }


### PR DESCRIPTION
## 关联

- 后续测试：#878

## 背景

继续测试 `1.4 alpha` 时，`packages/core` 的 conversation 相关用例暴露了几处回归和测试夹具失配。该 PR 针对这些问题做集中修复。

## 问题

- 旧消息的 `content` 可能为 `null`，导出 Markdown 时会继续调用 `gzipDecode(null)` 并失败。
- 跨 `preset lane` 列出会话时先按 `bindingKey` 排序，导致 `seq` 展示和数字切换顺序不稳定。
- `rollback_chat` / `stop_chat` 已有完整 `conversation resolution` 时仍会重复解析。
- 显式指定 `targetConversation` 时，不能复用当前预解析会话，否则会忽略用户指定的目标会话。
- core 测试夹具缺少 `database.set`、默认 `plugin` chat chain，并仍引用已移除的 `extension-agent` cli service 文件。

## 修复

- `exportMarkdown` 格式化消息时允许 `message.content` 为空，并回退使用 `message.text`。
- `listConversations` 跨 route / preset lane 排序时优先使用 `conversation.seq`，仅在 `seq` 相同且合并多 binding 时再比较 `bindingKey`。
- `rollback_chat` / `stop_chat` 在没有显式 `targetConversation` 且现有解析结果完整时复用 `context.options.conversation`。
- 为显式目标覆盖预解析会话的场景补充 `rollback_chat` 和 `stop_chat` 回归测试。
- 补齐测试夹具能力，并更新 lifecycle 事件断言以覆盖 `chatluna/after-binding-update`。

## 验证

本地已验证：

```text
yarn test                         # 96 passing
yarn fast-build shared-prompt-renderer
yarn fast-build core
yarn lint                         # 0 errors, 7 existing max-len warnings
```

GitHub Actions 已通过：

- `prepare`
- `lint`
- `build`
- `CodeFactor`
- `CodeRabbit`