### PR TITLE
fix(adapter-claude): 支持适配器多实例启用

### DIFF
--- a/packages/adapter-claude/src/index.ts
+++ b/packages/adapter-claude/src/index.ts
@@ -6,6 +6,8 @@ import { ClaudeClient } from './client'
 import { ModelCapabilities } from 'koishi-plugin-chatluna/llm-core/platform/types'
 
 export let logger: Logger
+export const reusable = true
+
 export function apply(ctx: Context, config: Config) {
     logger = createLogger(ctx, 'chatluna-claude-adapter')
 


### PR DESCRIPTION
在 Claude 适配器入口导出 reusable = true ，该变更使 Koishi 允许同一插件创建多份配置实例，避免第二份 Claude 配置被判定为不可重用而无法正常启用。

影响文件：packages/adapter-claude/src/index.ts

另外也对其他的adapter进行了一轮排查，没有发现类似问题