### PR TITLE
feat(adapter-gemini): 支持 camelCase 媒体字段配置

### DIFF
--- a/packages/adapter-gemini/src/index.ts
+++ b/packages/adapter-gemini/src/index.ts
@@ -50,6 +50,7 @@ export interface Config extends ChatLunaPlugin.Config {
     includeThoughts: boolean
     groundingContentDisplay: boolean
     useCamelCaseSystemInstruction: boolean
+    useCamelCaseMediaFields: boolean
     nonStreaming: boolean
 }
 
@@ -86,6 +87,7 @@ export const Config: Schema<Config> = Schema.intersect([
         groundingContentDisplay: Schema.boolean().default(false),
         imageGeneration: Schema.boolean().default(false),
         useCamelCaseSystemInstruction: Schema.boolean().default(false),
+        useCamelCaseMediaFields: Schema.boolean().default(false),
         nonStreaming: Schema.boolean().default(false)
     })
 ]).i18n({

--- a/packages/adapter-gemini/src/locales/en-US.schema.yml
+++ b/packages/adapter-gemini/src/locales/en-US.schema.yml
@@ -22,4 +22,5 @@ $inner:
       codeExecution: 'Enable code execution tool'
       urlContext: 'Enable URL context retrieval tool'
       useCamelCaseSystemInstruction: 'Use camelCase systemInstruction instead of snake_case system_instruction'
+      useCamelCaseMediaFields: 'Use camelCase inlineData and mimeType instead of snake_case inline_data and mime_type'
       nonStreaming: 'Force disable streaming response. When enabled, requests will always be made in non-streaming mode, even if the stream parameter is configured.'

--- a/packages/adapter-gemini/src/locales/zh-CN.schema.yml
+++ b/packages/adapter-gemini/src/locales/zh-CN.schema.yml
@@ -22,4 +22,5 @@ $inner:
       codeExecution: '为模型启用代码执行工具。（开启后将无法使用工具调用）'
       urlContext: '为模型启用 URL 内容获取工具。（开启后将无法使用工具调用）'
       useCamelCaseSystemInstruction: 使用大写的 systemInstruction 而不是小写的 system_instruction
+      useCamelCaseMediaFields: 使用大写的 inlineData 和 mimeType，而不是小写的 inline_data 和 mime_type
       nonStreaming: 强制不启用流式返回。开启后，将总是以非流式发起请求，即便配置了 stream 参数。

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -223,9 +223,7 @@ async function processGeminiImageContent(
     const mineType = url.match(/^data:([^;]+);base64,/)?.[1] ?? 'image/jpeg'
     const data = url.replace(/^data:image\/\w+;base64,/, '')
 
-    return {
-        inline_data: { data, mime_type: mineType }
-    }
+    return createGeminiInlineDataPart(plugin, data, mineType)
 }
 
 type GeminiFileLikeContent = MessageContentComplex &
@@ -254,18 +252,33 @@ function isGeminiFileLikeContent(
     )
 }
 
+function createGeminiInlineDataPart(
+    plugin: ChatLunaPlugin,
+    data: string,
+    mimeType: string
+) {
+    if ((plugin.config as Config).useCamelCaseMediaFields) {
+        return {
+            inlineData: { data, mimeType }
+        }
+    }
+
+    return {
+        inline_data: { data, mime_type: mimeType }
+    }
+}
+
 async function processGeminiFileLikeContent(
     plugin: ChatLunaPlugin,
     part: GeminiFileLikeContent
 ) {
     try {
         const { buffer, mimeType } = await fetchFileLikeUrl(plugin, part)
-        return {
-            inline_data: {
-                data: buffer.toString('base64'),
-                mime_type: mimeType
-            }
-        }
+        return createGeminiInlineDataPart(
+            plugin,
+            buffer.toString('base64'),
+            mimeType
+        )
     } catch (e) {
         logger.warn(`Failed to fetch ${part.type}`, e)
         return null

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -146,7 +146,7 @@ function parseJsonArgs(args: string) {
 }
 
 async function processFunctionMessage(
-    plugin: ChatLunaPlugin,
+    plugin: ChatLunaPlugin<ClientConfig, Config>,
     message: AIMessage | ToolMessage,
     removeId: boolean
 ): Promise<ChatCompletionResponseMessage> {
@@ -205,7 +205,7 @@ async function processFunctionMessage(
 }
 
 async function processGeminiImageContent(
-    plugin: ChatLunaPlugin,
+    plugin: ChatLunaPlugin<ClientConfig, Config>,
     part: MessageContentImageUrl
 ) {
     let url: string
@@ -253,11 +253,11 @@ function isGeminiFileLikeContent(
 }
 
 function createGeminiInlineDataPart(
-    plugin: ChatLunaPlugin,
+    plugin: ChatLunaPlugin<ClientConfig, Config>,
     data: string,
     mimeType: string
 ) {
-    if ((plugin.config as Config).useCamelCaseMediaFields) {
+    if (plugin.config.useCamelCaseMediaFields) {
         return {
             inlineData: { data, mimeType }
         }
@@ -269,7 +269,7 @@ function createGeminiInlineDataPart(
 }
 
 async function processGeminiFileLikeContent(
-    plugin: ChatLunaPlugin,
+    plugin: ChatLunaPlugin<ClientConfig, Config>,
     part: GeminiFileLikeContent
 ) {
     try {
@@ -286,7 +286,7 @@ async function processGeminiFileLikeContent(
 }
 
 async function processGeminiContentParts(
-    plugin: ChatLunaPlugin,
+    plugin: ChatLunaPlugin<ClientConfig, Config>,
     content: MessageContentComplex[],
     thoughtData: Record<string, any> = {}
 ) {


### PR DESCRIPTION
## 摘要
- 为 Gemini 适配器增加对 `inlineData` 和 `mimeType` 字段的驼峰命名（camelCase）选项支持。
- 默认禁用上述两项配置。
- 为 zh-CN 和 en-US 补充模式标签（Schema labels）。