### PR TITLE
[Feature] delete conversations by sequence range

### DIFF
--- a/packages/core/src/commands/conversation.ts
+++ b/packages/core/src/commands/conversation.ts
@@ -240,8 +240,6 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
         .option('all', '--all')
         .action(async ({ options, session }, conversation) => {
             const presetLane = options.preset?.trim() || undefined
-            const target = conversation?.trim() || undefined
-            const seqs = target == null ? undefined : parseSeqs(target)
             const includeArchived =
                 options.archived === true || options.all === true
             await chain.receiveCommand(
@@ -250,8 +248,7 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
                 {
                     allPresetLanes: presetLane == null,
                     conversation_manage: {
-                        targetConversation: seqs == null ? target : undefined,
-                        targetConversationSeqs: seqs,
+                        targetConversation: conversation?.trim() || undefined,
                         presetLane,
                         includeArchived
                     }
@@ -418,28 +415,6 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
     })
 }
 
-function parseSeqs(input: string) {
-    if (!input.includes(',') && !input.includes('..')) return undefined
-    if (!/^\d+(?:\.\.\d+)?(?:,\d+(?:\.\.\d+)?)*$/.test(input)) {
-        return undefined
-    }
-
-    const seqs = new Set<number>()
-    for (const part of input.split(',')) {
-        const [start, end = start] = part.split('..').map(Number)
-        for (
-            let seq = Math.min(start, end);
-            seq <= Math.max(start, end);
-            seq += 1
-        ) {
-            seqs.add(seq)
-            if (seqs.size > 100) return undefined
-        }
-    }
-
-    return [...seqs]
-}
-
 declare module '../chains/chain' {
     interface ChainMiddlewareContextOptions {
         conversation_create?: {
@@ -450,7 +425,6 @@ declare module '../chains/chain' {
         }
         conversation_manage?: {
             targetConversation?: string
-            targetConversationSeqs?: number[]
             presetLane?: string
             includeArchived?: boolean
             title?: string

--- a/packages/core/src/commands/conversation.ts
+++ b/packages/core/src/commands/conversation.ts
@@ -433,6 +433,7 @@ function parseSeqs(input: string) {
             seq += 1
         ) {
             seqs.add(seq)
+            if (seqs.size > 100) return undefined
         }
     }
 

--- a/packages/core/src/commands/conversation.ts
+++ b/packages/core/src/commands/conversation.ts
@@ -240,6 +240,8 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
         .option('all', '--all')
         .action(async ({ options, session }, conversation) => {
             const presetLane = options.preset?.trim() || undefined
+            const target = conversation?.trim() || undefined
+            const seqs = target == null ? undefined : parseSeqs(target)
             const includeArchived =
                 options.archived === true || options.all === true
             await chain.receiveCommand(
@@ -248,7 +250,8 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
                 {
                     allPresetLanes: presetLane == null,
                     conversation_manage: {
-                        targetConversation: conversation?.trim() || undefined,
+                        targetConversation: seqs == null ? target : undefined,
+                        targetConversationSeqs: seqs,
                         presetLane,
                         includeArchived
                     }
@@ -415,6 +418,27 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
     })
 }
 
+function parseSeqs(input: string) {
+    if (!input.includes(',') && !input.includes('..')) return undefined
+    if (!/^\d+(?:\.\.\d+)?(?:,\d+(?:\.\.\d+)?)*$/.test(input)) {
+        return undefined
+    }
+
+    const seqs = new Set<number>()
+    for (const part of input.split(',')) {
+        const [start, end = start] = part.split('..').map(Number)
+        for (
+            let seq = Math.min(start, end);
+            seq <= Math.max(start, end);
+            seq += 1
+        ) {
+            seqs.add(seq)
+        }
+    }
+
+    return [...seqs]
+}
+
 declare module '../chains/chain' {
     interface ChainMiddlewareContextOptions {
         conversation_create?: {
@@ -425,6 +449,7 @@ declare module '../chains/chain' {
         }
         conversation_manage?: {
             targetConversation?: string
+            targetConversationSeqs?: number[]
             presetLane?: string
             includeArchived?: boolean
             title?: string

--- a/packages/core/src/locales/en-US.yml
+++ b/packages/core/src/locales/en-US.yml
@@ -579,6 +579,7 @@ chatluna:
             rename_success: 'Renamed to: {0}'
             rename_failed: 'Failed to rename conversation: {0}'
             delete_success: 'Deleted conversation: {0}'
+            delete_success_multi: 'Deleted conversations:\n{0}'
             delete_failed: 'Failed to delete conversation: {0}'
             use_model_success: '{1} now uses model {0}.'
             use_model_failed: 'Failed to switch model: {0}'

--- a/packages/core/src/locales/zh-CN.yml
+++ b/packages/core/src/locales/zh-CN.yml
@@ -578,6 +578,7 @@ chatluna:
             rename_success: '已重命名为：{0}'
             rename_failed: '重命名会话失败：{0}'
             delete_success: '已删除会话：{0}'
+            delete_success_multi: '已删除会话：\n{0}'
             delete_failed: '删除会话失败：{0}'
             use_model_success: '{1} 已切换到模型 {0}。'
             use_model_failed: '切换模型失败：{0}'

--- a/packages/core/src/middlewares/conversation/resolve_conversation.ts
+++ b/packages/core/src/middlewares/conversation/resolve_conversation.ts
@@ -13,14 +13,17 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             const { options } = context
             const presetLane =
                 options.conversation_manage?.presetLane ?? options.presetLane
-            const rawTarget =
+            const targetConversation =
                 options.conversation_manage?.targetConversation ??
                 options.targetConversation
             const batchTarget =
                 context.command === 'conversation_delete' &&
-                rawTarget != null &&
-                (rawTarget.includes(',') || rawTarget.includes('..'))
-            const targetConversation = batchTarget ? undefined : rawTarget
+                targetConversation != null &&
+                targetConversation.length <= 512 &&
+                targetConversation.split(',').length <= 100 &&
+                /^\d+(?:\.\.\d+)?(?:,\d+(?:\.\.\d+)?)*$/.test(
+                    targetConversation
+                )
             const explicitConversationId =
                 options.conversation?.conversationId ??
                 options.conversation?.conversation?.id
@@ -51,6 +54,11 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                     )
 
                 if (hasExplicitTarget && resolved.conversation == null) {
+                    if (batchTarget) {
+                        options.conversation = resolved
+                        return ChainMiddlewareRunStatus.CONTINUE
+                    }
+
                     context.message =
                         targetValue == null
                             ? notFoundMessage(session, context)

--- a/packages/core/src/middlewares/conversation/resolve_conversation.ts
+++ b/packages/core/src/middlewares/conversation/resolve_conversation.ts
@@ -13,9 +13,14 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             const { options } = context
             const presetLane =
                 options.conversation_manage?.presetLane ?? options.presetLane
-            const targetConversation =
+            const rawTarget =
                 options.conversation_manage?.targetConversation ??
                 options.targetConversation
+            const batchTarget =
+                context.command === 'conversation_delete' &&
+                rawTarget != null &&
+                (rawTarget.includes(',') || rawTarget.includes('..'))
+            const targetConversation = batchTarget ? undefined : rawTarget
             const explicitConversationId =
                 options.conversation?.conversationId ??
                 options.conversation?.conversation?.id

--- a/packages/core/src/middlewares/system/conversation_manage.ts
+++ b/packages/core/src/middlewares/system/conversation_manage.ts
@@ -15,7 +15,6 @@ import {
     ConversationRecord,
     ConversationResolutionError,
     getBaseBindingKey,
-    getPresetLane,
     InvalidChatModeError,
     ResolvedConversationContext
 } from '../../types'
@@ -77,13 +76,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
 
         for (const field of ['model', 'preset', 'chatMode'] as const) {
             const value = create?.[field]
-            const fixedKey =
-                field === 'model'
-                    ? 'fixedModel'
-                    : field === 'preset'
-                      ? 'fixedPreset'
-                      : 'fixedChatMode'
-            const fixed = resolved.constraint[fixedKey]
+            const fixed = resolved.constraint[FIXED_FIELD_KEY[field]]
             if (value != null && fixed != null && value !== fixed) {
                 context.message = session.text(
                     `chatluna.conversation.messages.${FIXED_FIELD_MSG_KEY[field]}`,
@@ -199,7 +192,6 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                     session,
                     item.conversation,
                     resolved,
-                    false,
                     item.displaySeq
                 ),
             formatString: {
@@ -344,17 +336,9 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
     }
 
     middleware('conversation_archive', async (session, context) => {
-        const conversation = context.options.conversation?.conversation
+        const conversation = requireConversation(session, context, 'archive')
 
         if (conversation == null) {
-            context.message = session.text(
-                'chatluna.conversation.messages.archive_failed',
-                [
-                    session.text(
-                        'chatluna.conversation.messages.target_not_found'
-                    )
-                ]
-            )
             return ChainMiddlewareRunStatus.STOP
         }
 
@@ -386,17 +370,9 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
     })
 
     middleware('conversation_restore', async (session, context) => {
-        const current = context.options.conversation?.conversation
+        const current = requireConversation(session, context, 'restore')
 
         if (current == null) {
-            context.message = session.text(
-                'chatluna.conversation.messages.restore_failed',
-                [
-                    session.text(
-                        'chatluna.conversation.messages.target_not_found'
-                    )
-                ]
-            )
             return ChainMiddlewareRunStatus.STOP
         }
 
@@ -426,17 +402,9 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
     })
 
     middleware('conversation_export', async (session, context) => {
-        const conversation = context.options.conversation?.conversation
+        const conversation = requireConversation(session, context, 'export')
 
         if (conversation == null) {
-            context.message = session.text(
-                'chatluna.conversation.messages.export_failed',
-                [
-                    session.text(
-                        'chatluna.conversation.messages.target_not_found'
-                    )
-                ]
-            )
             return ChainMiddlewareRunStatus.STOP
         }
 
@@ -768,13 +736,28 @@ function resolvedConversationId(context: ChainMiddlewareContext) {
 
 function getManageOptions(context: ChainMiddlewareContext) {
     const presetLane = context.options.conversation_manage?.presetLane
-    const includeArchived =
-        context.options.conversation_manage?.includeArchived === true
     return {
         presetLane,
-        includeArchived: includeArchived || undefined,
+        includeArchived:
+            context.options.conversation_manage?.includeArchived === true ||
+            undefined,
         allPresetLanes: presetLane == null
     }
+}
+
+function requireConversation(
+    session: Session,
+    context: ChainMiddlewareContext,
+    action: string
+) {
+    const conversation = context.options.conversation?.conversation
+    if (conversation == null) {
+        context.message = session.text(
+            `chatluna.conversation.messages.${action}_failed`,
+            [session.text('chatluna.conversation.messages.target_not_found')]
+        )
+    }
+    return conversation
 }
 
 async function deleteBySeqs(
@@ -802,7 +785,7 @@ async function deleteBySeqs(
         )
     }
 
-    return session.text('chatluna.conversation.messages.delete_success', [
+    return session.text('chatluna.conversation.messages.delete_success_multi', [
         deleted.map((item) => item.title).join('\n')
     ])
 }
@@ -935,7 +918,6 @@ function formatConversationLine(
     session: Session,
     conversation: ConversationRecord,
     resolved: ResolvedConversationContext,
-    showLane = false,
     seq: number | string = conversation.seq ?? '-'
 ) {
     const status = formatConversationStatus(
@@ -943,48 +925,33 @@ function formatConversationLine(
         conversation,
         resolved.binding?.activeConversationId
     )
-    const effectiveModel =
+    const model =
         ctx.chatluna.conversation.pickModel(
             resolved.constraint,
             conversation
         ) ?? '-'
-    const effectivePreset =
+    const preset =
         resolved.constraint.fixedPreset ??
         conversation.preset ??
         resolved.constraint.defaultPreset ??
         '-'
-    const lane = formatPresetLane(
-        session,
-        getPresetLane(conversation.bindingKey)
-    )
 
-    if (!showLane && status == null) {
+    if (status == null) {
         return session.text('chatluna.conversation.conversation_line', [
             seq,
             conversation.title,
-            effectiveModel,
-            effectivePreset
+            model,
+            preset
         ])
     }
 
-    if (!showLane) {
-        return session.text(
-            'chatluna.conversation.conversation_line_with_status',
-            [seq, conversation.title, effectiveModel, effectivePreset, status]
-        )
-    }
-
-    if (status == null) {
-        return session.text(
-            'chatluna.conversation.conversation_line_with_lane',
-            [seq, conversation.title, effectiveModel, effectivePreset, lane]
-        )
-    }
-
-    return session.text(
-        'chatluna.conversation.conversation_line_with_lane_status',
-        [seq, conversation.title, effectiveModel, effectivePreset, lane, status]
-    )
+    return session.text('chatluna.conversation.conversation_line_with_status', [
+        seq,
+        conversation.title,
+        model,
+        preset,
+        status
+    ])
 }
 
 function formatLockState(lock: boolean | null | undefined) {
@@ -1034,6 +1001,12 @@ const RULE_FIELDS = [
         msgKey: 'rule_mode_status'
     }
 ] as const
+
+const FIXED_FIELD_KEY = {
+    model: 'fixedModel',
+    preset: 'fixedPreset',
+    chatMode: 'fixedChatMode'
+} as const
 
 const FIXED_FIELD_MSG_KEY = {
     model: 'fixed_model',

--- a/packages/core/src/middlewares/system/conversation_manage.ts
+++ b/packages/core/src/middlewares/system/conversation_manage.ts
@@ -800,7 +800,7 @@ function requireConversation(
 }
 
 function parseDeleteSeqs(input?: string) {
-    if (input == null || (!input.includes(',') && !input.includes('..'))) {
+    if (input == null || input.length === 0) {
         return
     }
 
@@ -825,10 +825,10 @@ function parseDeleteSeqs(input?: string) {
 
         const min = Math.min(start, end)
         const max = Math.max(start, end)
-        if (seqs.size + max - min + 1 > 100) return null
 
         for (let seq = min; seq <= max; seq += 1) {
             seqs.add(seq)
+            if (seqs.size > 100) return null
         }
     }
 

--- a/packages/core/src/middlewares/system/conversation_manage.ts
+++ b/packages/core/src/middlewares/system/conversation_manage.ts
@@ -274,69 +274,73 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 getManageOptions(context)
             const target =
                 context.options.conversation_manage?.targetConversation
-            const parsed = parseDeleteTarget(target)
+            const conversationId = resolvedConversationId(context)
 
-            if (parsed.type === 'invalid') {
-                context.message = session.text(
-                    'chatluna.conversation.messages.target_not_found'
-                )
-                return ChainMiddlewareRunStatus.STOP
-            }
+            if (conversationId == null) {
+                const parsed = parseDeleteTarget(target)
 
-            if (parsed.type === 'seqs') {
-                const entries =
-                    await ctx.chatluna.conversation.listConversationEntries(
-                        session,
-                        {
-                            presetLane,
-                            includeArchived,
-                            allPresetLanes
-                        }
-                    )
-                const seqSet = new Set(parsed.seqs)
-                const targets = entries.filter((item) =>
-                    seqSet.has(item.displaySeq)
-                )
-
-                if (targets.length !== parsed.seqs.length) {
+                if (parsed.type === 'invalid') {
                     context.message = session.text(
                         'chatluna.conversation.messages.target_not_found'
                     )
                     return ChainMiddlewareRunStatus.STOP
                 }
 
-                const deleted: ConversationRecord[] = []
-                for (const item of targets) {
-                    deleted.push(
-                        await ctx.chatluna.conversation.deleteConversation(
+                if (parsed.type === 'seqs') {
+                    const entries =
+                        await ctx.chatluna.conversation.listConversationEntries(
                             session,
                             {
-                                conversationId: item.conversation.id,
                                 presetLane,
                                 includeArchived,
                                 allPresetLanes
                             }
                         )
+                    const seqSet = new Set(parsed.seqs)
+                    const targets = entries.filter((item) =>
+                        seqSet.has(item.displaySeq)
                     )
-                }
 
-                context.message = session.text(
-                    'chatluna.conversation.messages.delete_success_multi',
-                    [
-                        deleted
-                            .map(
-                                (item) =>
-                                    `${item.title} (${item.seq ?? item.id})`
+                    if (targets.length !== parsed.seqs.length) {
+                        context.message = session.text(
+                            'chatluna.conversation.messages.target_not_found'
+                        )
+                        return ChainMiddlewareRunStatus.STOP
+                    }
+
+                    const deleted: ConversationRecord[] = []
+                    for (const item of targets) {
+                        deleted.push(
+                            await ctx.chatluna.conversation.deleteConversation(
+                                session,
+                                {
+                                    conversationId: item.conversation.id,
+                                    presetLane,
+                                    includeArchived,
+                                    allPresetLanes
+                                }
                             )
-                            .join('\n')
-                    ]
-                )
-                return ChainMiddlewareRunStatus.STOP
+                        )
+                    }
+
+                    context.message = session.text(
+                        'chatluna.conversation.messages.delete_success_multi',
+                        [
+                            deleted
+                                .map(
+                                    (item) =>
+                                        `${item.title} (${item.seq ?? item.id})`
+                                )
+                                .join('\n')
+                        ]
+                    )
+                    return ChainMiddlewareRunStatus.STOP
+                }
             }
 
             const conversation =
                 await ctx.chatluna.conversation.deleteConversation(session, {
-                    conversationId: resolvedConversationId(context),
+                    conversationId,
                     presetLane,
                     includeArchived,
                     allPresetLanes

--- a/packages/core/src/middlewares/system/conversation_manage.ts
+++ b/packages/core/src/middlewares/system/conversation_manage.ts
@@ -270,69 +270,56 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
 
     middleware('conversation_delete', async (session, context) => {
         try {
-            const { presetLane, includeArchived, allPresetLanes } =
-                getManageOptions(context)
-            const target =
-                context.options.conversation_manage?.targetConversation
+            const opts = getManageOptions(context)
             const conversationId = resolvedConversationId(context)
 
             if (conversationId == null) {
-                const parsed = parseDeleteTarget(target)
+                const seqs = parseDeleteSeqs(
+                    context.options.conversation_manage?.targetConversation
+                )
 
-                if (parsed.type === 'invalid') {
+                if (seqs === null) {
                     context.message = session.text(
                         'chatluna.conversation.messages.target_not_found'
                     )
                     return ChainMiddlewareRunStatus.STOP
                 }
 
-                if (parsed.type === 'seqs') {
+                if (seqs != null) {
                     const entries =
                         await ctx.chatluna.conversation.listConversationEntries(
                             session,
-                            {
-                                presetLane,
-                                includeArchived,
-                                allPresetLanes
-                            }
+                            opts
                         )
-                    const seqSet = new Set(parsed.seqs)
                     const targets = entries.filter((item) =>
-                        seqSet.has(item.displaySeq)
+                        seqs.includes(item.displaySeq)
                     )
 
-                    if (targets.length !== parsed.seqs.length) {
+                    if (targets.length !== seqs.length) {
                         context.message = session.text(
                             'chatluna.conversation.messages.target_not_found'
                         )
                         return ChainMiddlewareRunStatus.STOP
                     }
 
-                    const deleted: ConversationRecord[] = []
+                    const deleted: string[] = []
                     for (const item of targets) {
-                        deleted.push(
+                        const conversation =
                             await ctx.chatluna.conversation.deleteConversation(
                                 session,
                                 {
-                                    conversationId: item.conversation.id,
-                                    presetLane,
-                                    includeArchived,
-                                    allPresetLanes
+                                    ...opts,
+                                    conversationId: item.conversation.id
                                 }
                             )
+                        deleted.push(
+                            `${conversation.title} (${conversation.seq ?? conversation.id})`
                         )
                     }
 
                     context.message = session.text(
                         'chatluna.conversation.messages.delete_success_multi',
-                        [
-                            deleted
-                                .map(
-                                    (item) =>
-                                        `${item.title} (${item.seq ?? item.id})`
-                                )
-                                .join('\n')
-                        ]
+                        [deleted.join('\n')]
                     )
                     return ChainMiddlewareRunStatus.STOP
                 }
@@ -340,10 +327,8 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
 
             const conversation =
                 await ctx.chatluna.conversation.deleteConversation(session, {
-                    conversationId,
-                    presetLane,
-                    includeArchived,
-                    allPresetLanes
+                    ...opts,
+                    conversationId
                 })
 
             context.message = session.text(
@@ -781,11 +766,6 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
     })
 }
 
-type DeleteTarget =
-    | { type: 'single'; target?: string }
-    | { type: 'seqs'; seqs: number[] }
-    | { type: 'invalid' }
-
 function resolvedConversationId(context: ChainMiddlewareContext) {
     return (
         context.options.conversation?.conversationId ??
@@ -819,22 +799,18 @@ function requireConversation(
     return conversation
 }
 
-function parseDeleteTarget(input?: string): DeleteTarget {
-    if (input == null || input.length === 0) {
-        return { type: 'single', target: input }
+function parseDeleteSeqs(input?: string) {
+    if (input == null || (!input.includes(',') && !input.includes('..'))) {
+        return
     }
-    if (!input.includes(',') && !input.includes('..')) {
-        return { type: 'single', target: input }
-    }
-    if (input.length > 512) return { type: 'invalid' }
 
     const parts = input.split(',')
-    if (parts.length > 100) return { type: 'invalid' }
+    if (input.length > 512 || parts.length > 100) return null
 
     const seqs = new Set<number>()
     for (const part of parts) {
         const match = /^(\d+)(?:\.\.(\d+))?$/.exec(part)
-        if (match == null) return { type: 'invalid' }
+        if (match == null) return null
 
         const start = Number(match[1])
         const end = Number(match[2] ?? match[1])
@@ -844,20 +820,19 @@ function parseDeleteTarget(input?: string): DeleteTarget {
             start < 1 ||
             end < 1
         ) {
-            return { type: 'invalid' }
+            return null
         }
 
         const min = Math.min(start, end)
         const max = Math.max(start, end)
-        const count = max - min + 1
-        if (seqs.size + count > 100) return { type: 'invalid' }
+        if (seqs.size + max - min + 1 > 100) return null
 
-        for (let idx = 0; idx < count; idx += 1) {
-            seqs.add(min + idx)
+        for (let seq = min; seq <= max; seq += 1) {
+            seqs.add(seq)
         }
     }
 
-    return { type: 'seqs', seqs: Array.from(seqs) }
+    return Array.from(seqs)
 }
 
 function conversationSummary(conversation: ConversationRecord) {

--- a/packages/core/src/middlewares/system/conversation_manage.ts
+++ b/packages/core/src/middlewares/system/conversation_manage.ts
@@ -280,6 +280,18 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
         try {
             const { presetLane, includeArchived, allPresetLanes } =
                 getManageOptions(context)
+            const seqs =
+                context.options.conversation_manage?.targetConversationSeqs
+
+            if (seqs != null) {
+                context.message = await deleteBySeqs(ctx, session, seqs, {
+                    presetLane,
+                    includeArchived,
+                    allPresetLanes
+                })
+                return ChainMiddlewareRunStatus.STOP
+            }
+
             const conversation =
                 await ctx.chatluna.conversation.deleteConversation(session, {
                     conversationId: resolvedConversationId(context),
@@ -763,6 +775,36 @@ function getManageOptions(context: ChainMiddlewareContext) {
         includeArchived: includeArchived || undefined,
         allPresetLanes: presetLane == null
     }
+}
+
+async function deleteBySeqs(
+    ctx: Context,
+    session: Session,
+    seqs: number[],
+    opts: ReturnType<typeof getManageOptions>
+) {
+    const entries = await ctx.chatluna.conversation.listConversationEntries(
+        session,
+        opts
+    )
+    const targets = entries.filter((item) => seqs.includes(item.displaySeq))
+    if (targets.length !== seqs.length) {
+        return session.text('chatluna.conversation.messages.target_not_found')
+    }
+
+    const deleted: ConversationRecord[] = []
+    for (const target of targets) {
+        deleted.push(
+            await ctx.chatluna.conversation.deleteConversation(session, {
+                conversationId: target.conversation.id,
+                ...opts
+            })
+        )
+    }
+
+    return session.text('chatluna.conversation.messages.delete_success', [
+        deleted.map((item) => item.title).join('\n')
+    ])
 }
 
 function conversationSummary(conversation: ConversationRecord) {

--- a/packages/core/src/middlewares/system/conversation_manage.ts
+++ b/packages/core/src/middlewares/system/conversation_manage.ts
@@ -272,15 +272,65 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
         try {
             const { presetLane, includeArchived, allPresetLanes } =
                 getManageOptions(context)
-            const seqs =
-                context.options.conversation_manage?.targetConversationSeqs
+            const target =
+                context.options.conversation_manage?.targetConversation
+            const parsed = parseDeleteTarget(target)
 
-            if (seqs != null) {
-                context.message = await deleteBySeqs(ctx, session, seqs, {
-                    presetLane,
-                    includeArchived,
-                    allPresetLanes
-                })
+            if (parsed.type === 'invalid') {
+                context.message = session.text(
+                    'chatluna.conversation.messages.target_not_found'
+                )
+                return ChainMiddlewareRunStatus.STOP
+            }
+
+            if (parsed.type === 'seqs') {
+                const entries =
+                    await ctx.chatluna.conversation.listConversationEntries(
+                        session,
+                        {
+                            presetLane,
+                            includeArchived,
+                            allPresetLanes
+                        }
+                    )
+                const seqSet = new Set(parsed.seqs)
+                const targets = entries.filter((item) =>
+                    seqSet.has(item.displaySeq)
+                )
+
+                if (targets.length !== parsed.seqs.length) {
+                    context.message = session.text(
+                        'chatluna.conversation.messages.target_not_found'
+                    )
+                    return ChainMiddlewareRunStatus.STOP
+                }
+
+                const deleted: ConversationRecord[] = []
+                for (const item of targets) {
+                    deleted.push(
+                        await ctx.chatluna.conversation.deleteConversation(
+                            session,
+                            {
+                                conversationId: item.conversation.id,
+                                presetLane,
+                                includeArchived,
+                                allPresetLanes
+                            }
+                        )
+                    )
+                }
+
+                context.message = session.text(
+                    'chatluna.conversation.messages.delete_success_multi',
+                    [
+                        deleted
+                            .map(
+                                (item) =>
+                                    `${item.title} (${item.seq ?? item.id})`
+                            )
+                            .join('\n')
+                    ]
+                )
                 return ChainMiddlewareRunStatus.STOP
             }
 
@@ -727,6 +777,11 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
     })
 }
 
+type DeleteTarget =
+    | { type: 'single'; target?: string }
+    | { type: 'seqs'; seqs: number[] }
+    | { type: 'invalid' }
+
 function resolvedConversationId(context: ChainMiddlewareContext) {
     return (
         context.options.conversation?.conversationId ??
@@ -760,34 +815,45 @@ function requireConversation(
     return conversation
 }
 
-async function deleteBySeqs(
-    ctx: Context,
-    session: Session,
-    seqs: number[],
-    opts: ReturnType<typeof getManageOptions>
-) {
-    const entries = await ctx.chatluna.conversation.listConversationEntries(
-        session,
-        opts
-    )
-    const targets = entries.filter((item) => seqs.includes(item.displaySeq))
-    if (targets.length !== seqs.length) {
-        return session.text('chatluna.conversation.messages.target_not_found')
+function parseDeleteTarget(input?: string): DeleteTarget {
+    if (input == null || input.length === 0) {
+        return { type: 'single', target: input }
+    }
+    if (!input.includes(',') && !input.includes('..')) {
+        return { type: 'single', target: input }
+    }
+    if (input.length > 512) return { type: 'invalid' }
+
+    const parts = input.split(',')
+    if (parts.length > 100) return { type: 'invalid' }
+
+    const seqs = new Set<number>()
+    for (const part of parts) {
+        const match = /^(\d+)(?:\.\.(\d+))?$/.exec(part)
+        if (match == null) return { type: 'invalid' }
+
+        const start = Number(match[1])
+        const end = Number(match[2] ?? match[1])
+        if (
+            !Number.isSafeInteger(start) ||
+            !Number.isSafeInteger(end) ||
+            start < 1 ||
+            end < 1
+        ) {
+            return { type: 'invalid' }
+        }
+
+        const min = Math.min(start, end)
+        const max = Math.max(start, end)
+        const count = max - min + 1
+        if (seqs.size + count > 100) return { type: 'invalid' }
+
+        for (let idx = 0; idx < count; idx += 1) {
+            seqs.add(min + idx)
+        }
     }
 
-    const deleted: ConversationRecord[] = []
-    for (const target of targets) {
-        deleted.push(
-            await ctx.chatluna.conversation.deleteConversation(session, {
-                conversationId: target.conversation.id,
-                ...opts
-            })
-        )
-    }
-
-    return session.text('chatluna.conversation.messages.delete_success_multi', [
-        deleted.map((item) => item.title).join('\n')
-    ])
+    return { type: 'seqs', seqs: Array.from(seqs) }
 }
 
 function conversationSummary(conversation: ConversationRecord) {

--- a/packages/core/tests/conversation-resolve.spec.ts
+++ b/packages/core/tests/conversation-resolve.spec.ts
@@ -10,6 +10,7 @@ import { apply as applyResolve } from '../src/middlewares/conversation/resolve_c
 import { apply as applyRequest } from '../src/middlewares/conversation/request_conversation'
 import { apply as applyManage } from '../src/middlewares/system/conversation_manage'
 import { apply as applyLifecycle } from '../src/middlewares/system/lifecycle'
+import { apply as applyCommands } from '../src/commands/conversation'
 import { ConversationResolutionError } from '../src/types'
 import {
     createConfig,
@@ -723,6 +724,97 @@ it('conversation_switch accepts resolved direct conversation ids', async () => {
     } finally {
         await app.stop()
     }
+})
+
+it('chatluna.delete removes range and list selectors', async () => {
+    const conversations = [
+        createConversation({ id: 'conversation-first', title: 'First Topic' }),
+        createConversation({
+            id: 'conversation-second',
+            title: 'Second Topic'
+        }),
+        createConversation({ id: 'conversation-third', title: 'Third Topic' })
+    ]
+    const actions = new Map<string, (...args: any[]) => Promise<void>>()
+    const deleted: string[] = []
+    const messages: string[] = []
+    let run:
+        | ((session: any, context: any) => Promise<ChainMiddlewareRunStatus>)
+        | undefined
+    const ctx = {
+        command: (decl: string) => {
+            const cmd = {
+                alias: () => cmd,
+                option: () => cmd,
+                action: (fn: (...args: any[]) => Promise<void>) => {
+                    actions.set(decl, fn)
+                    return cmd
+                }
+            }
+            return cmd
+        },
+        chatluna: {
+            conversation: {
+                listConversationEntries: async () =>
+                    conversations.map((conversation, idx) => ({
+                        conversation,
+                        displaySeq: idx + 1
+                    })),
+                deleteConversation: async (_session, opts) => {
+                    deleted.push(opts.conversationId)
+                    return conversations.find(
+                        (item) => item.id === opts.conversationId
+                    )
+                }
+            }
+        }
+    }
+    const chain = {
+        middleware: (name, fn) => {
+            if (name === 'conversation_delete') run = fn
+            return {
+                after() {
+                    return this
+                },
+                before() {
+                    return this
+                }
+            }
+        }
+    }
+
+    applyManage(ctx as never, {} as never, chain as never)
+    applyCommands(
+        ctx as never,
+        {} as never,
+        {
+            receiveCommand: async (session, name, opts) => {
+                await run!(session, { command: name, options: opts })
+            }
+        } as never
+    )
+
+    const session = createSession() as any
+    session.text = (key, params) => {
+        const msg = params == null ? key : `${key}:${params.join(',')}`
+        messages.push(msg)
+        return msg
+    }
+
+    const action = actions.get('chatluna.delete [conversation:string]')!
+    await action({ options: {}, session }, '1..2')
+    await action({ options: {}, session }, '1,3')
+
+    assert.deepEqual(deleted, [
+        'conversation-first',
+        'conversation-second',
+        'conversation-first',
+        'conversation-third'
+    ])
+    assert.deepEqual(messages, [
+        'chatluna.conversation.messages.delete_success:First Topic\nSecond Topic',
+        'chatluna.conversation.messages.delete_success:First Topic\nThird Topic'
+    ])
 })
 
 it('conversation_switch preserves explicit chain conversation through middleware order', async () => {

--- a/packages/core/tests/conversation-resolve.spec.ts
+++ b/packages/core/tests/conversation-resolve.spec.ts
@@ -812,8 +812,8 @@ it('chatluna.delete removes range and list selectors', async () => {
         'conversation-third'
     ])
     assert.deepEqual(messages, [
-        'chatluna.conversation.messages.delete_success:First Topic\nSecond Topic',
-        'chatluna.conversation.messages.delete_success:First Topic\nThird Topic'
+        'chatluna.conversation.messages.delete_success_multi:First Topic\nSecond Topic',
+        'chatluna.conversation.messages.delete_success_multi:First Topic\nThird Topic'
     ])
 })
 

--- a/packages/core/tests/conversation-resolve.spec.ts
+++ b/packages/core/tests/conversation-resolve.spec.ts
@@ -852,13 +852,6 @@ it('chatluna.delete removes range and list selectors', async () => {
     await action({ options: {}, session }, '1,1')
     await action({ options: {}, session }, '3..1')
 
-    conversations.push(
-        createConversation({
-            id: 'conversation-range-title',
-            title: '1..101',
-            seq: 4
-        })
-    )
     const beforeInvalid = deleted.length
     await action({ options: {}, session }, '1..101')
     await action(
@@ -866,6 +859,15 @@ it('chatluna.delete removes range and list selectors', async () => {
         '999999999999999999999..999999999999999999999'
     )
     assert.equal(deleted.length, beforeInvalid)
+
+    conversations.push(
+        createConversation({
+            id: 'conversation-range-title',
+            title: '1..101',
+            seq: 4
+        })
+    )
+    await action({ options: {}, session }, '1..101')
 
     assert.deepEqual(deleted, [
         'conversation-first',
@@ -875,17 +877,18 @@ it('chatluna.delete removes range and list selectors', async () => {
         'conversation-first',
         'conversation-first',
         'conversation-second',
-        'conversation-third'
+        'conversation-third',
+        'conversation-range-title'
     ])
-    assert.notInclude(deleted, 'conversation-range-title')
     assert.deepEqual(resolveTargets, [
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined
+        '1..2',
+        '1,3',
+        '1,4',
+        '1,1',
+        '3..1',
+        '1..101',
+        '999999999999999999999..999999999999999999999',
+        '1..101'
     ])
     assert.deepEqual(messages, [
         'chatluna.conversation.messages.delete_success_multi:First Topic (1)\nSecond Topic (2)',
@@ -894,7 +897,8 @@ it('chatluna.delete removes range and list selectors', async () => {
         'chatluna.conversation.messages.delete_success_multi:First Topic (1)',
         'chatluna.conversation.messages.delete_success_multi:First Topic (1)\nSecond Topic (2)\nThird Topic (3)',
         'chatluna.conversation.messages.target_not_found',
-        'chatluna.conversation.messages.target_not_found'
+        'chatluna.conversation.messages.target_not_found',
+        'chatluna.conversation.messages.delete_success:1..101,4,conversation-range-title'
     ])
 })
 

--- a/packages/core/tests/conversation-resolve.spec.ts
+++ b/packages/core/tests/conversation-resolve.spec.ts
@@ -728,16 +728,34 @@ it('conversation_switch accepts resolved direct conversation ids', async () => {
 
 it('chatluna.delete removes range and list selectors', async () => {
     const conversations = [
-        createConversation({ id: 'conversation-first', title: 'First Topic' }),
+        createConversation({
+            id: 'conversation-first',
+            title: 'First Topic',
+            seq: 1
+        }),
         createConversation({
             id: 'conversation-second',
-            title: 'Second Topic'
+            title: 'Second Topic',
+            seq: 2
         }),
-        createConversation({ id: 'conversation-third', title: 'Third Topic' })
+        createConversation({
+            id: 'conversation-third',
+            title: 'Third Topic',
+            seq: 3
+        })
     ]
     const actions = new Map<string, (...args: any[]) => Promise<void>>()
     const deleted: string[] = []
     const messages: string[] = []
+    const resolveTargets: (string | undefined)[] = []
+    const entries = () =>
+        conversations.map((conversation, idx) => ({
+            conversation,
+            displaySeq: idx + 1
+        }))
+    let resolve:
+        | ((session: any, context: any) => Promise<ChainMiddlewareRunStatus>)
+        | undefined
     let run:
         | ((session: any, context: any) => Promise<ChainMiddlewareRunStatus>)
         | undefined
@@ -755,11 +773,28 @@ it('chatluna.delete removes range and list selectors', async () => {
         },
         chatluna: {
             conversation: {
-                listConversationEntries: async () =>
-                    conversations.map((conversation, idx) => ({
-                        conversation,
-                        displaySeq: idx + 1
-                    })),
+                resolveConversation: async (_session, opts) => {
+                    resolveTargets.push(opts.targetConversation)
+                    const entry = entries().find(
+                        (item) =>
+                            opts.targetConversation === item.conversation.id ||
+                            opts.targetConversation ===
+                                String(item.displaySeq) ||
+                            opts.targetConversation === item.conversation.title
+                    )
+
+                    return {
+                        bindingKey: 'shared:discord:bot:guild',
+                        constraint: {},
+                        effectiveModel: 'test-platform/test-model',
+                        effectivePreset: 'default-preset',
+                        effectiveChatMode: 'plugin',
+                        conversation: entry?.conversation ?? null,
+                        conversationId: entry?.conversation.id ?? null,
+                        mode: opts.mode
+                    }
+                },
+                listConversationEntries: async () => entries(),
                 deleteConversation: async (_session, opts) => {
                     deleted.push(opts.conversationId)
                     return conversations.find(
@@ -771,6 +806,7 @@ it('chatluna.delete removes range and list selectors', async () => {
     }
     const chain = {
         middleware: (name, fn) => {
+            if (name === 'resolve_conversation') resolve = fn
             if (name === 'conversation_delete') run = fn
             return {
                 after() {
@@ -783,13 +819,18 @@ it('chatluna.delete removes range and list selectors', async () => {
         }
     }
 
+    applyResolve(ctx as never, {} as never, chain as never)
     applyManage(ctx as never, {} as never, chain as never)
     applyCommands(
         ctx as never,
         {} as never,
         {
             receiveCommand: async (session, name, opts) => {
-                await run!(session, { command: name, options: opts })
+                const state = { command: name, options: opts }
+                const status = await resolve!(session, state)
+                if (status !== ChainMiddlewareRunStatus.STOP) {
+                    await run!(session, state)
+                }
             }
         } as never
     )
@@ -804,16 +845,56 @@ it('chatluna.delete removes range and list selectors', async () => {
     const action = actions.get('chatluna.delete [conversation:string]')!
     await action({ options: {}, session }, '1..2')
     await action({ options: {}, session }, '1,3')
+    const validCount = deleted.length
+    await action({ options: {}, session }, '1,4')
+    assert.equal(deleted.length, validCount)
+
+    await action({ options: {}, session }, '1,1')
+    await action({ options: {}, session }, '3..1')
+
+    conversations.push(
+        createConversation({
+            id: 'conversation-range-title',
+            title: '1..101',
+            seq: 4
+        })
+    )
+    const beforeInvalid = deleted.length
+    await action({ options: {}, session }, '1..101')
+    await action(
+        { options: {}, session },
+        '999999999999999999999..999999999999999999999'
+    )
+    assert.equal(deleted.length, beforeInvalid)
 
     assert.deepEqual(deleted, [
         'conversation-first',
         'conversation-second',
         'conversation-first',
+        'conversation-third',
+        'conversation-first',
+        'conversation-first',
+        'conversation-second',
         'conversation-third'
     ])
+    assert.notInclude(deleted, 'conversation-range-title')
+    assert.deepEqual(resolveTargets, [
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+    ])
     assert.deepEqual(messages, [
-        'chatluna.conversation.messages.delete_success_multi:First Topic\nSecond Topic',
-        'chatluna.conversation.messages.delete_success_multi:First Topic\nThird Topic'
+        'chatluna.conversation.messages.delete_success_multi:First Topic (1)\nSecond Topic (2)',
+        'chatluna.conversation.messages.delete_success_multi:First Topic (1)\nThird Topic (3)',
+        'chatluna.conversation.messages.target_not_found',
+        'chatluna.conversation.messages.delete_success_multi:First Topic (1)',
+        'chatluna.conversation.messages.delete_success_multi:First Topic (1)\nSecond Topic (2)\nThird Topic (3)',
+        'chatluna.conversation.messages.target_not_found',
+        'chatluna.conversation.messages.target_not_found'
     ])
 })
 

--- a/packages/core/tests/conversation-resolve.spec.ts
+++ b/packages/core/tests/conversation-resolve.spec.ts
@@ -748,6 +748,7 @@ it('chatluna.delete removes range and list selectors', async () => {
     const deleted: string[] = []
     const messages: string[] = []
     const resolveTargets: (string | undefined)[] = []
+    let listCalls = 0
     const entries = () =>
         conversations.map((conversation, idx) => ({
             conversation,
@@ -794,7 +795,10 @@ it('chatluna.delete removes range and list selectors', async () => {
                         mode: opts.mode
                     }
                 },
-                listConversationEntries: async () => entries(),
+                listConversationEntries: async () => {
+                    listCalls += 1
+                    return entries()
+                },
                 deleteConversation: async (_session, opts) => {
                     deleted.push(opts.conversationId)
                     return conversations.find(
@@ -853,6 +857,10 @@ it('chatluna.delete removes range and list selectors', async () => {
     await action({ options: {}, session }, '3..1')
 
     const beforeInvalid = deleted.length
+    await action({ options: {}, session }, '4')
+    const beforeOverlap = listCalls
+    await action({ options: {}, session }, '1..50,25..75')
+    assert.equal(listCalls, beforeOverlap + 1)
     await action({ options: {}, session }, '1..101')
     await action(
         { options: {}, session },
@@ -886,6 +894,8 @@ it('chatluna.delete removes range and list selectors', async () => {
         '1,4',
         '1,1',
         '3..1',
+        '4',
+        '1..50,25..75',
         '1..101',
         '999999999999999999999..999999999999999999999',
         '1..101'
@@ -896,6 +906,8 @@ it('chatluna.delete removes range and list selectors', async () => {
         'chatluna.conversation.messages.target_not_found',
         'chatluna.conversation.messages.delete_success_multi:First Topic (1)',
         'chatluna.conversation.messages.delete_success_multi:First Topic (1)\nSecond Topic (2)\nThird Topic (3)',
+        'chatluna.conversation.messages.target_not_found',
+        'chatluna.conversation.messages.target_not_found',
         'chatluna.conversation.messages.target_not_found',
         'chatluna.conversation.messages.target_not_found',
         'chatluna.conversation.messages.delete_success:1..101,4,conversation-range-title'


### PR DESCRIPTION
This pr adds batch sequence selectors to the `chatluna.delete` command.

## New Features

- Support deleting conversations by sequence ranges like `1..3`.
- Support deleting conversations by sequence lists like `1,3,5`.

## Bug fixes

- Return the existing target-not-found message when any requested sequence is missing.

## Other Changes

- Add regression coverage for range and list deletion selectors.
- Validation: `yarn lint-fix` completed with no errors. Existing max-len warnings remain in `read_chat_message.ts` and `extension-agent/src/sub-agent/builtin.ts`.