### PR TITLE
fix(adapter-openai): include grok models

### DIFF
--- a/packages/adapter-openai/src/client.ts
+++ b/packages/adapter-openai/src/client.ts
@@ -60,6 +60,7 @@ export class OpenAIClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
                 .filter(
                     (model) =>
                         model.includes('gpt') ||
+                        model.includes('grok') ||
                         model.includes('text-embedding') ||
                         model.includes('o1') ||
                         model.includes('o3') ||


### PR DESCRIPTION
## Summary

- Include `grok-*` models in the OpenAI adapter model allowlist.
- Keep existing filtering for GPT, embedding, and OpenAI reasoning models unchanged.

## Verification

- Attempted `yarn fast-build adapter-openai`, but the local workspace failed before build because the root workspace package is not present in the current lockfile.
- Attempted `npx tsc -p packages/adapter-openai/tsconfig.json --noEmit`, but the local dependency graph reports existing type/export mismatches unrelated to this one-line model filter change.
