### PR TITLE
[Fix] unify ChatLuna agent data paths

### DIFF
--- a/packages/extension-agent/README.md
+++ b/packages/extension-agent/README.md
@@ -21,7 +21,7 @@ ctx.chatluna_agent.mcp.listTools()
 
 ## 配置
 
-配置文件位于 `data/chatluna/agent/config.json`。
+配置文件位于 `data/chatluna/agents/config.json`。
 
 ## License
 

--- a/packages/extension-agent/src/computer/materialize.ts
+++ b/packages/extension-agent/src/computer/materialize.ts
@@ -36,7 +36,12 @@ export class SkillMaterializer {
     ) {
         const root = this.getPath(skill, session)
         if (session.backend === 'local') {
-            if (skill.name === AGENTCLI_SKILL_NAME && ctx) {
+            if (
+                skill.name === AGENTCLI_SKILL_NAME &&
+                skill.source === 'chatluna' &&
+                skill.scope === 'data' &&
+                ctx
+            ) {
                 const target = path.join(root, 'config.json')
                 try {
                     await access(target)

--- a/packages/extension-agent/src/config/defaults.ts
+++ b/packages/extension-agent/src/config/defaults.ts
@@ -248,7 +248,7 @@ export function createDefaultToolConfig(): ToolConfig {
 
 export function createDefaultSubAgentConfig(): SubAgentConfig {
     return {
-        dirs: ['~/.claude/agents', '~/.config/opencode/agents'],
+        dirs: [],
         items: {},
         builtin: {
             plan: createSubAgentItemConfig({

--- a/packages/extension-agent/src/config/migrate.ts
+++ b/packages/extension-agent/src/config/migrate.ts
@@ -32,10 +32,12 @@ export async function migrateAgentData(ctx: Context) {
     const oldSkills = join(old, 'skills')
     const oldAgents = join(old, 'agents')
     const hasConfig = (await stat(oldConfig).catch(() => undefined))?.isFile()
-    const hasSkills = (await stat(oldSkills).catch(() => undefined))
-        ?.isDirectory()
-    const hasAgents = (await stat(oldAgents).catch(() => undefined))
-        ?.isDirectory()
+    const hasSkills = (
+        await stat(oldSkills).catch(() => undefined)
+    )?.isDirectory()
+    const hasAgents = (
+        await stat(oldAgents).catch(() => undefined)
+    )?.isDirectory()
 
     if (!hasConfig && !hasSkills && !hasAgents) {
         return

--- a/packages/extension-agent/src/config/migrate.ts
+++ b/packages/extension-agent/src/config/migrate.ts
@@ -1,0 +1,67 @@
+/** @module config/migrate */
+
+import { Context } from 'koishi'
+import { cp, mkdir, rm, stat } from 'fs/promises'
+import { join, resolve } from 'path'
+
+export async function migrateAgentData(ctx: Context) {
+    const data = resolve(ctx.baseDir, 'data/chatluna')
+    const root = join(data, 'agents')
+    const old = join(data, 'agent')
+
+    try {
+        await mkdir(root, { recursive: true })
+
+        if (
+            (
+                await stat(join(old, 'config.json')).catch(() => undefined)
+            )?.isFile()
+        ) {
+            await cp(join(old, 'config.json'), join(root, 'config.json'), {
+                force: false,
+                errorOnExist: false
+            })
+        }
+
+        if (
+            (
+                await stat(join(old, 'skills')).catch(() => undefined)
+            )?.isDirectory()
+        ) {
+            await cp(join(old, 'skills'), join(root, 'skills'), {
+                recursive: true,
+                force: false,
+                errorOnExist: false
+            })
+        }
+
+        if (
+            (
+                await stat(join(old, 'agents')).catch(() => undefined)
+            )?.isDirectory()
+        ) {
+            await cp(join(old, 'agents'), root, {
+                recursive: true,
+                force: false,
+                errorOnExist: false
+            })
+        }
+
+        if (
+            (
+                await stat(join(data, 'skills')).catch(() => undefined)
+            )?.isDirectory()
+        ) {
+            await cp(join(data, 'skills'), join(root, 'skills'), {
+                recursive: true,
+                force: false,
+                errorOnExist: false
+            })
+            await rm(join(data, 'skills'), { recursive: true, force: true })
+        }
+
+        await rm(old, { recursive: true, force: true })
+    } catch (err) {
+        ctx.logger.warn('Failed to migrate chatluna agent data', err)
+    }
+}

--- a/packages/extension-agent/src/config/migrate.ts
+++ b/packages/extension-agent/src/config/migrate.ts
@@ -1,63 +1,142 @@
 /** @module config/migrate */
 
 import { Context } from 'koishi'
-import { cp, mkdir, rm, stat } from 'fs/promises'
-import { join, resolve } from 'path'
+import { cp, mkdir, readFile, rm, stat, writeFile } from 'fs/promises'
+import { basename, join, relative, resolve } from 'path'
+import { collectFilesRecursive } from '../utils/fs'
+import { createHashId } from '../utils/id'
+import { getConfigPath, getSkillsRootPath, getSubAgentsRootPath } from './path'
+
+const OLD_SKILL_DIRS = [
+    './.agents/skills',
+    './.openclaw/skills',
+    './.codex/skills',
+    './.claude/skills',
+    './.opencode/skills',
+    '~/.agents/skills',
+    '~/.openclaw/skills',
+    '~/.codex/skills',
+    '~/.claude/skills',
+    '~/.config/opencode/skills'
+]
+
+const OLD_SUB_AGENT_DIRS = ['~/.claude/agents', '~/.config/opencode/agents']
 
 export async function migrateAgentData(ctx: Context) {
     const data = resolve(ctx.baseDir, 'data/chatluna')
-    const root = join(data, 'agents')
     const old = join(data, 'agent')
+    const config = getConfigPath(ctx)
+    const skills = getSkillsRootPath(ctx)
+    const agents = getSubAgentsRootPath(ctx)
+    const oldConfig = join(old, 'config.json')
+    const oldSkills = join(old, 'skills')
+    const oldAgents = join(old, 'agents')
+    const hasConfig = (await stat(oldConfig).catch(() => undefined))?.isFile()
+    const hasSkills = (await stat(oldSkills).catch(() => undefined))
+        ?.isDirectory()
+    const hasAgents = (await stat(oldAgents).catch(() => undefined))
+        ?.isDirectory()
+
+    if (!hasConfig && !hasSkills && !hasAgents) {
+        return
+    }
 
     try {
-        await mkdir(root, { recursive: true })
+        await mkdir(agents, { recursive: true })
 
-        if (
-            (
-                await stat(join(old, 'config.json')).catch(() => undefined)
-            )?.isFile()
-        ) {
-            await cp(join(old, 'config.json'), join(root, 'config.json'), {
-                force: false,
-                errorOnExist: false
-            })
+        if (hasConfig && !(await stat(config).catch(() => undefined))) {
+            const raw = await readFile(oldConfig, 'utf-8')
+            let content = raw
+
+            try {
+                const cfg = JSON.parse(raw) as {
+                    skills?: {
+                        dirs?: string[]
+                        items?: Record<string, unknown>
+                    }
+                    subAgent?: {
+                        dirs?: string[]
+                        items?: Record<string, unknown>
+                    }
+                }
+
+                if (
+                    cfg.skills?.dirs?.length === OLD_SKILL_DIRS.length &&
+                    cfg.skills.dirs.every(
+                        (item, idx) => item === OLD_SKILL_DIRS[idx]
+                    )
+                ) {
+                    cfg.skills.dirs = []
+                }
+
+                if (
+                    cfg.subAgent?.dirs?.length === OLD_SUB_AGENT_DIRS.length &&
+                    cfg.subAgent.dirs.every(
+                        (item, idx) => item === OLD_SUB_AGENT_DIRS[idx]
+                    )
+                ) {
+                    cfg.subAgent.dirs = []
+                }
+
+                if (cfg.skills?.items && hasSkills) {
+                    const files = (
+                        await collectFilesRecursive(oldSkills)
+                    ).filter((file) => basename(file) === 'SKILL.md')
+                    for (const file of files) {
+                        const from = createHashId(file)
+                        const to = createHashId(
+                            join(skills, relative(oldSkills, file))
+                        )
+                        if (
+                            cfg.skills.items[from] != null &&
+                            cfg.skills.items[to] == null
+                        ) {
+                            cfg.skills.items[to] = cfg.skills.items[from]
+                        }
+                        delete cfg.skills.items[from]
+                    }
+                }
+
+                if (cfg.subAgent?.items && hasAgents) {
+                    const files = await collectFilesRecursive(oldAgents, {
+                        extensionFilter: '.md'
+                    })
+                    for (const file of files) {
+                        const from = createHashId(file)
+                        const to = createHashId(
+                            join(agents, relative(oldAgents, file))
+                        )
+                        if (
+                            cfg.subAgent.items[from] != null &&
+                            cfg.subAgent.items[to] == null
+                        ) {
+                            cfg.subAgent.items[to] = cfg.subAgent.items[from]
+                        }
+                        delete cfg.subAgent.items[from]
+                    }
+                }
+
+                content = `${JSON.stringify(cfg, null, 4)}\n`
+            } catch {}
+
+            await writeFile(config, content, 'utf-8')
         }
 
-        if (
-            (
-                await stat(join(old, 'skills')).catch(() => undefined)
-            )?.isDirectory()
-        ) {
-            await cp(join(old, 'skills'), join(root, 'skills'), {
+        if (hasSkills) {
+            await mkdir(skills, { recursive: true })
+            await cp(oldSkills, skills, {
                 recursive: true,
                 force: false,
                 errorOnExist: false
             })
         }
 
-        if (
-            (
-                await stat(join(old, 'agents')).catch(() => undefined)
-            )?.isDirectory()
-        ) {
-            await cp(join(old, 'agents'), root, {
+        if (hasAgents) {
+            await cp(oldAgents, agents, {
                 recursive: true,
                 force: false,
                 errorOnExist: false
             })
-        }
-
-        if (
-            (
-                await stat(join(data, 'skills')).catch(() => undefined)
-            )?.isDirectory()
-        ) {
-            await cp(join(data, 'skills'), join(root, 'skills'), {
-                recursive: true,
-                force: false,
-                errorOnExist: false
-            })
-            await rm(join(data, 'skills'), { recursive: true, force: true })
         }
 
         await rm(old, { recursive: true, force: true })

--- a/packages/extension-agent/src/config/path.ts
+++ b/packages/extension-agent/src/config/path.ts
@@ -3,25 +3,14 @@
 import { Context } from 'koishi'
 import { resolve } from 'path'
 
-export const DEFAULT_SKILL_DIRS = [
-    './.agents/skills',
-    './.openclaw/skills',
-    './.codex/skills',
-    './.claude/skills',
-    './.opencode/skills',
-    '~/.agents/skills',
-    '~/.openclaw/skills',
-    '~/.codex/skills',
-    '~/.claude/skills',
-    '~/.config/opencode/skills'
-]
+export const DEFAULT_SKILL_DIRS: string[] = []
 
 export function getConfigPath(ctx: Context): string {
     return resolve(ctx.baseDir, 'data/chatluna/agents/config.json')
 }
 
 export function getSkillsRootPath(ctx: Context): string {
-    return resolve(ctx.baseDir, 'data/chatluna/agents/skills')
+    return resolve(ctx.baseDir, 'data/chatluna/skills')
 }
 
 export function getSubAgentsRootPath(ctx: Context): string {

--- a/packages/extension-agent/src/config/path.ts
+++ b/packages/extension-agent/src/config/path.ts
@@ -17,11 +17,11 @@ export const DEFAULT_SKILL_DIRS = [
 ]
 
 export function getConfigPath(ctx: Context): string {
-    return resolve(ctx.baseDir, 'data/chatluna/agent/config.json')
+    return resolve(ctx.baseDir, 'data/chatluna/agents/config.json')
 }
 
 export function getSkillsRootPath(ctx: Context): string {
-    return resolve(ctx.baseDir, 'data/chatluna/skills')
+    return resolve(ctx.baseDir, 'data/chatluna/agents/skills')
 }
 
 export function getSubAgentsRootPath(ctx: Context): string {

--- a/packages/extension-agent/src/index.ts
+++ b/packages/extension-agent/src/index.ts
@@ -4,6 +4,7 @@ import { Context, Logger, Schema } from 'koishi'
 import { createLogger } from 'koishi-plugin-chatluna/utils/logger'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { ChatLunaAgentService } from './service'
+import { migrateAgentData } from './config/migrate'
 import { readConfig } from './config/read'
 import * as webui from './webui'
 import * as mcpCommands from './commands/mcp'
@@ -18,6 +19,7 @@ export async function apply(ctx: Context, config: Config) {
     logger = createLogger(ctx, 'chatluna-agent')
 
     plugin = new ChatLunaPlugin(ctx, config, 'agent', false)
+    await migrateAgentData(ctx)
 
     ctx.plugin(ChatLunaAgentService, {
         config: await readConfig(ctx),

--- a/packages/extension-agent/src/service/index.ts
+++ b/packages/extension-agent/src/service/index.ts
@@ -377,13 +377,22 @@ export class ChatLunaAgentService extends Service {
             throw new Error(`Sub-agent not found: ${id}`)
         }
 
-        if (
-            info.source !== 'markdown' ||
-            info.remote ||
-            !info.path ||
-            !isPathInside(info.path, getSubAgentsRootPath(this.ctx))
-        ) {
-            return undefined
+        if (info.source !== 'markdown') {
+            throw new Error('Only markdown sub-agents can save content here')
+        }
+
+        if (info.remote) {
+            throw new Error('Cannot edit remote sub-agent content')
+        }
+
+        if (!info.path) {
+            throw new Error('Sub-agent path is missing')
+        }
+
+        if (!isPathInside(info.path, getSubAgentsRootPath(this.ctx))) {
+            throw new Error(
+                'Only sub-agents inside data/chatluna/agents can save content here'
+            )
         }
 
         await writeFile(
@@ -536,13 +545,15 @@ export class ChatLunaAgentService extends Service {
             }
 
             if (!info.path) {
-                return
+                throw new Error('Sub-agent path is missing')
             }
 
             const root = resolve(getSubAgentsRootPath(this.ctx))
             const file = resolve(info.path)
             if (!isPathInside(file, root)) {
-                return
+                throw new Error(
+                    'Only sub-agents inside data/chatluna/agents can be removed here'
+                )
             }
 
             const dir = dirname(file)

--- a/packages/extension-agent/src/service/index.ts
+++ b/packages/extension-agent/src/service/index.ts
@@ -44,6 +44,7 @@ import { ChatLunaAgentRuntimeSyncService } from '../utils/runtime_sync'
 import { ChatLunaAgentSkillsService } from './skills'
 import { ChatLunaAgentSubAgentService } from './sub_agent'
 import { ChatLunaAgentTriggerService } from './trigger'
+import { isPathInside } from '../utils/path'
 
 export class ChatLunaAgentService extends Service {
     public computer: ChatLunaAgentComputerService
@@ -291,7 +292,9 @@ export class ChatLunaAgentService extends Service {
     }
 
     async removeSkill(id: string) {
-        await this.skills.removeSkill(id)
+        if (!(await this.skills.removeSkill(id))) {
+            return
+        }
 
         const skills = {
             dirs: [...this.args.config.skills.dirs],
@@ -374,16 +377,13 @@ export class ChatLunaAgentService extends Service {
             throw new Error(`Sub-agent not found: ${id}`)
         }
 
-        if (info.source !== 'markdown') {
-            throw new Error('Only markdown sub-agents can save content here')
-        }
-
-        if (info.remote) {
-            throw new Error('Cannot edit remote sub-agent content')
-        }
-
-        if (!info.path) {
-            throw new Error('Sub-agent path is missing')
+        if (
+            info.source !== 'markdown' ||
+            info.remote ||
+            !info.path ||
+            !isPathInside(info.path, getSubAgentsRootPath(this.ctx))
+        ) {
+            return undefined
         }
 
         await writeFile(
@@ -526,12 +526,7 @@ export class ChatLunaAgentService extends Service {
         }
 
         if (info.source === 'markdown') {
-            if (!info.path) {
-                throw new Error('Sub-agent path is missing')
-            }
-
             if (info.remote) {
-                await this.computer.removeRemoteSubAgent(info.path)
                 const subAgent = structuredClone(this.args.config.subAgent)
                 delete subAgent.items[id]
                 await this.updateConfig('subAgent', subAgent, async () => {
@@ -540,12 +535,14 @@ export class ChatLunaAgentService extends Service {
                 return
             }
 
+            if (!info.path) {
+                return
+            }
+
             const root = resolve(getSubAgentsRootPath(this.ctx))
             const file = resolve(info.path)
-            if (!file.startsWith(root)) {
-                throw new Error(
-                    'Only sub-agents inside data/chatluna/agents can be removed here'
-                )
+            if (!isPathInside(file, root)) {
+                return
             }
 
             const dir = dirname(file)

--- a/packages/extension-agent/src/service/skills.ts
+++ b/packages/extension-agent/src/service/skills.ts
@@ -42,6 +42,7 @@ import { buildSkillCatalog } from '../skills/catalog'
 import { getRemoteSkillDir, getRemoteSkillsRoot } from '../computer/materialize'
 import { ChatLunaAgentPermissionService } from './permissions'
 import { ComputerSessionApi } from '../computer/types'
+import { isPathInside } from '../utils/path'
 
 export class ChatLunaAgentSkillsService implements SkillToolService {
     private _catalog: SkillInfo[] = []
@@ -191,12 +192,8 @@ export class ChatLunaAgentSkillsService implements SkillToolService {
 
     async saveSkillContent(id: string, content: string) {
         const skill = this._skills.get(id)
-        if (!skill) {
-            throw new Error(`Skill not found: ${id}`)
-        }
-
-        if (skill.remote) {
-            throw new Error('Cannot edit remote skill content')
+        if (!skill || !isPathInside(skill.dir, getSkillsRootPath(this.ctx))) {
+            return
         }
 
         await writeFile(skill.path, content, 'utf-8')
@@ -224,13 +221,8 @@ export class ChatLunaAgentSkillsService implements SkillToolService {
         const skill = this._skills.get(id)
         if (!skill) return undefined
 
-        if (skill.remote) {
-            await this.ctx.chatluna_agent?.computer.removeRemoteSkill(skill.dir)
-            return skill.name
-        }
-
-        if (skill.source !== 'chatluna' || skill.scope !== 'data') {
-            throw new Error('Only imported local skills can be removed here')
+        if (!isPathInside(skill.dir, getSkillsRootPath(this.ctx))) {
+            return undefined
         }
 
         await removeSkillDirectory(getSkillsRootPath(this.ctx), skill.dir)

--- a/packages/extension-agent/src/service/skills.ts
+++ b/packages/extension-agent/src/service/skills.ts
@@ -192,13 +192,22 @@ export class ChatLunaAgentSkillsService implements SkillToolService {
 
     async saveSkillContent(id: string, content: string) {
         const skill = this._skills.get(id)
-        if (!skill || !isPathInside(skill.dir, getSkillsRootPath(this.ctx))) {
-            return
+        if (!skill) {
+            throw new Error(`Skill not found: ${id}`)
+        }
+
+        if (skill.remote) {
+            throw new Error('Cannot edit remote skill content')
+        }
+
+        if (!isPathInside(skill.dir, getSkillsRootPath(this.ctx))) {
+            return false
         }
 
         await writeFile(skill.path, content, 'utf-8')
 
         await this.reload()
+        return true
     }
 
     async previewImport(
@@ -221,8 +230,14 @@ export class ChatLunaAgentSkillsService implements SkillToolService {
         const skill = this._skills.get(id)
         if (!skill) return undefined
 
+        if (skill.remote) {
+            return skill.name
+        }
+
         if (!isPathInside(skill.dir, getSkillsRootPath(this.ctx))) {
-            return undefined
+            throw new Error(
+                'Only skills inside data/chatluna/skills can be removed'
+            )
         }
 
         await removeSkillDirectory(getSkillsRootPath(this.ctx), skill.dir)

--- a/packages/extension-agent/src/skills/import.ts
+++ b/packages/extension-agent/src/skills/import.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'crypto'
 import { unzipSync } from 'fflate'
 import { cp, mkdir, rm, stat, writeFile } from 'fs/promises'
 import { Context } from 'koishi'
-import { basename, dirname, join, resolve } from 'path'
+import { basename, dirname, join } from 'path'
 import { getSkillsRootPath } from '../config/path'
 import {
     SkillImportInput,

--- a/packages/extension-agent/src/skills/import.ts
+++ b/packages/extension-agent/src/skills/import.ts
@@ -26,7 +26,7 @@ export async function previewSkillsImport(
 
     const tmp = resolve(
         ctx.baseDir,
-        'data/chatluna/agent/tmp',
+        'data/chatluna/agents/tmp',
         `skills-${randomUUID()}`
     )
 
@@ -53,7 +53,7 @@ export async function importSkills(
 ): Promise<SkillImportResult> {
     const tmp = resolve(
         ctx.baseDir,
-        'data/chatluna/agent/tmp',
+        'data/chatluna/agents/tmp',
         `skills-${randomUUID()}`
     )
 
@@ -356,7 +356,7 @@ async function previewGithub(ctx: Context, url: string) {
 
     const tmp = resolve(
         ctx.baseDir,
-        'data/chatluna/agent/tmp',
+        'data/chatluna/agents/tmp',
         `skills-${randomUUID()}`
     )
 

--- a/packages/extension-agent/src/skills/import.ts
+++ b/packages/extension-agent/src/skills/import.ts
@@ -24,11 +24,7 @@ export async function previewSkillsImport(
         return await previewGithub(ctx, input.url)
     }
 
-    const tmp = resolve(
-        ctx.baseDir,
-        'data/chatluna/agents/tmp',
-        `skills-${randomUUID()}`
-    )
+    const tmp = join(getSkillsRootPath(ctx), '.tmp', `skills-${randomUUID()}`)
 
     await mkdir(tmp, { recursive: true })
 
@@ -51,11 +47,7 @@ export async function importSkills(
     ctx: Context,
     input: SkillImportInput
 ): Promise<SkillImportResult> {
-    const tmp = resolve(
-        ctx.baseDir,
-        'data/chatluna/agents/tmp',
-        `skills-${randomUUID()}`
-    )
+    const tmp = join(getSkillsRootPath(ctx), '.tmp', `skills-${randomUUID()}`)
 
     await mkdir(tmp, { recursive: true })
 
@@ -354,11 +346,7 @@ async function previewGithub(ctx: Context, url: string) {
         diagnostics.push('GitHub 地址下没有找到可预览的文件。')
     }
 
-    const tmp = resolve(
-        ctx.baseDir,
-        'data/chatluna/agents/tmp',
-        `skills-${randomUUID()}`
-    )
+    const tmp = join(getSkillsRootPath(ctx), '.tmp', `skills-${randomUUID()}`)
 
     await mkdir(tmp, { recursive: true })
 

--- a/packages/extension-agent/src/skills/manage.ts
+++ b/packages/extension-agent/src/skills/manage.ts
@@ -38,9 +38,7 @@ export async function exportSkillArchive(
 
 export async function removeSkillDirectory(root: string, dir: string) {
     if (!isPathInside(resolve(dir), root)) {
-        throw new Error(
-            'Only skills inside data/chatluna/skills can be removed'
-        )
+        return
     }
 
     await rm(resolve(dir), { recursive: true, force: true })

--- a/packages/extension-agent/src/sub-agent/scan.ts
+++ b/packages/extension-agent/src/sub-agent/scan.ts
@@ -20,6 +20,7 @@ interface ScanTarget {
     priority: number
     hint?: 'chatluna' | 'claude' | 'opencode'
     remote: boolean
+    excludeNames?: string[]
 }
 
 export const WRITE_TOOL_PATTERNS = [
@@ -56,7 +57,14 @@ function getScanTargets(ctx: Context, cfg: AgentConfig['subAgent']) {
     const root = getSubAgentsRootPath(ctx)
     const seen = new Set([toPathKey(root)])
     const targets: ScanTarget[] = [
-        { root, scope: 'data', priority: 0, hint: 'chatluna', remote: false }
+        {
+            root,
+            scope: 'data',
+            priority: 0,
+            hint: 'chatluna',
+            remote: false,
+            excludeNames: ['skills', 'tmp']
+        }
     ]
 
     for (let idx = 0; idx < cfg.dirs.length; idx++) {
@@ -101,7 +109,8 @@ async function scanTarget(target: ScanTarget, cfg: AgentConfig['subAgent']) {
     if (!info?.isDirectory()) return [] as SubAgentInfo[]
 
     const files = await collectFilesRecursive(target.root, {
-        extensionFilter: '.md'
+        extensionFilter: '.md',
+        excludeNames: target.excludeNames
     })
     return await Promise.all(
         files.map(async (file) => {

--- a/packages/extension-agent/src/sub-agent/scan.ts
+++ b/packages/extension-agent/src/sub-agent/scan.ts
@@ -20,7 +20,6 @@ interface ScanTarget {
     priority: number
     hint?: 'chatluna' | 'claude' | 'opencode'
     remote: boolean
-    excludeNames?: string[]
 }
 
 export const WRITE_TOOL_PATTERNS = [
@@ -62,8 +61,7 @@ function getScanTargets(ctx: Context, cfg: AgentConfig['subAgent']) {
             scope: 'data',
             priority: 0,
             hint: 'chatluna',
-            remote: false,
-            excludeNames: ['skills', 'tmp']
+            remote: false
         }
     ]
 
@@ -109,8 +107,7 @@ async function scanTarget(target: ScanTarget, cfg: AgentConfig['subAgent']) {
     if (!info?.isDirectory()) return [] as SubAgentInfo[]
 
     const files = await collectFilesRecursive(target.root, {
-        extensionFilter: '.md',
-        excludeNames: target.excludeNames
+        extensionFilter: '.md'
     })
     return await Promise.all(
         files.map(async (file) => {

--- a/packages/extension-agent/src/utils/runtime_sync.ts
+++ b/packages/extension-agent/src/utils/runtime_sync.ts
@@ -241,8 +241,21 @@ async function collectSyncFiles(
     }
 
     for (const file of remoteFiles) {
-        const content = await session.readFile(posix.join(remoteRoot, file))
-        const targetPath = join(localRoot, ...file.split('/'))
+        const name = file.replaceAll('\\', '/')
+        if (kind === 'subagent') {
+            const lower = name.toLowerCase()
+            if (
+                !lower.endsWith('.md') ||
+                lower === 'config.json' ||
+                lower.startsWith('skills/') ||
+                lower.startsWith('tmp/')
+            ) {
+                continue
+            }
+        }
+
+        const content = await session.readFile(posix.join(remoteRoot, name))
+        const targetPath = join(localRoot, ...name.split('/'))
         const current = await readFile(targetPath, 'utf-8').catch(
             (err: NodeJS.ErrnoException) => {
                 if (err.code === 'ENOENT') {

--- a/packages/extension-agent/src/utils/runtime_sync.ts
+++ b/packages/extension-agent/src/utils/runtime_sync.ts
@@ -13,14 +13,9 @@ import { Context } from 'koishi'
 import { logger } from '..'
 import { getRemoteSkillsRoot } from '../computer/materialize'
 import type { ComputerSessionApi } from '../computer/types'
-import {
-    DEFAULT_SKILL_DIRS,
-    getSkillsRootPath,
-    getSubAgentsRootPath
-} from '../config/path'
+import { getSkillsRootPath, getSubAgentsRootPath } from '../config/path'
 import { REMOTE_SUBAGENTS_ROOT } from '../sub-agent/scan'
 import type { ChatLunaAgentService } from '../service'
-import { expandDir } from './path'
 import { quoteShellPath } from './shell'
 
 interface RuntimeSyncFile {
@@ -198,30 +193,19 @@ async function syncRuntimeSession(
     agent: ChatLunaAgentService,
     session: ComputerSessionApi
 ) {
-    const skillRoots = Array.from(
-        new Map(
-            [
-                getSkillsRootPath(agent.ctx),
-                ...DEFAULT_SKILL_DIRS.map((item) =>
-                    expandDir(agent.ctx.baseDir, item)
-                ),
-                ...agent.args.config.skills.dirs
-                    .map((item) => item.trim())
-                    .filter(Boolean)
-                    .map((item) => expandDir(agent.ctx.baseDir, item))
-            ].map((item) => [item.replaceAll('\\', '/').toLowerCase(), item])
-        ).values()
-    )
     const files = [
         ...(await collectSyncFiles(
             session,
             'skill',
             getRemoteSkillsRoot(),
-            skillRoots
+            getSkillsRootPath(agent.ctx)
         )),
-        ...(await collectSyncFiles(session, 'subagent', REMOTE_SUBAGENTS_ROOT, [
+        ...(await collectSyncFiles(
+            session,
+            'subagent',
+            REMOTE_SUBAGENTS_ROOT,
             getSubAgentsRootPath(agent.ctx)
-        ]))
+        ))
     ]
 
     for (const item of files) {
@@ -246,41 +230,38 @@ async function collectSyncFiles(
     session: ComputerSessionApi,
     kind: RuntimeSyncFile['kind'],
     remoteRoot: string,
-    localRoots: string[]
+    localRoot: string
 ) {
     const files: RuntimeSyncFile[] = []
     const remoteFiles = await listRemoteFiles(session, remoteRoot)
     if (remoteFiles.length > 0) {
         logger?.debug(
-            `collectSyncFiles kind=${kind} backend=${session.backend} remoteRoot=${remoteRoot} files=${remoteFiles.length} localRoots=${localRoots.length}`
+            `collectSyncFiles kind=${kind} backend=${session.backend} remoteRoot=${remoteRoot} files=${remoteFiles.length} localRoot=${localRoot}`
         )
     }
 
     for (const file of remoteFiles) {
         const content = await session.readFile(posix.join(remoteRoot, file))
-
-        for (const localRoot of localRoots) {
-            const targetPath = join(localRoot, ...file.split('/'))
-            const current = await readFile(targetPath, 'utf-8').catch(
-                (err: NodeJS.ErrnoException) => {
-                    if (err.code === 'ENOENT') {
-                        return undefined
-                    }
-
-                    throw err
+        const targetPath = join(localRoot, ...file.split('/'))
+        const current = await readFile(targetPath, 'utf-8').catch(
+            (err: NodeJS.ErrnoException) => {
+                if (err.code === 'ENOENT') {
+                    return undefined
                 }
-            )
 
-            if (current === content) {
-                continue
+                throw err
             }
+        )
 
-            files.push({
-                kind,
-                targetPath,
-                content
-            })
+        if (current === content) {
+            continue
         }
+
+        files.push({
+            kind,
+            targetPath,
+            content
+        })
     }
 
     if (files.length > 0) {

--- a/packages/extension-agent/src/webui/index.ts
+++ b/packages/extension-agent/src/webui/index.ts
@@ -259,7 +259,10 @@ function registerSkillsListeners(ctx: Context, agent: AgentRef) {
 
     ctx.console.addListener(
         'chatluna-agent/saveSkillContent',
-        ok((id, content) => agent().skills.saveSkillContent(id, content))
+        async (id, content) => ({
+            success:
+                (await agent().skills.saveSkillContent(id, content)) !== false
+        })
     )
 
     ctx.console.addListener('chatluna-agent/exportSkill', async (id) =>


### PR DESCRIPTION
This pr unifies ChatLuna agent data paths and migrates existing agent data.

Closes #890

## Bug fixes
- Move agent config and imported skills under data/chatluna/agents.
- Migrate existing data/chatluna/agent and data/chatluna/skills data into the unified directory on startup.
- Restrict skill and sub-agent edit/removal operations to unified local data paths so external runtime paths are not managed from the UI.
- Keep remote runtime sync scoped to ChatLuna's data-managed skills and sub-agents.

## Other Changes
- Updated agent README path documentation.

## Validation
- yarn lint-fix (0 errors, existing max-len warnings only)