### PR TITLE
[Feat] add per-agent sub-agent tool dedupe

### DIFF
--- a/packages/extension-agent/client/components/sub-agent/sub-agent-detail.vue
+++ b/packages/extension-agent/client/components/sub-agent/sub-agent-detail.vue
@@ -64,6 +64,15 @@
                             <el-switch v-model="draft.hidden" />
                         </div>
                     </div>
+                    <div class="field-card flat-card switch-card">
+                        <div class="scope-row">
+                            <div>
+                                <div class="field-label">主 LLM 去重重复工具</div>
+                                <div class="field-help">开启后，主 LLM 会隐藏与当前 Sub Agent 重叠的工具。</div>
+                            </div>
+                            <el-switch v-model="draft.dedupeTools" />
+                        </div>
+                    </div>
                 </div>
 
                 <el-divider style="margin: 4px 0;" />
@@ -351,6 +360,7 @@ interface RuleDraft {
 
 interface AgentDraft {
     enabled: boolean
+    dedupeTools: boolean
     name: string
     description: string
     promptContent: string

--- a/packages/extension-agent/client/components/sub-agent/sub-agent-page.vue
+++ b/packages/extension-agent/client/components/sub-agent/sub-agent-page.vue
@@ -39,6 +39,13 @@
                         >
                             {{ hideDesc ? '显示描述' : '隐藏描述' }}
                         </el-button>
+                        <div class="dedupe-switch">
+                            <span>主 LLM 去重重复工具</span>
+                            <el-switch
+                                :model-value="props.config.dedupeTools === true"
+                                @change="saveDedupeTools($event as boolean)"
+                            />
+                        </div>
                     </template>
                 </div>
             </div>
@@ -250,6 +257,7 @@ const props = withDefaults(
     {
         config: () => ({
             dirs: ['~/.claude/agents', '~/.config/opencode/agents'],
+            dedupeTools: false,
             items: {},
             builtin: {
                 plan: {
@@ -696,6 +704,21 @@ async function saveSelected() {
     }
 }
 
+async function saveDedupeTools(enabled: boolean) {
+    try {
+        busy.value = true
+        await send('chatluna-agent/saveSubAgentConfig', {
+            ...structuredClone(toRaw(props.config)),
+            dedupeTools: enabled
+        })
+        ElMessage.success(enabled ? '已启用工具去重。' : '已关闭工具去重。')
+    } catch {
+        ElMessage.error('保存工具去重配置失败，请稍后重试。')
+    } finally {
+        busy.value = false
+    }
+}
+
 async function removeSelected() {
     const item = selectedAgent.value
     if (!item) return
@@ -976,6 +999,14 @@ function canRemoveAgent(item: SubAgentInfo) {
     align-items: center;
     gap: 8px;
     flex-wrap: wrap;
+}
+
+.dedupe-switch {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--k-text-light);
 }
 
 .tabs {

--- a/packages/extension-agent/client/components/sub-agent/sub-agent-page.vue
+++ b/packages/extension-agent/client/components/sub-agent/sub-agent-page.vue
@@ -39,13 +39,6 @@
                         >
                             {{ hideDesc ? '显示描述' : '隐藏描述' }}
                         </el-button>
-                        <div class="dedupe-switch">
-                            <span>主 LLM 去重重复工具</span>
-                            <el-switch
-                                :model-value="props.config.dedupeTools === true"
-                                @change="saveDedupeTools($event as boolean)"
-                            />
-                        </div>
                     </template>
                 </div>
             </div>
@@ -257,11 +250,11 @@ const props = withDefaults(
     {
         config: () => ({
             dirs: ['~/.claude/agents', '~/.config/opencode/agents'],
-            dedupeTools: false,
             items: {},
             builtin: {
                 plan: {
                     enabled: false,
+                    dedupeTools: false,
                     name: 'plan',
                     description: '',
                     chatluna: true,
@@ -288,6 +281,7 @@ const props = withDefaults(
                 },
                 general: {
                     enabled: false,
+                    dedupeTools: false,
                     name: 'general',
                     description: '',
                     chatluna: true,
@@ -314,6 +308,7 @@ const props = withDefaults(
                 },
                 explore: {
                     enabled: false,
+                    dedupeTools: false,
                     name: 'explore',
                     description: '',
                     chatluna: true,
@@ -392,6 +387,7 @@ const previewDraft = reactive({
 
 const draft = reactive({
     enabled: false,
+    dedupeTools: false,
     name: '',
     description: '',
     promptContent: '',
@@ -446,6 +442,7 @@ watch(
         if (!value) return
 
         draft.enabled = value.enabled
+        draft.dedupeTools = value.dedupeTools === true
         draft.name = value.name ?? ''
         draft.description = value.description ?? ''
         draft.promptContent = value.promptContent ?? ''
@@ -652,6 +649,7 @@ async function saveSelected() {
         const next = structuredClone(toRaw(props.config))
         const saved = {
             enabled: draft.enabled,
+            dedupeTools: draft.dedupeTools,
             name: draft.name,
             description: draft.description,
             chatluna: draft.chatluna,
@@ -704,21 +702,6 @@ async function saveSelected() {
     }
 }
 
-async function saveDedupeTools(enabled: boolean) {
-    try {
-        busy.value = true
-        await send('chatluna-agent/saveSubAgentConfig', {
-            ...structuredClone(toRaw(props.config)),
-            dedupeTools: enabled
-        })
-        ElMessage.success(enabled ? '已启用工具去重。' : '已关闭工具去重。')
-    } catch {
-        ElMessage.error('保存工具去重配置失败，请稍后重试。')
-    } finally {
-        busy.value = false
-    }
-}
-
 async function removeSelected() {
     const item = selectedAgent.value
     if (!item) return
@@ -758,20 +741,20 @@ async function removeAgent(item: SubAgentInfo) {
 async function createPresetAgent(
     name: string,
     preset: string,
-        options: {
-            description: string
-            chatluna?: boolean
-            character?: boolean
-            characterGroup?: boolean
-            characterPrivate?: boolean
-            characterGroupMode?: 'all' | 'allow' | 'deny'
-            characterPrivateMode?: 'all' | 'allow' | 'deny'
-            characterGroupIds?: string[]
-            characterPrivateIds?: string[]
-            authority?: number
-            model: string | undefined
-            maxTurns: number
-            hidden: boolean
+    options: {
+        description: string
+        chatluna?: boolean
+        character?: boolean
+        characterGroup?: boolean
+        characterPrivate?: boolean
+        characterGroupMode?: 'all' | 'allow' | 'deny'
+        characterPrivateMode?: 'all' | 'allow' | 'deny'
+        characterGroupIds?: string[]
+        characterPrivateIds?: string[]
+        authority?: number
+        model: string | undefined
+        maxTurns: number
+        hidden: boolean
         allowKoishiMessageTransform: boolean
     }
 ) {
@@ -864,6 +847,7 @@ async function savePreview() {
             name: previewDraft.name.trim(),
             description: previewDraft.description.trim(),
             promptContent: previewDraft.promptContent.trim(),
+            dedupeTools: item.dedupeTools,
             chatluna: item.chatlunaEnabled,
             character: item.characterEnabled,
             characterGroup: item.characterGroupEnabled,
@@ -999,14 +983,6 @@ function canRemoveAgent(item: SubAgentInfo) {
     align-items: center;
     gap: 8px;
     flex-wrap: wrap;
-}
-
-.dedupe-switch {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 13px;
-    color: var(--k-text-light);
 }
 
 .tabs {

--- a/packages/extension-agent/src/config/defaults.ts
+++ b/packages/extension-agent/src/config/defaults.ts
@@ -49,6 +49,7 @@ export function createSubAgentItemConfig(
 ): SubAgentItemConfig {
     return {
         enabled: input.enabled ?? true,
+        dedupeTools: input.dedupeTools === true,
         name: input.name ?? '',
         description: input.description ?? '',
         chatluna: input.chatluna !== false,
@@ -249,7 +250,6 @@ export function createDefaultToolConfig(): ToolConfig {
 export function createDefaultSubAgentConfig(): SubAgentConfig {
     return {
         dirs: ['~/.claude/agents', '~/.config/opencode/agents'],
-        dedupeTools: false,
         items: {},
         builtin: {
             plan: createSubAgentItemConfig({

--- a/packages/extension-agent/src/config/defaults.ts
+++ b/packages/extension-agent/src/config/defaults.ts
@@ -249,6 +249,7 @@ export function createDefaultToolConfig(): ToolConfig {
 export function createDefaultSubAgentConfig(): SubAgentConfig {
     return {
         dirs: ['~/.claude/agents', '~/.config/opencode/agents'],
+        dedupeTools: false,
         items: {},
         builtin: {
             plan: createSubAgentItemConfig({

--- a/packages/extension-agent/src/service/index.ts
+++ b/packages/extension-agent/src/service/index.ts
@@ -407,6 +407,7 @@ export class ChatLunaAgentService extends Service {
                 characterPrivateIds:
                     input.characterPrivateIds ?? info.characterPrivateIds,
                 authority: input.authority ?? info.authority,
+                dedupeTools: input.dedupeTools ?? info.dedupeTools,
                 model: input.model ?? info.model,
                 maxTurns: input.maxTurns ?? info.maxTurns,
                 hidden: input.hidden ?? info.hidden,
@@ -458,6 +459,7 @@ export class ChatLunaAgentService extends Service {
                 characterGroupIds: info.characterGroupIds,
                 characterPrivateIds: info.characterPrivateIds,
                 authority: info.authority,
+                dedupeTools: info.dedupeTools,
                 promptContent: info.promptContent,
                 model: info.model,
                 maxTurns: info.maxTurns,

--- a/packages/extension-agent/src/service/index.ts
+++ b/packages/extension-agent/src/service/index.ts
@@ -481,6 +481,7 @@ export class ChatLunaAgentService extends Service {
         const subAgent = structuredClone(this.args.config.subAgent)
         subAgent.presetAgents[name] = createSubAgentItemConfig({
             enabled: config.enabled ?? true,
+            dedupeTools: config.dedupeTools,
             name,
             description: config.description ?? name,
             chatluna: config.chatluna,
@@ -773,6 +774,7 @@ ${truncateOutput(input.text, limit)}`
 function itemFromInfo(info: SubAgentInfo, enabled: boolean) {
     return createSubAgentItemConfig({
         enabled,
+        dedupeTools: info.dedupeTools,
         name: info.name,
         description: info.description,
         chatluna: info.chatlunaEnabled,

--- a/packages/extension-agent/src/service/permissions.ts
+++ b/packages/extension-agent/src/service/permissions.ts
@@ -263,24 +263,36 @@ export class ChatLunaAgentPermissionService {
                 this.isSessionAllowed(session, source, item)
         )
         const task = mainTools.find((item) => item.name === 'task')
-        const dupes = new Set(
-            task && this.hasAuthority(session, task.authority)
-                ? (
-                      this.ctx.chatluna_agent?.subAgent
-                          .listRunnableAgents(session, source)
-                          .filter((agent) => agent.dedupeTools) ?? []
-                  ).flatMap((agent) =>
-                      mainTools
-                          .filter((item) => this.canUseTool(agent, item.name))
-                          .map((item) => item.name)
-                  )
-                : []
-        )
-        const allow = mainTools
-            .filter((item) => !dupes.has(item.name))
-            .map((item) => item.name)
+        const mainNames = mainTools.map((item) => item.name)
 
-        return buildToolMask(allNames, allow)
+        if (!task || !this.hasAuthority(session, task.authority)) {
+            return buildToolMask(allNames, mainNames)
+        }
+
+        const agents =
+            this.ctx.chatluna_agent?.subAgent
+                .listRunnableAgents(session, source)
+                .filter((agent) => agent.dedupeTools) ?? []
+        if (agents.length < 1) {
+            return buildToolMask(allNames, mainNames)
+        }
+
+        const hidden = new Set(
+            agents.flatMap((agent) =>
+                mainTools
+                    .filter(
+                        (item) =>
+                            item.name !== 'task' &&
+                            this.canUseTool(agent, item.name)
+                    )
+                    .map((item) => item.name)
+            )
+        )
+
+        return buildToolMask(
+            allNames,
+            mainNames.filter((name) => !hidden.has(name))
+        )
     }
 
     async createSubAgentToolMask(

--- a/packages/extension-agent/src/service/permissions.ts
+++ b/packages/extension-agent/src/service/permissions.ts
@@ -256,12 +256,31 @@ export class ChatLunaAgentPermissionService {
     ): ToolMask {
         const tools = this.listTools()
         const allNames = tools.map((item) => item.name)
+        const dupes = new Set(
+            this.config.subAgent.dedupeTools === true
+                ? (
+                      this.ctx.chatluna_agent?.subAgent.listRunnableAgents(
+                          session,
+                          source
+                      ) ?? []
+                  ).flatMap((agent) =>
+                      tools
+                          .filter(
+                              (item) =>
+                                  this.canUseTool(agent, item.name) &&
+                                  this.isSessionAllowed(session, source, item)
+                          )
+                          .map((item) => item.name)
+                  )
+                : []
+        )
         const allow = tools
             .filter(
                 (item) =>
                     item.enabled &&
                     item.main &&
-                    this.isSessionAllowed(session, source, item)
+                    this.isSessionAllowed(session, source, item) &&
+                    !dupes.has(item.name)
             )
             .map((item) => item.name)
 

--- a/packages/extension-agent/src/service/permissions.ts
+++ b/packages/extension-agent/src/service/permissions.ts
@@ -257,22 +257,19 @@ export class ChatLunaAgentPermissionService {
         const tools = this.listTools()
         const allNames = tools.map((item) => item.name)
         const dupes = new Set(
-            this.config.subAgent.dedupeTools === true
-                ? (
-                      this.ctx.chatluna_agent?.subAgent.listRunnableAgents(
-                          session,
-                          source
-                      ) ?? []
-                  ).flatMap((agent) =>
-                      tools
-                          .filter(
-                              (item) =>
-                                  this.canUseTool(agent, item.name) &&
-                                  this.isSessionAllowed(session, source, item)
-                          )
-                          .map((item) => item.name)
-                  )
-                : []
+            (
+                this.ctx.chatluna_agent?.subAgent
+                    .listRunnableAgents(session, source)
+                    .filter((agent) => agent.dedupeTools) ?? []
+            ).flatMap((agent) =>
+                tools
+                    .filter(
+                        (item) =>
+                            this.canUseTool(agent, item.name) &&
+                            this.isSessionAllowed(session, source, item)
+                    )
+                    .map((item) => item.name)
+            )
         )
         const allow = tools
             .filter(

--- a/packages/extension-agent/src/service/permissions.ts
+++ b/packages/extension-agent/src/service/permissions.ts
@@ -256,29 +256,28 @@ export class ChatLunaAgentPermissionService {
     ): ToolMask {
         const tools = this.listTools()
         const allNames = tools.map((item) => item.name)
-        const dupes = new Set(
-            (
-                this.ctx.chatluna_agent?.subAgent
-                    .listRunnableAgents(session, source)
-                    .filter((agent) => agent.dedupeTools) ?? []
-            ).flatMap((agent) =>
-                tools
-                    .filter(
-                        (item) =>
-                            this.canUseTool(agent, item.name) &&
-                            this.isSessionAllowed(session, source, item)
-                    )
-                    .map((item) => item.name)
-            )
+        const mainTools = tools.filter(
+            (item) =>
+                item.enabled &&
+                item.main &&
+                this.isSessionAllowed(session, source, item)
         )
-        const allow = tools
-            .filter(
-                (item) =>
-                    item.enabled &&
-                    item.main &&
-                    this.isSessionAllowed(session, source, item) &&
-                    !dupes.has(item.name)
-            )
+        const task = mainTools.find((item) => item.name === 'task')
+        const dupes = new Set(
+            task && this.hasAuthority(session, task.authority)
+                ? (
+                      this.ctx.chatluna_agent?.subAgent
+                          .listRunnableAgents(session, source)
+                          .filter((agent) => agent.dedupeTools) ?? []
+                  ).flatMap((agent) =>
+                      mainTools
+                          .filter((item) => this.canUseTool(agent, item.name))
+                          .map((item) => item.name)
+                  )
+                : []
+        )
+        const allow = mainTools
+            .filter((item) => !dupes.has(item.name))
             .map((item) => item.name)
 
         return buildToolMask(allNames, allow)

--- a/packages/extension-agent/src/sub-agent/builtin.ts
+++ b/packages/extension-agent/src/sub-agent/builtin.ts
@@ -21,6 +21,7 @@ function createBuiltin(
         id: `builtin:${name}`,
         name,
         description: item.description,
+        dedupeTools: item.dedupeTools,
         source: 'builtin',
         format: 'chatluna',
         state: 'ready',

--- a/packages/extension-agent/src/sub-agent/manual.ts
+++ b/packages/extension-agent/src/sub-agent/manual.ts
@@ -11,6 +11,7 @@ export function createManualAgent(
 ): SubAgentInfo {
     const item = createSubAgentItemConfig({
         enabled: input.enabled,
+        dedupeTools: input.dedupeTools,
         name: input.name,
         description: input.description ?? input.name,
         chatluna: input.chatluna,
@@ -37,6 +38,7 @@ export function createManualAgent(
         id: input.id?.trim() || `manual:${randomUUID()}`,
         name: item.name,
         description: item.description,
+        dedupeTools: item.dedupeTools,
         source: 'manual',
         format: item.format,
         state: 'ready',

--- a/packages/extension-agent/src/sub-agent/markdown.ts
+++ b/packages/extension-agent/src/sub-agent/markdown.ts
@@ -15,6 +15,7 @@ export function createSubAgentMarkdown(input: ManualSubAgentInput) {
             description: input.description?.trim() || input.name.trim(),
             format: 'chatluna',
             enabled: input.enabled ?? true,
+            dedupeTools: input.dedupeTools === true,
             chatluna: input.chatluna ?? true,
             character: input.character ?? true,
             characterGroup: input.characterGroup ?? true,

--- a/packages/extension-agent/src/sub-agent/parse.ts
+++ b/packages/extension-agent/src/sub-agent/parse.ts
@@ -17,6 +17,7 @@ export interface ParsedAgentFrontmatter {
     characterGroupIds: string[]
     characterPrivateIds: string[]
     authority: number
+    dedupeTools: boolean
     model?: string
     maxTurns?: number
     hidden: boolean
@@ -101,6 +102,7 @@ export function parseAgentFrontmatter(
     let characterGroupIds: string[] = []
     let characterPrivateIds: string[] = []
     let authority = 0
+    let dedupeTools = false
     let model: string | undefined
     let maxTurns: number | undefined
     let allowKoishiMessageTransform = false
@@ -250,6 +252,7 @@ export function parseAgentFrontmatter(
     } else {
         hidden = frontmatter.hidden === true
         enabled = frontmatter.enabled !== false
+        dedupeTools = frontmatter.dedupeTools === true
         chatluna = frontmatter.chatluna !== false
         character = frontmatter.character !== false
         characterGroup = frontmatter.characterGroup !== false
@@ -329,6 +332,7 @@ export function parseAgentFrontmatter(
             characterGroupIds,
             characterPrivateIds,
             authority,
+            dedupeTools,
             model,
             maxTurns,
             hidden,

--- a/packages/extension-agent/src/sub-agent/parse.ts
+++ b/packages/extension-agent/src/sub-agent/parse.ts
@@ -102,7 +102,7 @@ export function parseAgentFrontmatter(
     let characterGroupIds: string[] = []
     let characterPrivateIds: string[] = []
     let authority = 0
-    let dedupeTools = false
+    const dedupeTools = frontmatter.dedupeTools === true
     let model: string | undefined
     let maxTurns: number | undefined
     let allowKoishiMessageTransform = false
@@ -252,7 +252,6 @@ export function parseAgentFrontmatter(
     } else {
         hidden = frontmatter.hidden === true
         enabled = frontmatter.enabled !== false
-        dedupeTools = frontmatter.dedupeTools === true
         chatluna = frontmatter.chatluna !== false
         character = frontmatter.character !== false
         characterGroup = frontmatter.characterGroup !== false

--- a/packages/extension-agent/src/sub-agent/preset.ts
+++ b/packages/extension-agent/src/sub-agent/preset.ts
@@ -12,6 +12,7 @@ export function getPresetAgents(
             id: `preset:${name}`,
             name,
             description: item.description,
+            dedupeTools: item.dedupeTools,
             source: 'preset' as const,
             format: 'chatluna' as const,
             enabled: item.enabled,

--- a/packages/extension-agent/src/sub-agent/scan.ts
+++ b/packages/extension-agent/src/sub-agent/scan.ts
@@ -112,6 +112,7 @@ async function scanTarget(target: ScanTarget, cfg: AgentConfig['subAgent']) {
 
             const base = createSubAgentItemConfig({
                 enabled: parsed.value?.enabled ?? true,
+                dedupeTools: parsed.value?.dedupeTools,
                 name: parsed.value?.name ?? name,
                 description: parsed.value?.description ?? '',
                 chatluna: parsed.value?.chatluna ?? true,
@@ -162,6 +163,7 @@ async function scanTarget(target: ScanTarget, cfg: AgentConfig['subAgent']) {
                 id,
                 name: item.name,
                 description: item.description,
+                dedupeTools: item.dedupeTools,
                 source: 'markdown',
                 format: item.format,
                 state: parsed.state,

--- a/packages/extension-agent/src/types/sub_agent.ts
+++ b/packages/extension-agent/src/types/sub_agent.ts
@@ -12,6 +12,7 @@ export interface SubAgentPermissionConfig {
 
 export interface SubAgentItemConfig {
     enabled: boolean
+    dedupeTools: boolean
     name: string
     description: string
     chatluna: boolean
@@ -36,7 +37,6 @@ export interface SubAgentItemConfig {
 
 export interface SubAgentConfig {
     dirs: string[]
-    dedupeTools: boolean
     items: Record<string, SubAgentItemConfig>
     builtin: {
         plan: SubAgentItemConfig
@@ -51,6 +51,7 @@ export interface SubAgentInfo {
     id: string
     name: string
     description: string
+    dedupeTools: boolean
     source: 'builtin' | 'markdown' | 'preset' | 'manual'
     format: 'chatluna' | 'claude' | 'opencode'
     state: 'ready' | 'invalid' | 'missing'
@@ -144,6 +145,7 @@ export interface ManualSubAgentInput {
     id?: string
     name: string
     description?: string
+    dedupeTools?: boolean
     promptContent?: string
     chatluna?: boolean
     character?: boolean

--- a/packages/extension-agent/src/types/sub_agent.ts
+++ b/packages/extension-agent/src/types/sub_agent.ts
@@ -36,6 +36,7 @@ export interface SubAgentItemConfig {
 
 export interface SubAgentConfig {
     dirs: string[]
+    dedupeTools: boolean
     items: Record<string, SubAgentItemConfig>
     builtin: {
         plan: SubAgentItemConfig


### PR DESCRIPTION
This pr adds per-agent tool dedupe settings for Sub Agents.

Closes #891

## Feature Changes

- Add a `主 LLM 去重重复工具` switch in each Sub Agent detail page.
- Keep the setting disabled by default so existing agents preserve current behavior.
- When enabled for a runnable Sub Agent, hide tools from the main LLM if that Sub Agent can use the same tools.

## Other Changes

- Persist the per-agent setting through built-in, markdown, preset, and manual Sub Agent config flows.
- Keep Sub Agent tool permissions unchanged; this only affects the main LLM tool list.

## Validation

- yarn fast-build extension-agent