### PR TITLE
fix(adapter-gemini): preserve function call parts

### DIFF
--- a/packages/adapter-gemini/src/locales/en-US.schema.yml
+++ b/packages/adapter-gemini/src/locales/en-US.schema.yml
@@ -17,7 +17,6 @@ $inner:
       groundingContentDisplay: 'Enable display of search results'
       imageGeneration: 'Enable image generation (only for `gemini-*-image-*` and `gemini-2.5-flash-image-preview` model)'
       imageModelSearch: 'Enable search for image generation models. When enabled, supported image models will generate additional variants with a `-search` suffix (e.g. `gemini-3-pro-image-search`).'
-      searchThreshold: 'Search confidence [threshold](https://ai.google.dev/gemini-api/docs/grounding?lang=rest#dynamic-retrieval) (0-1). Lower: more likely to use Google search'
       includeThoughts: 'Enable retrieval of model thoughts'
       codeExecution: 'Enable code execution tool'
       urlContext: 'Enable URL context retrieval tool'

--- a/packages/adapter-gemini/src/locales/zh-CN.schema.yml
+++ b/packages/adapter-gemini/src/locales/zh-CN.schema.yml
@@ -17,7 +17,6 @@ $inner:
       thinkingBudget: '思考预算，范围：(-1~24576)，设置的数值越大，思考时花费的 Token 越多,-1 为动态思考。目前仅支持 gemini 2.5 系列模型。'
       groundingContentDisplay: '是否显示谷歌搜索结果。'
       imageModelSearch: '为图片生成模型启用搜索功能。开启后，支持搜索的图片模型将额外生成带 `-search` 后缀的变体（如 `gemini-3-pro-image-search`）。'
-      searchThreshold: '搜索的[置信度阈值](https://ai.google.dev/gemini-api/docs/grounding?lang=rest#dynamic-retrieval)，范围：0~1，设置的数值越低，则越倾向于使用谷歌搜索。（仅支持 `gemini-1.5` 系列模型。gemini 2.0 模型起使用动态的工具调用）'
       includeThoughts: '是否获取模型的思考内容。'
       codeExecution: '为模型启用代码执行工具。（开启后将无法使用工具调用）'
       urlContext: '为模型启用 URL 内容获取工具。（开启后将无法使用工具调用）'

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -605,9 +605,13 @@ export class GeminiRequester
             } else {
                 const buffer = Buffer.from(imagePart.inlineData.data, 'base64')
 
+                const hash = await hashString(imagePart.inlineData.data, 8)
+                const type = (
+                    imagePart.inlineData.mimeType ?? 'image/png'
+                ).split('/')[1]
                 const file = await storageService.createTempFile(
                     buffer,
-                    `${await hashString(imagePart.inlineData.data, 8)}.${(imagePart.inlineData.mimeType ?? 'image/png').split('/')[1]}`
+                    `${hash}.${type}`
                 )
 
                 messagePart.text = '[image]'

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -426,13 +426,8 @@ export class GeminiRequester
                         : chunk
 
                 const usage = getUsage(transformValue)
-                if (usage != null) {
-                    controller.enqueue({
-                        usage
-                    })
-                }
-
                 if (!transformValue?.candidates) {
+                    if (usage != null) controller.enqueue({ usage })
                     return
                 }
 
@@ -445,6 +440,8 @@ export class GeminiRequester
                         currentGroundingIndex
                     )
                 }
+
+                if (usage != null) controller.enqueue({ usage })
             }
         })
     }
@@ -488,8 +485,6 @@ export class GeminiRequester
         let errorCount = 0
 
         let functionIndex = 0
-        let hasGeneration = false
-        let pendingUsage: ReturnType<typeof createUsageMetadata> | undefined
 
         for await (const chunk of iterable) {
             let parsedChunk: ChatUsageMetadataPart | undefined
@@ -511,22 +506,18 @@ export class GeminiRequester
                     reasoningTokens: parsedChunk.usage.reasoningTokens
                 })
 
-                if (hasGeneration) {
-                    yield {
-                        type: 'generation',
-                        generation: new ChatGenerationChunk({
-                            generationInfo: {
-                                usage_metadata: usageMetadata
-                            },
-                            message: new AIMessageChunk({
-                                content: '',
-                                usage_metadata: usageMetadata
-                            }),
-                            text: ''
-                        })
-                    }
-                } else {
-                    pendingUsage = usageMetadata
+                yield {
+                    type: 'generation',
+                    generation: new ChatGenerationChunk({
+                        generationInfo: {
+                            usage_metadata: usageMetadata
+                        },
+                        message: new AIMessageChunk({
+                            content: '',
+                            usage_metadata: usageMetadata
+                        }),
+                        text: ''
+                    })
                 }
                 continue
             }
@@ -546,27 +537,22 @@ export class GeminiRequester
                     continue
                 }
 
-                if (updatedContent || updatedToolCalling) {
-                    const usageMetadata = pendingUsage
+                if (
+                    updatedContent ||
+                    updatedToolCalling ||
+                    chunk['thoughtSignature'] != null
+                ) {
                     const messageChunk = this._createMessageChunk(
                         updatedContent,
                         updatedToolCalling,
-                        chunk,
-                        usageMetadata
+                        chunk
                     )
-                    pendingUsage = undefined
 
                     const generationChunk = new ChatGenerationChunk({
-                        generationInfo: usageMetadata
-                            ? {
-                                  usage_metadata: usageMetadata
-                              }
-                            : undefined,
                         message: messageChunk,
                         text: getMessageContent(messageChunk.content) ?? ''
                     })
 
-                    hasGeneration = true
                     yield { type: 'generation', generation: generationChunk }
                 }
 
@@ -689,8 +675,7 @@ export class GeminiRequester
     private _createMessageChunk(
         content: MessageContent,
         functionCall: ToolCallChunk | undefined,
-        chunk: ChatPart,
-        usageMetadata?: ReturnType<typeof createUsageMetadata>
+        chunk: ChatPart
     ) {
         const imagePart =
             this.ctx.chatluna_storage != null
@@ -701,13 +686,24 @@ export class GeminiRequester
                   )
         const messageChunk = new AIMessageChunk({
             content: content ?? '',
-            tool_call_chunks: [functionCall].filter(Boolean),
-            usage_metadata: usageMetadata
+            tool_call_chunks: [functionCall].filter(Boolean)
         })
-        const part =
-            chunk['functionCall'] || chunk['text'] || chunk['inlineData']
-                ? [chunk]
-                : undefined
+        const thoughtData =
+            chunk['thoughtSignature'] == null
+                ? undefined
+                : chunk['functionCall']?.id != null
+                  ? {
+                        [chunk['functionCall'].id]: {
+                            thoughtSignature: chunk['thoughtSignature']
+                        }
+                    }
+                  : {
+                        thoughtSignature: chunk['thoughtSignature'],
+                        toolCall: chunk['toolCall'],
+                        toolResponse: chunk['toolResponse'],
+                        executableCode: chunk['executableCode'],
+                        codeExecutionResult: chunk['codeExecutionResult']
+                    }
 
         messageChunk.additional_kwargs = {
             images: imagePart
@@ -715,10 +711,7 @@ export class GeminiRequester
                       `data:${imagePart.inlineData.mimeType ?? 'image/png'};base64,${imagePart.inlineData.data}`
                   ]
                 : undefined,
-            gemini_parts: part,
-            thought_data: {
-                thoughtSignature: chunk['thoughtSignature']
-            }
+            thought_data: thoughtData
         }
 
         return messageChunk

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -688,22 +688,26 @@ export class GeminiRequester
             content: content ?? '',
             tool_call_chunks: [functionCall].filter(Boolean)
         })
-        const thoughtData =
-            chunk['thoughtSignature'] == null
-                ? undefined
-                : chunk['functionCall']?.id != null
-                  ? {
-                        [chunk['functionCall'].id]: {
-                            thoughtSignature: chunk['thoughtSignature']
-                        }
+        const sig = chunk['thoughtSignature']
+        let thoughtData: Record<string, unknown> | undefined
+        if (sig != null) {
+            const id = chunk['functionCall']?.id
+            if (id != null) {
+                thoughtData = {
+                    [id]: {
+                        thoughtSignature: sig
                     }
-                  : {
-                        thoughtSignature: chunk['thoughtSignature'],
-                        toolCall: chunk['toolCall'],
-                        toolResponse: chunk['toolResponse'],
-                        executableCode: chunk['executableCode'],
-                        codeExecutionResult: chunk['codeExecutionResult']
-                    }
+                }
+            } else {
+                thoughtData = {
+                    thoughtSignature: sig,
+                    toolCall: chunk['toolCall'],
+                    toolResponse: chunk['toolResponse'],
+                    executableCode: chunk['executableCode'],
+                    codeExecutionResult: chunk['codeExecutionResult']
+                }
+            }
+        }
 
         messageChunk.additional_kwargs = {
             images: imagePart

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -333,6 +333,13 @@ export class GeminiRequester
             result = result.concat(finalChunk)
         }
 
+        if (result == null) {
+            throw new ChatLunaError(
+                ChatLunaErrorCode.API_REQUEST_FAILED,
+                new Error('empty gemini response')
+            )
+        }
+
         return result
     }
 
@@ -490,30 +497,7 @@ export class GeminiRequester
                     (chunk) => chunk['usage'] != null
                 ))
             ) {
-                const usageMetadata = createUsageMetadata({
-                    inputTokens: parsedChunk.usage.promptTokens,
-                    outputTokens: parsedChunk.usage.completionTokens,
-                    totalTokens: parsedChunk.usage.totalTokens,
-                    inputImageTokens: parsedChunk.usage.inputImageTokens,
-                    outputImageTokens: parsedChunk.usage.outputImageTokens,
-                    inputAudioTokens: parsedChunk.usage.inputAudioTokens,
-                    outputAudioTokens: parsedChunk.usage.outputAudioTokens,
-                    cacheReadTokens: parsedChunk.usage.cacheReadTokens,
-                    reasoningTokens: parsedChunk.usage.reasoningTokens
-                })
-
-                const generationChunk = new ChatGenerationChunk({
-                    generationInfo: {
-                        usage_metadata: usageMetadata
-                    },
-                    message: new AIMessageChunk({
-                        content: '',
-                        usage_metadata: usageMetadata
-                    }),
-                    text: ''
-                })
-
-                yield { type: 'generation', generation: generationChunk }
+                continue
             }
 
             try {
@@ -677,6 +661,10 @@ export class GeminiRequester
             content: content ?? '',
             tool_call_chunks: [functionCall].filter(Boolean)
         })
+        const part =
+            chunk['functionCall'] || chunk['text'] || chunk['inlineData']
+                ? [chunk]
+                : undefined
 
         messageChunk.additional_kwargs = {
             images: imagePart
@@ -684,6 +672,7 @@ export class GeminiRequester
                       `data:${imagePart.inlineData.mimeType ?? 'image/png'};base64,${imagePart.inlineData.data}`
                   ]
                 : undefined,
+            gemini_parts: part,
             thought_data: {
                 thoughtSignature: chunk['thoughtSignature']
             }

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -699,13 +699,23 @@ export class GeminiRequester
                     }
                 }
             } else {
-                thoughtData = {
+                const part = {
                     thoughtSignature: sig,
                     toolCall: chunk['toolCall'],
                     toolResponse: chunk['toolResponse'],
                     executableCode: chunk['executableCode'],
                     codeExecutionResult: chunk['codeExecutionResult']
                 }
+                const contextId =
+                    chunk['toolCall']?.id ??
+                    chunk['toolResponse']?.id ??
+                    chunk['executableCode']?.id ??
+                    chunk['codeExecutionResult']?.id
+
+                thoughtData =
+                    contextId != null
+                        ? { [contextId]: [part] }
+                        : { parts: [part] }
             }
         }
 

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -330,7 +330,7 @@ export class GeminiRequester
         )
 
         if (finalChunk != null) {
-            result = result.concat(finalChunk)
+            result = result != null ? result.concat(finalChunk) : finalChunk
         }
 
         if (result == null) {
@@ -488,6 +488,8 @@ export class GeminiRequester
         let errorCount = 0
 
         let functionIndex = 0
+        let hasGeneration = false
+        let pendingUsage: ReturnType<typeof createUsageMetadata> | undefined
 
         for await (const chunk of iterable) {
             let parsedChunk: ChatUsageMetadataPart | undefined
@@ -497,6 +499,35 @@ export class GeminiRequester
                     (chunk) => chunk['usage'] != null
                 ))
             ) {
+                const usageMetadata = createUsageMetadata({
+                    inputTokens: parsedChunk.usage.promptTokens,
+                    outputTokens: parsedChunk.usage.completionTokens,
+                    totalTokens: parsedChunk.usage.totalTokens,
+                    inputImageTokens: parsedChunk.usage.inputImageTokens,
+                    outputImageTokens: parsedChunk.usage.outputImageTokens,
+                    inputAudioTokens: parsedChunk.usage.inputAudioTokens,
+                    outputAudioTokens: parsedChunk.usage.outputAudioTokens,
+                    cacheReadTokens: parsedChunk.usage.cacheReadTokens,
+                    reasoningTokens: parsedChunk.usage.reasoningTokens
+                })
+
+                if (hasGeneration) {
+                    yield {
+                        type: 'generation',
+                        generation: new ChatGenerationChunk({
+                            generationInfo: {
+                                usage_metadata: usageMetadata
+                            },
+                            message: new AIMessageChunk({
+                                content: '',
+                                usage_metadata: usageMetadata
+                            }),
+                            text: ''
+                        })
+                    }
+                } else {
+                    pendingUsage = usageMetadata
+                }
                 continue
             }
 
@@ -515,17 +546,26 @@ export class GeminiRequester
                 }
 
                 if (updatedContent || updatedToolCalling) {
+                    const usageMetadata = pendingUsage
                     const messageChunk = this._createMessageChunk(
                         updatedContent,
                         updatedToolCalling,
-                        chunk
+                        chunk,
+                        usageMetadata
                     )
+                    pendingUsage = undefined
 
                     const generationChunk = new ChatGenerationChunk({
+                        generationInfo: usageMetadata
+                            ? {
+                                  usage_metadata: usageMetadata
+                              }
+                            : undefined,
                         message: messageChunk,
                         text: getMessageContent(messageChunk.content) ?? ''
                     })
 
+                    hasGeneration = true
                     yield { type: 'generation', generation: generationChunk }
                 }
 
@@ -648,7 +688,8 @@ export class GeminiRequester
     private _createMessageChunk(
         content: MessageContent,
         functionCall: ToolCallChunk | undefined,
-        chunk: ChatPart
+        chunk: ChatPart,
+        usageMetadata?: ReturnType<typeof createUsageMetadata>
     ) {
         const imagePart =
             this.ctx.chatluna_storage != null
@@ -659,7 +700,8 @@ export class GeminiRequester
                   )
         const messageChunk = new AIMessageChunk({
             content: content ?? '',
-            tool_call_chunks: [functionCall].filter(Boolean)
+            tool_call_chunks: [functionCall].filter(Boolean),
+            usage_metadata: usageMetadata
         })
         const part =
             chunk['functionCall'] || chunk['text'] || chunk['inlineData']

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -324,20 +324,20 @@ export class GeminiRequester
             }
         }
 
+        if (result == null) {
+            throw new ChatLunaError(
+                ChatLunaErrorCode.API_REQUEST_FAILED,
+                new Error('empty gemini response')
+            )
+        }
+
         const finalChunk = this._handleFinalContent(
             reasoningContent,
             groundingContent.value
         )
 
         if (finalChunk != null) {
-            result = result != null ? result.concat(finalChunk) : finalChunk
-        }
-
-        if (result == null) {
-            throw new ChatLunaError(
-                ChatLunaErrorCode.API_REQUEST_FAILED,
-                new Error('empty gemini response')
-            )
+            result = result.concat(finalChunk)
         }
 
         return result
@@ -532,9 +532,10 @@ export class GeminiRequester
             }
 
             try {
+                const part = Object.assign({}, chunk)
                 const { updatedContent, updatedReasoning, updatedToolCalling } =
                     await this._processChunk(
-                        chunk,
+                        part,
                         reasoningContent,
                         functionIndex
                     )

--- a/packages/adapter-gemini/src/types.ts
+++ b/packages/adapter-gemini/src/types.ts
@@ -12,6 +12,7 @@ export type ChatPart =
     | ChatInlineDataPart
     | (ChatFunctionCallingPart & BaseChatPart)
     | ChatFunctionResponsePart
+    | (ChatToolContextPart & BaseChatPart)
     | ChatUploadDataPart
     // Only used for token
     | ChatUsageMetadataPart
@@ -85,6 +86,17 @@ export type ChatFunctionResponsePart = {
         parts?: (ChatMessagePart | ChatInlineDataPart | ChatUploadDataPart)[]
         id?: string
     }
+}
+
+export type ChatToolContextPart = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    toolCall?: Record<string, any>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    toolResponse?: Record<string, any>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    executableCode?: Record<string, any>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    codeExecutionResult?: Record<string, any>
 }
 
 export interface ChatResponse {

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -51,6 +51,17 @@ export async function langchainMessageToGeminiMessage(
                 (message as AIMessage).tool_calls != null &&
                 (message as AIMessage).tool_calls.length > 0
 
+            if (
+                role === 'model' &&
+                Array.isArray(message.additional_kwargs['gemini_parts']) &&
+                message.additional_kwargs['gemini_parts'].length > 0
+            ) {
+                return {
+                    role,
+                    parts: message.additional_kwargs['gemini_parts'] as ChatPart[]
+                }
+            }
+
             if (role === 'function' || hasFunctionCall) {
                 return await processFunctionMessage(
                     plugin,
@@ -87,9 +98,28 @@ export async function langchainMessageToGeminiMessage(
         })
     )
 
-    return mappedMessages.flatMap((item) =>
+    const geminiMessages = mappedMessages.flatMap((item) =>
         Array.isArray(item) ? item : [item]
     )
+
+    const result: ChatCompletionResponseMessage[] = []
+    for (const message of geminiMessages) {
+        const previous = result[result.length - 1]
+        if (
+            previous?.role === 'user' &&
+            message.role === 'user' &&
+            previous.parts.length > 0 &&
+            message.parts.length > 0 &&
+            previous.parts.every((part) => part['functionResponse'] != null) &&
+            message.parts.every((part) => part['functionResponse'] != null)
+        ) {
+            previous.parts.push(...message.parts)
+            continue
+        }
+        result.push(message)
+    }
+
+    return result
 }
 
 export function extractSystemMessages(
@@ -150,11 +180,18 @@ async function processFunctionMessage(
     message: AIMessage | ToolMessage,
     removeId: boolean
 ): Promise<ChatCompletionResponseMessage> {
-    const thoughtData: Record<string, any> =
-        message.additional_kwargs['thought_data'] ?? {}
-
     if (message['tool_calls']) {
         message = message as AIMessage
+        if (
+            Array.isArray(message.additional_kwargs['gemini_parts']) &&
+            message.additional_kwargs['gemini_parts'].length > 0
+        ) {
+            return {
+                role: 'model',
+                parts: message.additional_kwargs['gemini_parts'] as ChatPart[]
+            }
+        }
+
         const toolCalls = message.tool_calls
         return {
             role: 'model',
@@ -167,8 +204,7 @@ async function processFunctionMessage(
                     functionCall.id = toolCall.id
                 }
                 return {
-                    functionCall,
-                    ...thoughtData
+                    functionCall
                 }
             })
         }

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -172,10 +172,8 @@ function isContextPart(part: any): part is ChatPart {
 }
 
 function getContextParts(data: Record<string, any>, id?: string) {
-    const raw =
-        id != null
-            ? data[id]
-            : (data['parts'] ?? [data, ...Object.values(data)])
+    const parts = data['parts'] ?? [data, ...Object.values(data)]
+    const raw = id != null ? data[id] : parts
     if (raw == null) return []
 
     return (Array.isArray(raw) ? raw : [raw]).filter(isContextPart)

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -88,15 +88,12 @@ export async function langchainMessageToGeminiMessage(
         const item: ChatCompletionResponseMessage = { role, parts: [] }
         const thoughtData: Record<string, any> =
             message.additional_kwargs['thought_data'] ?? {}
-
-        item.parts =
+        const parts =
             typeof message.content === 'string'
-                ? [{ text: message.content, ...thoughtData }]
-                : await processGeminiContentParts(
-                      plugin,
-                      message.content,
-                      thoughtData
-                  )
+                ? [{ text: message.content }]
+                : await processGeminiContentParts(plugin, message.content)
+
+        item.parts = [...getContextParts(thoughtData), ...parts]
 
         if (message.additional_kwargs.images != null) {
             logger.warn(
@@ -163,6 +160,27 @@ function parseJsonArgs(args: string) {
     }
 }
 
+function isContextPart(part: any): part is ChatPart {
+    return (
+        typeof part === 'object' &&
+        part != null &&
+        (part['toolCall'] != null ||
+            part['toolResponse'] != null ||
+            part['executableCode'] != null ||
+            part['codeExecutionResult'] != null)
+    )
+}
+
+function getContextParts(data: Record<string, any>, id?: string) {
+    const raw =
+        id != null
+            ? data[id]
+            : (data['parts'] ?? [data, ...Object.values(data)])
+    if (raw == null) return []
+
+    return (Array.isArray(raw) ? raw : [raw]).filter(isContextPart)
+}
+
 async function processFunctionMessage(
     plugin: ChatLunaPlugin<ClientConfig, Config>,
     message: AIMessage | ToolMessage,
@@ -176,19 +194,10 @@ async function processFunctionMessage(
         const toolCalls = message.tool_calls
         const parts: ChatPart[] = []
 
-        // tool context: preserve built-in tool context parts for Gemini 3.
-        for (const item of Object.values(thoughtData)) {
-            if (
-                typeof item === 'object' &&
-                item != null &&
-                (item['toolCall'] != null || item['toolResponse'] != null)
-            ) {
-                parts.push(item as ChatPart)
-            }
-        }
-
-        // tool calls: reattach custom tool calls with their thought signatures.
         for (const toolCall of toolCalls) {
+            // tool context: replay context tied to this tool call first.
+            parts.push(...getContextParts(thoughtData, toolCall.id))
+
             const functionCall: ChatFunctionCallingPart['functionCall'] = {
                 name: toolCall.name,
                 args: toolCall.args
@@ -197,11 +206,16 @@ async function processFunctionMessage(
                 functionCall.id = toolCall.id
             }
             const data = thoughtData[toolCall.id] ?? thoughtData
+            const sig = Array.isArray(data)
+                ? data.find(
+                      (item) => typeof item?.thoughtSignature === 'string'
+                  )?.thoughtSignature
+                : data.thoughtSignature
+
+            // tool calls: reattach custom tool calls with their thought signatures.
             parts.push({
                 functionCall,
-                ...(typeof data.thoughtSignature === 'string'
-                    ? { thoughtSignature: data.thoughtSignature }
-                    : {})
+                ...(typeof sig === 'string' ? { thoughtSignature: sig } : {})
             })
         }
 
@@ -324,13 +338,12 @@ async function processGeminiFileLikeContent(
 
 async function processGeminiContentParts(
     plugin: ChatLunaPlugin<ClientConfig, Config>,
-    content: MessageContentComplex[],
-    thoughtData: Record<string, any> = {}
+    content: MessageContentComplex[]
 ) {
     const mappedParts = await Promise.all(
         content.map(async (part) => {
             if (isMessageContentText(part)) {
-                return { text: part.text, ...thoughtData }
+                return { text: part.text }
             }
             if (isMessageContentImageUrl(part)) {
                 return await processGeminiImageContent(plugin, part)
@@ -790,11 +803,12 @@ export function createGeminiCapabilities(
 }
 
 export function shouldFilterOutGeminiModel(modelNameLower: string): boolean {
+    const name = modelNameLower.slice(modelNameLower.lastIndexOf('/') + 1)
+
     return (
-        modelNameLower.includes('-tts') ||
-        modelNameLower.includes('gemini-live-') ||
-        (modelNameLower.startsWith('gemini-') &&
-            Number(modelNameLower.split('-')[1]) < 2)
+        name.includes('-tts') ||
+        name.includes('gemini-live-') ||
+        (name.startsWith('gemini-') && Number(name.split('-')[1]) < 2)
     )
 }
 

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -175,6 +175,8 @@ async function processFunctionMessage(
         message = message as AIMessage
         const toolCalls = message.tool_calls
         const parts: ChatPart[] = []
+
+        // tool context: preserve built-in tool context parts for Gemini 3.
         for (const item of Object.values(thoughtData)) {
             if (
                 typeof item === 'object' &&
@@ -185,6 +187,7 @@ async function processFunctionMessage(
             }
         }
 
+        // tool calls: reattach custom tool calls with their thought signatures.
         for (const toolCall of toolCalls) {
             const functionCall: ChatFunctionCallingPart['functionCall'] = {
                 name: toolCall.name,
@@ -454,10 +457,9 @@ export function formatToolsToGeminiAITools(
 
     // --- 处理内置工具（googleSearch / codeExecution / urlContext）---
     let { googleSearch, codeExecution, urlContext } = config
-    const useBuiltinTools = googleSearch || codeExecution || urlContext
 
     if (
-        useBuiltinTools &&
+        (googleSearch || codeExecution || urlContext) &&
         isCustomToolsUnsupported(model, config.imageGeneration)
     ) {
         logger.warn(
@@ -468,8 +470,17 @@ export function formatToolsToGeminiAITools(
         urlContext = false
     }
 
-    if (functions.length > 0) {
+    const useBuiltinTools = googleSearch || codeExecution || urlContext
+
+    if (
+        functions.length > 0 &&
+        (!useBuiltinTools || model.includes('gemini-3'))
+    ) {
         result.push({ functionDeclarations: functions })
+    } else if (functions.length > 0) {
+        logger.warn(
+            `The model ${model} does not support combining built-in tools and function calling. Function calling will be disabled.`
+        )
     }
 
     appendBuiltinTools(result, googleSearch, codeExecution, urlContext, model)
@@ -693,9 +704,6 @@ export async function createChatGenerationParams(
                   modelConfig.model
               )
             : undefined
-    const hasFunctionDeclarations = tools?.some(
-        (tool) => tool.functionDeclarations != null
-    )
     const hasBuiltinTools = tools?.some(
         (tool) =>
             tool.google_search != null ||
@@ -715,9 +723,7 @@ export async function createChatGenerationParams(
             systemInstruction != null ? systemInstruction : undefined,
         tools,
         toolConfig:
-            modelConfig.model.includes('gemini-3') &&
-            hasFunctionDeclarations &&
-            hasBuiltinTools
+            modelConfig.model.includes('gemini-3') && hasBuiltinTools
                 ? { includeServerSideToolInvocations: true }
                 : undefined
     }

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -58,7 +58,9 @@ export async function langchainMessageToGeminiMessage(
             ) {
                 return {
                     role,
-                    parts: message.additional_kwargs['gemini_parts'] as ChatPart[]
+                    parts: message.additional_kwargs[
+                        'gemini_parts'
+                    ] as ChatPart[]
                 }
             }
 
@@ -108,8 +110,8 @@ export async function langchainMessageToGeminiMessage(
         if (
             previous?.role === 'user' &&
             message.role === 'user' &&
-            previous.parts.length > 0 &&
-            message.parts.length > 0 &&
+            (previous.parts?.length ?? 0) > 0 &&
+            (message.parts?.length ?? 0) > 0 &&
             previous.parts.every((part) => part['functionResponse'] != null) &&
             message.parts.every((part) => part['functionResponse'] != null)
         ) {
@@ -182,16 +184,6 @@ async function processFunctionMessage(
 ): Promise<ChatCompletionResponseMessage> {
     if (message['tool_calls']) {
         message = message as AIMessage
-        if (
-            Array.isArray(message.additional_kwargs['gemini_parts']) &&
-            message.additional_kwargs['gemini_parts'].length > 0
-        ) {
-            return {
-                role: 'model',
-                parts: message.additional_kwargs['gemini_parts'] as ChatPart[]
-            }
-        }
-
         const toolCalls = message.tool_calls
         return {
             role: 'model',

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -44,81 +44,67 @@ export async function langchainMessageToGeminiMessage(
     plugin: ChatLunaPlugin<ClientConfig, Config>,
     model?: string
 ): Promise<ChatCompletionResponseMessage[]> {
-    const mappedMessages = await Promise.all(
-        messages.map(async (message) => {
-            const role = messageTypeToGeminiRole(message.getType())
-            const hasFunctionCall =
-                (message as AIMessage).tool_calls != null &&
-                (message as AIMessage).tool_calls.length > 0
-
-            if (
-                role === 'model' &&
-                Array.isArray(message.additional_kwargs['gemini_parts']) &&
-                message.additional_kwargs['gemini_parts'].length > 0
-            ) {
-                return {
-                    role,
-                    parts: message.additional_kwargs[
-                        'gemini_parts'
-                    ] as ChatPart[]
-                }
-            }
-
-            if (role === 'function' || hasFunctionCall) {
-                return await processFunctionMessage(
-                    plugin,
-                    message,
-                    // 如果使用 new api，我们应该去掉 id，，，
-                    plugin.config.useCamelCaseSystemInstruction
-                )
-            }
-
-            const result: ChatCompletionResponseMessage = {
-                role,
-                parts: []
-            }
-
-            const thoughtData: Record<string, any> =
-                message.additional_kwargs['thought_data'] ?? {}
-
-            result.parts =
-                typeof message.content === 'string'
-                    ? [{ text: message.content, ...thoughtData }]
-                    : await processGeminiContentParts(
-                          plugin,
-                          message.content,
-                          thoughtData
-                      )
-
-            if (message.additional_kwargs.images != null) {
-                logger.warn(
-                    'Deprecated: `additional_kwargs.images` is no longer supported. Use `image_url` content parts instead.'
-                )
-            }
-
-            return result
-        })
-    )
-
-    const geminiMessages = mappedMessages.flatMap((item) =>
-        Array.isArray(item) ? item : [item]
-    )
-
     const result: ChatCompletionResponseMessage[] = []
-    for (const message of geminiMessages) {
-        const previous = result[result.length - 1]
-        if (
-            previous?.role === 'user' &&
-            message.role === 'user' &&
-            (previous.parts?.length ?? 0) > 0 &&
-            (message.parts?.length ?? 0) > 0 &&
-            previous.parts.every((part) => part['functionResponse'] != null) &&
-            message.parts.every((part) => part['functionResponse'] != null)
-        ) {
-            previous.parts.push(...message.parts)
+    for (let i = 0; i < messages.length; i++) {
+        const message = messages[i]
+        const role = messageTypeToGeminiRole(message.getType())
+        const hasFunctionCall =
+            (message as AIMessage).tool_calls != null &&
+            (message as AIMessage).tool_calls.length > 0
+
+        if (role === 'function') {
+            const parts: ChatPart[] = []
+            let j = i
+            while (j < messages.length) {
+                const msg = messages[j]
+                if (messageTypeToGeminiRole(msg.getType()) !== 'function') break
+                parts.push(
+                    ...(
+                        await processFunctionMessage(
+                            plugin,
+                            msg,
+                            plugin.config.useCamelCaseSystemInstruction
+                        )
+                    ).parts
+                )
+                j++
+            }
+            i = j - 1
+            result.push({ role: 'user', parts })
             continue
         }
-        result.push(message)
+
+        if (hasFunctionCall) {
+            result.push(
+                await processFunctionMessage(
+                    plugin,
+                    message,
+                    plugin.config.useCamelCaseSystemInstruction
+                )
+            )
+            continue
+        }
+
+        const item: ChatCompletionResponseMessage = { role, parts: [] }
+        const thoughtData: Record<string, any> =
+            message.additional_kwargs['thought_data'] ?? {}
+
+        item.parts =
+            typeof message.content === 'string'
+                ? [{ text: message.content, ...thoughtData }]
+                : await processGeminiContentParts(
+                      plugin,
+                      message.content,
+                      thoughtData
+                  )
+
+        if (message.additional_kwargs.images != null) {
+            logger.warn(
+                'Deprecated: `additional_kwargs.images` is no longer supported. Use `image_url` content parts instead.'
+            )
+        }
+
+        result.push(item)
     }
 
     return result
@@ -182,23 +168,43 @@ async function processFunctionMessage(
     message: AIMessage | ToolMessage,
     removeId: boolean
 ): Promise<ChatCompletionResponseMessage> {
+    const thoughtData: Record<string, any> =
+        message.additional_kwargs['thought_data'] ?? {}
+
     if (message['tool_calls']) {
         message = message as AIMessage
         const toolCalls = message.tool_calls
+        const parts: ChatPart[] = []
+        for (const item of Object.values(thoughtData)) {
+            if (
+                typeof item === 'object' &&
+                item != null &&
+                (item['toolCall'] != null || item['toolResponse'] != null)
+            ) {
+                parts.push(item as ChatPart)
+            }
+        }
+
+        for (const toolCall of toolCalls) {
+            const functionCall: ChatFunctionCallingPart['functionCall'] = {
+                name: toolCall.name,
+                args: toolCall.args
+            }
+            if (!removeId || toolCall.id) {
+                functionCall.id = toolCall.id
+            }
+            const data = thoughtData[toolCall.id] ?? thoughtData
+            parts.push({
+                functionCall,
+                ...(typeof data.thoughtSignature === 'string'
+                    ? { thoughtSignature: data.thoughtSignature }
+                    : {})
+            })
+        }
+
         return {
             role: 'model',
-            parts: toolCalls.map((toolCall) => {
-                const functionCall: ChatFunctionCallingPart['functionCall'] = {
-                    name: toolCall.name,
-                    args: toolCall.args
-                }
-                if (!removeId) {
-                    functionCall.id = toolCall.id
-                }
-                return {
-                    functionCall
-                }
-            })
+            parts
         }
     }
 
@@ -218,7 +224,7 @@ async function processFunctionMessage(
                   response: parseJsonArgs(message.content as string)
               }
 
-    if (!removeId) {
+    if (!removeId || finalMessage.tool_call_id) {
         functionResponse.id = finalMessage.tool_call_id
     }
 
@@ -349,9 +355,7 @@ export function partAsTypeCheck<T extends ChatPart>(
 
 // 不支持 googleSearch / codeExecution / urlContext 的模型列表
 const CUSTOM_TOOLS_UNSUPPORTED_MODELS = [
-    'gemini-1.0',
     'gemini-2.0-flash-lite',
-    'gemini-1.5-flash',
     'gemini-2.0-flash-exp'
 ]
 
@@ -396,7 +400,6 @@ function isImageSearchSupported(model: string): boolean {
 
 /**
  * 将 googleSearch / codeExecution / urlContext 对应的工具项追加到 result 中。
- * - gemini-1 系列使用旧版 google_search_retrieval 格式
  * - 支持 imageSearch 的模型会在 google_search 中注入 searchTypes
  * - 其余模型使用标准的新版 google_search: {} 格式
  */
@@ -449,21 +452,12 @@ export function formatToolsToGeminiAITools(
     const functions = tools.map(formatToolToGeminiAITool)
     const result: Record<string, any>[] = []
 
-    const useCustomTools =
-        config.googleSearch || config.codeExecution || config.urlContext
-
-    // --- 处理 functionDeclarations（与自定义工具互斥）---
-    if (functions.length > 0 && !useCustomTools) {
-        result.push({ functionDeclarations: functions })
-    } else if (functions.length > 0 && useCustomTools) {
-        logger.warn('Use custom tools instead of tool calls.')
-    }
-
     // --- 处理内置工具（googleSearch / codeExecution / urlContext）---
     let { googleSearch, codeExecution, urlContext } = config
+    const useBuiltinTools = googleSearch || codeExecution || urlContext
 
     if (
-        useCustomTools &&
+        useBuiltinTools &&
         isCustomToolsUnsupported(model, config.imageGeneration)
     ) {
         logger.warn(
@@ -472,6 +466,10 @@ export function formatToolsToGeminiAITools(
         googleSearch = false
         codeExecution = false
         urlContext = false
+    }
+
+    if (functions.length > 0) {
+        result.push({ functionDeclarations: functions })
     }
 
     appendBuiltinTools(result, googleSearch, codeExecution, urlContext, model)
@@ -599,29 +597,27 @@ export function prepareModelConfig(
     }
 }
 
-export function createSafetySettings(model: string) {
-    const isNonGemini1 = !model.includes('gemini-1')
-
+export function createSafetySettings() {
     return [
         {
             category: 'HARM_CATEGORY_HARASSMENT',
-            threshold: isNonGemini1 ? 'OFF' : 'BLOCK_NONE'
+            threshold: 'OFF'
         },
         {
             category: 'HARM_CATEGORY_HATE_SPEECH',
-            threshold: isNonGemini1 ? 'OFF' : 'BLOCK_NONE'
+            threshold: 'OFF'
         },
         {
             category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
-            threshold: isNonGemini1 ? 'OFF' : 'BLOCK_NONE'
+            threshold: 'OFF'
         },
         {
             category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
-            threshold: isNonGemini1 ? 'OFF' : 'BLOCK_NONE'
+            threshold: 'OFF'
         },
         {
             category: 'HARM_CATEGORY_CIVIC_INTEGRITY',
-            threshold: isNonGemini1 ? 'OFF' : 'BLOCK_NONE'
+            threshold: 'OFF'
         }
     ]
 }
@@ -680,10 +676,36 @@ export async function createChatGenerationParams(
     const systemInstructionKey = pluginConfig.useCamelCaseSystemInstruction
         ? 'systemInstruction'
         : 'system_instruction'
+    const tools =
+        params.tools != null ||
+        modelConfig.forceGoogleSearch ||
+        pluginConfig.googleSearch ||
+        pluginConfig.codeExecution ||
+        pluginConfig.urlContext
+            ? formatToolsToGeminiAITools(
+                  params.tools ?? [],
+                  {
+                      ...pluginConfig,
+                      googleSearch:
+                          pluginConfig.googleSearch ||
+                          modelConfig.forceGoogleSearch
+                  },
+                  modelConfig.model
+              )
+            : undefined
+    const hasFunctionDeclarations = tools?.some(
+        (tool) => tool.functionDeclarations != null
+    )
+    const hasBuiltinTools = tools?.some(
+        (tool) =>
+            tool.google_search != null ||
+            tool.code_execution != null ||
+            tool.urlContext != null
+    )
 
     return {
         contents: modelMessages,
-        safetySettings: createSafetySettings(modelConfig.model),
+        safetySettings: createSafetySettings(),
         generationConfig: createGenerationConfig(
             params,
             modelConfig,
@@ -691,22 +713,12 @@ export async function createChatGenerationParams(
         ),
         [systemInstructionKey]:
             systemInstruction != null ? systemInstruction : undefined,
-        tools:
-            params.tools != null ||
-            modelConfig.forceGoogleSearch ||
-            pluginConfig.googleSearch ||
-            pluginConfig.codeExecution ||
-            pluginConfig.urlContext
-                ? formatToolsToGeminiAITools(
-                      params.tools ?? [],
-                      {
-                          ...pluginConfig,
-                          googleSearch:
-                              pluginConfig.googleSearch ||
-                              modelConfig.forceGoogleSearch
-                      },
-                      modelConfig.model
-                  )
+        tools,
+        toolConfig:
+            modelConfig.model.includes('gemini-3') &&
+            hasFunctionDeclarations &&
+            hasBuiltinTools
+                ? { includeServerSideToolInvocations: true }
                 : undefined
     }
 }
@@ -734,13 +746,11 @@ export function createGeminiCapabilities(
     // - *-tts: text only
     // - *-image: image input only
     // - gemini-live native-audio: audio/video (no image/pdf)
-    // - gemini 1.5: image/audio/video (no pdf)
     // - newer flash/pro/flash-lite: image/audio/video/pdf
     const isTtsModel = modelNameLower.includes('-tts')
     const isImageOnlyModel = modelNameLower.includes('-image')
     const isLiveModel = modelNameLower.includes('gemini-live')
     const isNativeAudioLiveModel = modelNameLower.includes('native-audio')
-    const isGemini15Family = modelNameLower.startsWith('gemini-1.5-')
 
     const capabilities: ModelCapabilities[] = []
 
@@ -766,7 +776,7 @@ export function createGeminiCapabilities(
         ModelCapabilities.VideoInput
     )
 
-    if (!isGemini15Family && !isLiveModel) {
+    if (!isLiveModel) {
         capabilities.push(ModelCapabilities.FileInput)
     }
 
@@ -776,7 +786,9 @@ export function createGeminiCapabilities(
 export function shouldFilterOutGeminiModel(modelNameLower: string): boolean {
     return (
         modelNameLower.includes('-tts') ||
-        modelNameLower.includes('gemini-live-')
+        modelNameLower.includes('gemini-live-') ||
+        (modelNameLower.startsWith('gemini-') &&
+            Number(modelNameLower.split('-')[1]) < 2)
     )
 }
 

--- a/packages/core/src/llm-core/agent/sub-agent.ts
+++ b/packages/core/src/llm-core/agent/sub-agent.ts
@@ -863,14 +863,15 @@ function appendTaskToolBatch(task: AgentTaskSession, steps: AgentStep[]) {
 
 function createAgentToolMessages(steps: AgentStep[]): BaseMessage[] {
     const reasoning = steps[0]?.action.reasoningContent
+    const message = steps[0]?.action.messageLog?.[0]
 
     return [
         new AIMessage({
             content: '',
-            // DeepSeek-V4 thinking mode requires reasoning_content (possibly
-            // empty string) to be echoed back on every tool_call turn.
-            additional_kwargs:
-                reasoning != null ? { reasoning_content: reasoning } : {},
+            additional_kwargs: {
+                ...(message?.additional_kwargs ?? {}),
+                ...(reasoning != null ? { reasoning_content: reasoning } : {})
+            },
             tool_calls: steps.map((step) => ({
                 id: step.action.toolCallId,
                 name: step.action.tool,

--- a/packages/core/src/llm-core/agent/types.ts
+++ b/packages/core/src/llm-core/agent/types.ts
@@ -1,5 +1,6 @@
 import type {
     AIMessage,
+    BaseMessage,
     HumanMessage,
     MessageContent,
     MessageContentImageUrl,
@@ -180,6 +181,7 @@ export type AgentAction = {
     log: string
     content?: MessageContent
     reasoningContent?: string
+    messageLog?: BaseMessage[]
 }
 
 export type AgentFinish = {

--- a/packages/core/src/llm-core/memory/message/database_history.ts
+++ b/packages/core/src/llm-core/memory/message/database_history.ts
@@ -532,14 +532,15 @@ async function serializeMessage(
 
 function createAgentToolMessages(steps: AgentStep[]): BaseMessage[] {
     const reasoning = steps[0]?.action.reasoningContent
+    const message = steps[0]?.action.messageLog?.[0]
 
     return [
         new AIMessage({
             content: '',
-            // DeepSeek-V4 thinking mode requires reasoning_content (possibly
-            // empty string) to be echoed back on every tool_call turn.
-            additional_kwargs:
-                reasoning != null ? { reasoning_content: reasoning } : {},
+            additional_kwargs: {
+                ...(message?.additional_kwargs ?? {}),
+                ...(reasoning != null ? { reasoning_content: reasoning } : {})
+            },
             tool_calls: steps.map((step) => ({
                 id: step.action.toolCallId,
                 name: step.action.tool,

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -862,9 +862,7 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                     break
                 }
                 totalTokens += baselineTokens
-                for (let j = 0; j <= i; j++) {
-                    selectedRounds.unshift(conversationRounds[j])
-                }
+                selectedRounds.unshift(...conversationRounds.slice(0, i + 1))
                 break
             }
 

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -375,15 +375,18 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
 
     private _hasResponse(message?: AIMessage | AIMessageChunk): boolean {
         const content = message?.content
+        const kwargs = message?.additional_kwargs
+        const hasContent =
+            typeof content === 'string'
+                ? content.trim().length > 0
+                : Array.isArray(content) && content.length > 0
 
         return (
-            (typeof content === 'string'
-                ? content.trim().length > 0
-                : Array.isArray(content) && content.length > 0) ||
+            hasContent ||
             this._hasToolCallChunk(message) ||
-            ((message?.additional_kwargs?.tool_calls as unknown[] | undefined)
-                ?.length ?? 0) > 0 ||
-            message?.additional_kwargs?.function_call != null
+            ((kwargs?.tool_calls as unknown[] | undefined)?.length ?? 0) > 0 ||
+            kwargs?.function_call != null ||
+            kwargs?.thought_data != null
         )
     }
 

--- a/packages/extension-agent/src/sub-agent/session.ts
+++ b/packages/extension-agent/src/sub-agent/session.ts
@@ -201,9 +201,12 @@ export function formatTaskDetail(
 }
 
 function createAgentToolMessages(steps: AgentStep[]): BaseMessage[] {
+    const message = steps[0]?.action.messageLog?.[0]
+
     return [
         new AIMessage({
             content: '',
+            additional_kwargs: message?.additional_kwargs ?? {},
             tool_calls: steps.map((step) => ({
                 id: step.action.toolCallId,
                 name: step.action.tool,


### PR DESCRIPTION
This pr fixes Gemini function/tool response replay by preserving model-returned context parts and forwarding them through agent tool turns.

## Bug fixes
- Preserve Gemini thought/tool context data on AI chunks and replay it with later function calls.
- Store built-in tool context parts by context id when available, then replay those parts before the matching function call.
- Keep usage metadata chunks as empty generations so usage-only stream events are not dropped.
- Merge consecutive Gemini function response messages into one user turn for parallel tool responses.
- Carry original agent message additional kwargs into reconstructed tool-call turns for sub-agent and persisted history paths.
- Treat Gemini thought metadata as a real model response to avoid false empty-response handling.
- Only combine Gemini built-in tools with function calling on Gemini 3 models; older models keep built-in tools and disable function declarations with a warning.

## Other Changes
- Enable Gemini 3 server-side tool invocation config whenever built-in tools are present.
- Remove Gemini 1.x-specific search threshold/safety/model capability handling and filter old Gemini 1.x models from discovery, including provider-qualified model names.
- Remove obsolete search threshold schema text.

## Validation
- yarn lint-fix (0 errors, existing max-len warnings only)