### PR TITLE
fix(service-multimodal): simplify read_files schema

### DIFF
--- a/packages/service-multimodal/src/plugins/read_files.ts
+++ b/packages/service-multimodal/src/plugins/read_files.ts
@@ -45,21 +45,34 @@ export class ReadFilesTool extends StructuredTool {
         files: z
             .preprocess(
                 (arg: unknown) => {
+                    let value = arg
                     if (typeof arg === 'string') {
                         const base = JSON.parse(arg)
                         if (
                             typeof base === 'object' &&
+                            base != null &&
                             typeof base['files'] === 'string'
                         ) {
                             try {
-                                base['files'] = JSON.parse(base['files'])
-                                return base
+                                value = JSON.parse(base['files'])
                             } catch {
-                                return base
+                                value = base['files']
                             }
+                        } else if (
+                            typeof base === 'object' &&
+                            base != null &&
+                            base['files'] != null
+                        ) {
+                            value = base['files']
+                        } else {
+                            value = base
                         }
                     }
-                    return arg
+                    return typeof value === 'object' &&
+                        value != null &&
+                        !Array.isArray(value)
+                        ? [value]
+                        : value
                 },
                 z
                     .array(

--- a/packages/service-multimodal/src/plugins/read_files.ts
+++ b/packages/service-multimodal/src/plugins/read_files.ts
@@ -45,29 +45,8 @@ export class ReadFilesTool extends StructuredTool {
         files: z
             .preprocess(
                 (arg: unknown) => {
-                    let value = arg
-                    if (typeof arg === 'string') {
-                        const base = JSON.parse(arg)
-                        if (
-                            typeof base === 'object' &&
-                            base != null &&
-                            typeof base['files'] === 'string'
-                        ) {
-                            try {
-                                value = JSON.parse(base['files'])
-                            } catch {
-                                value = base['files']
-                            }
-                        } else if (
-                            typeof base === 'object' &&
-                            base != null &&
-                            base['files'] != null
-                        ) {
-                            value = base['files']
-                        } else {
-                            value = base
-                        }
-                    }
+                    const value =
+                        typeof arg === 'string' ? JSON.parse(arg) : arg
                     return typeof value === 'object' &&
                         value != null &&
                         !Array.isArray(value)

--- a/packages/service-multimodal/src/plugins/read_files.ts
+++ b/packages/service-multimodal/src/plugins/read_files.ts
@@ -61,22 +61,17 @@ export class ReadFilesTool extends StructuredTool {
                     }
                     return arg
                 },
-                z.union([
-                    z.object({
-                        url: z.string().url()
-                    }),
-                    z
-                        .array(
-                            z.object({
-                                url: z.string().url()
-                            })
-                        )
-                        .min(1)
-                        .max(10)
-                ])
+                z
+                    .array(
+                        z.object({
+                            url: z.string().url()
+                        })
+                    )
+                    .min(1)
+                    .max(10)
             )
             .describe(
-                'One file or a list of files to read (max 10). File format: { url: string }. MIME type is inferred from response headers, then URL extension.'
+                'A list of files to read (max 10). File format: { url: string }. MIME type is inferred from response headers, then URL extension.'
             )
     })
 
@@ -98,7 +93,7 @@ export class ReadFilesTool extends StructuredTool {
         _: unknown,
         runConfig?: ChatLunaToolRunnable
     ) {
-        const files = Array.isArray(input.files) ? input.files : [input.files]
+        const files = input.files
         const model = runConfig?.configurable?.model
         const conversationId = runConfig?.configurable?.conversationId
         const fileConfig = model?.fileHandlingConfig


### PR DESCRIPTION
## Summary

- simplify `read_files.files` schema to a fixed array of `{ url }` objects
- remove the single-object union branch to avoid `oneOf` / `anyOf` schema output for Gemini tool declarations
- keep MIME detection behavior unchanged: response header first, URL extension only when no header MIME is available

## Verification

- `./node_modules/.bin/yakumo build service-multimodal`
