### PR TITLE
fix(adapter-deepseek): align context variants

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-deepseek-adapter",
     "description": "deepseek adapter for chatluna",
-    "version": "1.4.0-alpha.6",
+    "version": "1.4.0-alpha.7",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-deepseek/src/client.ts
+++ b/packages/adapter-deepseek/src/client.ts
@@ -61,7 +61,7 @@ export class DeepseekClient extends PlatformModelAndEmbeddingsClient<ClientConfi
                 models.push(
                     `${model}-high-thinking`,
                     `${model}-max-thinking`,
-                    `${model}-instance`
+                    `${model}-instant`
                 )
             }
 
@@ -115,7 +115,7 @@ export class DeepseekClient extends PlatformModelAndEmbeddingsClient<ClientConfi
                 requester: this._requester,
                 model,
                 maxTokenLimit: Math.floor(
-                    (info.maxTokens || 100_000) * this._config.maxContextRatio
+                    (info.maxTokens || 1_000_000) * this._config.maxContextRatio
                 ),
                 frequencyPenalty: this._config.frequencyPenalty,
                 presencePenalty: this._config.presencePenalty,

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.4.0-alpha.21",
+    "version": "1.4.0-alpha.22",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/core/src/llm-core/agent/legacy-executor.ts
+++ b/packages/core/src/llm-core/agent/legacy-executor.ts
@@ -70,7 +70,10 @@ async function executeTools(
             if (tool == null) {
                 return {
                     action,
-                    observation: `${action.tool} is not a valid tool, try another one.`
+                    observation:
+                        `${action.tool} is not a valid tool. Try another tool. ` +
+                        'If this happens repeatedly, stop the task and tell ' +
+                        'the user you cannot call these tools right now.'
                 } as AgentStep
             }
 
@@ -84,7 +87,13 @@ async function executeTools(
 
                 return {
                     action,
-                    observation: `Tool '${action.tool}' is not allowed for the current agent. Available tools: ${allowed.join(', ')}`
+                    observation:
+                        `Tool '${action.tool}' is not allowed for the ` +
+                        `current agent. Available tools: ${allowed.join(', ')}. ` +
+                        'Try another tool, and test whether it can be ' +
+                        'called first. If this happens repeatedly, stop ' +
+                        'the task and tell the user you cannot call these ' +
+                        'tools right now.'
                 } as AgentStep
             }
 
@@ -95,7 +104,12 @@ async function executeTools(
             if (callMask && !applyToolMask(action.tool, callMask)) {
                 return {
                     action,
-                    observation: `You do not have permission to call tool '${action.tool}'. Try another tool.`
+                    observation:
+                        `You do not have permission to call tool ` +
+                        `'${action.tool}'. Try another tool, and test ` +
+                        'whether it can be called first. If this happens ' +
+                        'repeatedly, stop the task and tell the user you ' +
+                        'cannot call these tools right now.'
                 } as AgentStep
             }
 

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -89,7 +89,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22",
         "koishi-plugin-chatluna-agent": "^1.0.32",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },

--- a/packages/extension-usage/package.json
+++ b/packages/extension-usage/package.json
@@ -59,7 +59,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "koishi": {
         "description": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "koishi": {
         "description": {

--- a/packages/service-multimodal/package.json
+++ b/packages/service-multimodal/package.json
@@ -61,7 +61,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22",
         "koishi-plugin-ffmpeg-path": "^2.0.0"
     },
     "peerDependenciesMeta": {

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22",
         "koishi-plugin-chatluna-agent": "^1.0.32"
     },
     "peerDependenciesMeta": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.21"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.22"
     }
 }


### PR DESCRIPTION
This pr fixes DeepSeek model context defaults and improves legacy agent feedback when tool calls are unavailable.

## Bug fixes
- Rename the generated DeepSeek instance variant to instant.
- Raise the fallback DeepSeek context limit to 1,000,000 tokens before applying the configured context ratio.
- Make legacy agent tool-call denial messages tell the model to try another tool and stop cleanly if tools remain unavailable.

## Validation
- yarn lint-fix (0 errors, existing max-len warnings only)