### PR TITLE
fix(adapter-gemini): remove outdated tool call warning

### DIFF
--- a/packages/adapter-gemini/src/locales/zh-CN.schema.yml
+++ b/packages/adapter-gemini/src/locales/zh-CN.schema.yml
@@ -12,14 +12,14 @@ $inner:
     - $desc: '模型配置'
       maxContextRatio: 最大上下文使用比例（0~1），控制可用的模型上下文窗口大小的最大百分比。例如 0.35 表示最多使用模型上下文的 35%。
       temperature: '回复的随机性程度，数值越高，回复越随机（范围：0~2）。'
-      googleSearch: '为模型启用谷歌搜索。（开启后将无法使用工具调用）'
+      googleSearch: '为模型启用谷歌搜索。'
       imageGeneration: '为模型启用图像生成。目前仅支持 `gemini-*-image-*` 和 `gemini-2.5-flash-image-preview` 模型。'
       thinkingBudget: '思考预算，范围：(-1~24576)，设置的数值越大，思考时花费的 Token 越多,-1 为动态思考。目前仅支持 gemini 2.5 系列模型。'
       groundingContentDisplay: '是否显示谷歌搜索结果。'
       imageModelSearch: '为图片生成模型启用搜索功能。开启后，支持搜索的图片模型将额外生成带 `-search` 后缀的变体（如 `gemini-3-pro-image-search`）。'
       includeThoughts: '是否获取模型的思考内容。'
-      codeExecution: '为模型启用代码执行工具。（开启后将无法使用工具调用）'
-      urlContext: '为模型启用 URL 内容获取工具。（开启后将无法使用工具调用）'
+      codeExecution: '为模型启用代码执行工具。'
+      urlContext: '为模型启用 URL 内容获取工具。'
       useCamelCaseSystemInstruction: 使用大写的 systemInstruction 而不是小写的 system_instruction
       useCamelCaseMediaFields: 使用大写的 inlineData 和 mimeType，而不是小写的 inline_data 和 mime_type
       nonStreaming: 强制不启用流式返回。开启后，将总是以非流式发起请求，即便配置了 stream 参数。


### PR DESCRIPTION
## 变更内容

- 移除 Gemini 适配器内置工具配置项中“开启后将无法使用工具调用”的过期中文提示。
- 涉及 `googleSearch`、`codeExecution`、`urlContext` 三个配置说明。

## 说明

- 当前已经支持内置工具和自定义工具同时启用，原提示不再准确。
- 仅修改本地化文案，不涉及功能逻辑。

## 校验

- 未运行构建：本次仅修改 YAML 本地化文案。
