### PR TITLE
fix(agent): avoid using trigger requestId as platform message id

### DIFF
--- a/packages/extension-agent/src/trigger/executor.ts
+++ b/packages/extension-agent/src/trigger/executor.ts
@@ -306,8 +306,7 @@ export class ChatLunaAgentTriggerExecutor {
             if ('result' in routed) return { result: routed.result }
             session = buildVirtualSession(routed.bot, parsed.routing, {
                 message: action.message,
-                messageName: action.messageName,
-                requestId
+                messageName: action.messageName
             })
         } else {
             const routed = resolveBot(
@@ -319,8 +318,7 @@ export class ChatLunaAgentTriggerExecutor {
             if ('result' in routed) return { result: routed.result }
             session = buildVirtualSession(routed.bot, target as WakeupRouting, {
                 message: action.message,
-                messageName: action.messageName,
-                requestId
+                messageName: action.messageName
             })
         }
 
@@ -447,7 +445,6 @@ export class ChatLunaAgentTriggerExecutor {
                     },
                     {
                         message: getMessageContent(reply.content),
-                        requestId: session.messageId,
                         messageName: action.messageName
                     }
                 )

--- a/packages/extension-agent/src/trigger/session.ts
+++ b/packages/extension-agent/src/trigger/session.ts
@@ -6,7 +6,7 @@ import type { WakeupAction, WakeupRouting } from '../types'
 export function buildVirtualSession(
     bot: Session['bot'],
     routing: WakeupRouting,
-    action: Pick<WakeupAction, 'message' | 'messageName' | 'requestId'>
+    action: Pick<WakeupAction, 'message' | 'messageName'>
 ) {
     const event: Partial<Universal.Event> = {
         type: 'message',
@@ -23,7 +23,6 @@ export function buildVirtualSession(
             name: routing.username ?? action.messageName ?? 'trigger'
         },
         message: {
-            id: action.requestId,
             content: getMessageContent(action.message),
             elements:
                 typeof action.message === 'string'

--- a/packages/extension-agent/tests/trigger_session.spec.ts
+++ b/packages/extension-agent/tests/trigger_session.spec.ts
@@ -15,7 +15,6 @@ describe('buildVirtualSession', () => {
                 isDirect: false
             },
             {
-                requestId: 'req',
                 messageName: 'trigger',
                 message: [
                     { type: 'text', text: 'hello' },
@@ -39,7 +38,6 @@ describe('buildVirtualSession', () => {
                     name: string
                 }
                 message: {
-                    id: string
                     content: string
                     elements: Array<{ type: string }>
                 }
@@ -53,7 +51,7 @@ describe('buildVirtualSession', () => {
         expect(event.event.channel.type).to.equal(0)
         expect(event.event.user.id).to.equal('user')
         expect(event.event.user.name).to.equal('trigger')
-        expect(event.event.message.id).to.equal('req')
+        expect(event.event.message).to.not.have.property('id')
         expect(event.event.message.content).to.equal('hello')
         expect(event.event.message.elements).to.have.length(2)
         expect(event.event.message.elements[0].type).to.equal('text')
@@ -73,7 +71,6 @@ describe('buildVirtualSession', () => {
                 isDirect: false
             },
             {
-                requestId: 'req',
                 message: 'hello'
             }
         ) as {
@@ -116,7 +113,6 @@ describe('buildVirtualSession', () => {
                 isDirect: true
             },
             {
-                requestId: 'req',
                 message: 'hello'
             }
         ) as {


### PR DESCRIPTION
## Summary

Avoid exposing Agent Trigger's internal `requestId` as a platform message id in virtual sessions.

Previously, virtual trigger sessions set `event.message.id` from `requestId`, which could be mapped to `session.messageId` and later treated by adapters as a real platform message reference.

## Changes

- Stop setting `event.message.id` in `buildVirtualSession()`.
- Stop passing `requestId` into virtual session construction.
- Update trigger session tests.

## Verification

- `mocha packages/extension-agent/tests/trigger_session.spec.ts`
- `tsc -p packages/extension-agent/tsconfig.json --noEmit`
- `corepack yarn fast-build extension-agent`