### PR TITLE
fix(extension-usage): namespace token command

### DIFF
--- a/packages/extension-usage/package.json
+++ b/packages/extension-usage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-usage",
     "description": "Usage records for ChatLuna model calls",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-usage/src/index.ts
+++ b/packages/extension-usage/src/index.ts
@@ -76,11 +76,11 @@ class ChatLunaUsageService extends DataService<ChatLunaUsage.Payload> {
         })
 
         ctx.command(
-            'tokens [...args:string]',
+            'chatluna.tokens [...args:string]',
             '查看 ChatLuna 整体 token 消耗趋势',
             { authority: 1 }
         )
-            .alias('/tokens')
+            .alias('chatluna.usage', 'tokens')
             .option('day', '-d 按天统计')
             .option('week', '-w 按一周统计')
             .option('month', '-m 按一月统计')


### PR DESCRIPTION
This pr namespaces the usage token trend command under ChatLuna commands.

## Bug fixes
- Rename the primary token trend command to chatluna.tokens.
- Keep chatluna.usage and tokens aliases for compatibility.

## Other Changes
- Bump koishi-plugin-chatluna-usage to 1.0.3.

## Validation
- yarn lint-fix (0 errors, existing max-len warnings only)