### PR TITLE
fix(adapter-deepseek): set discovered context window

### DIFF
--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-deepseek-adapter",
     "description": "deepseek adapter for chatluna",
-    "version": "1.4.0-alpha.8",
+    "version": "1.4.0-alpha.9",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-deepseek/src/client.ts
+++ b/packages/adapter-deepseek/src/client.ts
@@ -80,6 +80,7 @@ export class DeepseekClient extends PlatformModelAndEmbeddingsClient<ClientConfi
                     return {
                         name: model,
                         type,
+                        maxTokens: 1_000_000,
                         capabilities:
                             type === ModelType.llm
                                 ? [ModelCapabilities.ToolCall]


### PR DESCRIPTION
This pr fixes DeepSeek model metadata for models returned by the provider API.

## Bug fixes
- Set the discovered DeepSeek model context window to 1,000,000 tokens.

## Other Changes
- Bump koishi-plugin-chatluna-deepseek-adapter to 1.4.0-alpha.9.

## Validation
- yarn lint-fix (0 errors, existing max-len warnings only)