### PR TITLE
fix(adapter): preserve discovered context windows

### DIFF
--- a/packages/adapter-deepseek/src/client.ts
+++ b/packages/adapter-deepseek/src/client.ts
@@ -115,6 +115,7 @@ export class DeepseekClient extends PlatformModelAndEmbeddingsClient<ClientConfi
                 modelInfo: info,
                 requester: this._requester,
                 model,
+                modelMaxContextSize: info.maxTokens,
                 maxTokenLimit: Math.floor(
                     (info.maxTokens || 1_000_000) * this._config.maxContextRatio
                 ),

--- a/packages/adapter-doubao/src/client.ts
+++ b/packages/adapter-doubao/src/client.ts
@@ -163,6 +163,7 @@ export class DouBaoClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
                 modelInfo: info,
                 requester: this._requester,
                 model,
+                modelMaxContextSize: info.maxTokens,
                 maxTokenLimit: Math.floor(
                     (info.maxTokens || 100_000) * this._config.maxContextRatio
                 ),

--- a/packages/shared-adapter/src/client.ts
+++ b/packages/shared-adapter/src/client.ts
@@ -128,7 +128,7 @@ export function getModelMaxContextSize(info: ModelInfo): number {
         'gemini-3.0-pro': 1_097_152,
         'gemini-3.1-pro': 1_097_152,
         'gemini-2.0': 2097152,
-        deepseek: 128000,
+        deepseek: 1_000_000,
         'llama3.1': 128000,
         'command-r-plus': 128000,
         'moonshot-v1-8k': 8192,


### PR DESCRIPTION
This pr preserves discovered model context windows for DeepSeek and Doubao chat models.

## Bug Fixes
- Pass discovered DeepSeek model max context sizes into the chat model constructor.
- Pass discovered Doubao model max context sizes into the chat model constructor.
- Raise the shared DeepSeek fallback context window to match the current adapter default.

## Validation
- yarn lint-fix (0 errors, existing max-len warnings in packages/extension-agent/src/sub-agent/builtin.ts only)