### PR TITLE
refactor(extension-usage): 优化 token 用量图表渲染与命令说明

### DIFF
--- a/packages/extension-usage/src/index.ts
+++ b/packages/extension-usage/src/index.ts
@@ -272,7 +272,16 @@ class ChatLunaUsageService extends DataService<ChatLunaUsage.Payload> {
                 plugin = true
                 continue
             }
-            return '参数只能是 day、week、month、all（或简写 d/w/m/a），以及 plugin（或 p）。'
+            return [
+                '指令：chatluna tokens',
+                '查看 ChatLuna 整体 token 消耗趋势',
+                '可用的子指令有：',
+                '  chatluna tokens day 显示当日的token用量',
+                '  chatluna tokens week 显示最近一周的token用量',
+                '  chatluna tokens month 显示最近一个月的token用量',
+                '  chatluna tokens all 显示至今的token用量',
+                '  chatluna tokens plugin 显示各插件的token用量明细'
+            ].join('\n')
         }
 
         try {

--- a/packages/extension-usage/src/index.ts
+++ b/packages/extension-usage/src/index.ts
@@ -291,7 +291,8 @@ class ChatLunaUsageService extends DataService<ChatLunaUsage.Payload> {
                 report,
                 this.config.tokensTheme === 'auto'
                     ? 'light'
-                    : this.config.tokensTheme
+                    : this.config.tokensTheme,
+                this.config.tokensRenderMode
             )
             await session.send(
                 typeof image === 'string'

--- a/packages/extension-usage/src/index.ts
+++ b/packages/extension-usage/src/index.ts
@@ -2,7 +2,7 @@ import { resolve } from 'path'
 import { Context, h, Logger, Time } from 'koishi'
 import type { Session } from 'koishi'
 import { DataService } from '@koishijs/plugin-console'
-import { ChatLunaUsage, summary } from './utils'
+import { calculateTheme, ChatLunaUsage, summary } from './utils'
 import type {} from 'koishi-plugin-puppeteer'
 import { renderTokenTrend } from './renderer'
 import { createTokenReport, formatTokenReport } from './tokens'
@@ -284,14 +284,18 @@ class ChatLunaUsageService extends DataService<ChatLunaUsage.Payload> {
             ].join('\n')
         }
 
+        let report: ChatLunaUsage.TokenReport
         try {
-            const report = await this.tokenReport(range, plugin)
-            await session.send(formatTokenReport(report))
+            report = await this.tokenReport(range, plugin)
+        } catch (e) {
+            logger.error(e)
+            return 'ChatLuna token 用量统计失败，请检查日志。'
+        }
 
+        try {
             const puppeteer = this.ctx.get('puppeteer')
             if (!puppeteer) {
-                await session.send('图表渲染需要启用 puppeteer 服务。')
-                return
+                return formatTokenReport(report)
             }
 
             const image = await renderTokenTrend(
@@ -299,7 +303,7 @@ class ChatLunaUsageService extends DataService<ChatLunaUsage.Payload> {
                 puppeteer,
                 report,
                 this.config.tokensTheme === 'auto'
-                    ? 'light'
+                    ? calculateTheme()
                     : this.config.tokensTheme,
                 this.config.tokensRenderMode
             )
@@ -310,7 +314,7 @@ class ChatLunaUsageService extends DataService<ChatLunaUsage.Payload> {
             )
         } catch (e) {
             logger.error(e)
-            return 'ChatLuna token 用量统计失败，请检查日志。'
+            return formatTokenReport(report)
         }
     }
 
@@ -433,16 +437,11 @@ class ChatLunaUsageService extends DataService<ChatLunaUsage.Payload> {
                     row.usageMetadata.output_token_details?.reasoning ?? 0
             }))
             .sort((a, b) => {
-                const left = a[query.listSortBy] as unknown
-                const right = b[query.listSortBy] as unknown
+                const left = a[query.listSortBy]
+                const right = b[query.listSortBy]
                 let diff: number
                 if (left instanceof Date && right instanceof Date) {
                     diff = +left - +right
-                } else if (
-                    typeof left === 'string' &&
-                    typeof right === 'string'
-                ) {
-                    diff = left.localeCompare(right)
                 } else {
                     diff = Number(left) - Number(right)
                 }

--- a/packages/extension-usage/src/renderer.tsx
+++ b/packages/extension-usage/src/renderer.tsx
@@ -13,16 +13,29 @@ type RenderTheme = Exclude<ChatLunaUsage.TokenTheme, 'auto'>
 
 const CSS = `
 :root {
-    --bg-stage: #f8fafc;
-    --bg-card: #ffffff;
-    --text-primary: #0f172a;
-    --text-secondary: #334155;
-    --text-muted: #4b5563;
-    --border-color: #cbd5e1;
-    --grid-line: #cbd5e1;
-    --color-total: #4f46e5;
-    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -2px rgba(0, 0, 0, 0.05);
+    --bg-paper: #fff8ea;
+    --bg-paper-soft: #f9ebd2;
+    --bg-paper-row: #fff1d7;
+    --bg-paper-line: rgba(122, 82, 38, 0.025);
+    --bg-paper-dot: rgba(255, 255, 255, 0.65);
+    --bg-paper-glow: rgba(255, 255, 255, 0.72);
+    --bg-legend: rgba(255, 242, 216, 0.78);
+    --bg-row: rgba(255, 244, 221, 0.78);
+    --bg-row-track: rgba(165, 128, 82, 0.22);
+    --text-primary: #3d3024;
+    --text-secondary: #6f5b45;
+    --text-muted: #9a7d5e;
+    --border-color: #e7cfaa;
+    --grid-line: #dcc49f;
+    --color-total: #c94f72;
+    --total-shadow: rgba(201, 79, 114, 0.24);
+    --edge-shade: rgba(157, 110, 58, 0.07);
+    --row-border: rgba(218, 183, 132, 0.42);
+    --legend-border: rgba(212, 178, 128, 0.62);
+    --bar-shadow: rgba(88, 56, 27, 0.16);
+    --shadow-paper: 0 22px 46px -28px rgba(107, 72, 36, 0.62), 0 8px 20px -14px rgba(77, 48, 20, 0.42);
+    --shadow-lift: 0 18px 28px -20px rgba(93, 58, 25, 0.48);
+    --shadow-hover: 0 20px 28px -20px rgba(93, 58, 25, 0.58);
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
     color-scheme: light;
 }
@@ -33,79 +46,150 @@ const CSS = `
 
 body {
     margin: 0;
-    background: var(--bg-stage);
+    background: transparent;
 }
 
 .stage {
-    display: inline-flex;
-    flex-direction: column;
-    gap: 16px;
-    padding: 20px;
-    background: var(--bg-stage);
+    position: relative;
+    display: inline-block;
+    width: 1000px;
+    padding: 32px 38px 34px;
+    background:
+        radial-gradient(circle at 18% 20%, var(--bg-paper-dot) 0 1px, transparent 1px 9px),
+        linear-gradient(145deg, var(--bg-paper-glow), transparent 36%),
+        var(--bg-paper);
+    border: 1px solid var(--border-color);
+    border-radius: 30px 22px 34px 26px;
+    box-shadow: var(--shadow-paper);
+    color: var(--text-primary);
+    overflow: hidden;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans SC", "Microsoft YaHei", sans-serif;
     -webkit-font-smoothing: antialiased;
 }
 
 .stage.theme-dark {
-    --bg-stage: #0f172a;
-    --bg-card: #1e293b;
-    --text-primary: #f8fafc;
-    --text-secondary: #cbd5e1;
-    --text-muted: #94a3b8;
-    --border-color: #475569;
-    --grid-line: #475569;
-    --color-total: #818cf8;
-    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
-    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4), 0 2px 4px -2px rgba(0, 0, 0, 0.4);
+    --bg-paper: #1b2436;
+    --bg-paper-soft: #27334b;
+    --bg-paper-row: #222e44;
+    --bg-paper-line: rgba(255, 235, 205, 0.035);
+    --bg-paper-dot: rgba(255, 241, 209, 0.08);
+    --bg-paper-glow: rgba(255, 235, 197, 0.1);
+    --bg-legend: rgba(41, 52, 75, 0.88);
+    --bg-row: rgba(36, 47, 68, 0.86);
+    --bg-row-track: rgba(223, 189, 137, 0.16);
+    --text-primary: #fff0d8;
+    --text-secondary: #dec69f;
+    --text-muted: #b5966a;
+    --border-color: #725d3e;
+    --grid-line: #695944;
+    --color-total: #f2c66d;
+    --total-shadow: rgba(242, 198, 109, 0.3);
+    --edge-shade: rgba(255, 211, 144, 0.08);
+    --row-border: rgba(153, 123, 82, 0.44);
+    --legend-border: rgba(153, 123, 82, 0.55);
+    --bar-shadow: rgba(0, 0, 0, 0.24);
+    --shadow-paper: 0 28px 52px -28px rgba(0, 0, 0, 0.62), 0 8px 20px -12px rgba(0, 0, 0, 0.42);
+    --shadow-lift: 0 20px 30px -18px rgba(0, 0, 0, 0.42);
+    --shadow-hover: 0 22px 30px -18px rgba(0, 0, 0, 0.52);
     color-scheme: dark;
 }
 
-.card {
+.stage::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+        linear-gradient(90deg, var(--edge-shade), transparent 12%, transparent 86%, var(--edge-shade)),
+        repeating-linear-gradient(0deg, var(--bg-paper-line) 0 1px, transparent 1px 7px);
+    mix-blend-mode: multiply;
+}
+
+.paper-content {
     position: relative;
-    width: 1000px;
-    padding: 24px;
-    background: var(--bg-card);
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
-    box-shadow: var(--shadow-sm);
-    color: var(--text-primary);
+    z-index: 1;
 }
 
-.card-header {
+.hero-header {
     display: flex;
+    align-items: center;
     justify-content: space-between;
-    align-items: flex-start;
-    border-bottom: 1px solid var(--border-color);
-    padding-bottom: 16px;
-    margin-bottom: 20px;
+    gap: 24px;
+    margin-bottom: 24px;
 }
 
-.card-title-group h1 {
+.hero-title {
     margin: 0;
-    font-size: 20px;
-    font-weight: 600;
-    letter-spacing: -0.025em;
+    font-size: 28px;
+    line-height: 1.18;
+    font-weight: 800;
+    letter-spacing: 0;
     color: var(--text-primary);
 }
 
-.card-subtitle {
-    margin: 4px 0 0;
+.time-strip {
+    display: inline-grid;
+    grid-template-columns: auto auto auto auto;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 15px;
+    background: var(--bg-paper-soft);
+    border: 1px solid var(--border-color);
+    border-radius: 999px 22px 999px 22px;
+    box-shadow: var(--shadow-lift);
+    transform: rotate(0.35deg);
+}
+
+.time-label {
     color: var(--text-muted);
+    font-size: 12px;
+    font-weight: 700;
+}
+
+.time-value,
+.time-sep {
+    color: var(--text-secondary);
     font-size: 13px;
+    font-family: var(--font-mono);
+    font-weight: 700;
+    font-style: normal;
 }
 
 .metrics-grid {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
-    gap: 16px;
-    margin-bottom: 20px;
+    gap: 12px;
+    margin-bottom: 24px;
 }
 
 .metric-item {
+    position: relative;
     border: 1px solid var(--border-color);
-    border-radius: 6px;
-    padding: 16px;
-    background: var(--bg-card);
+    border-radius: 18px 14px 20px 13px;
+    padding: 15px 16px 16px;
+    background: var(--bg-paper-row);
+    box-shadow: var(--shadow-lift);
+    transition:
+        transform 180ms ease,
+        box-shadow 180ms ease;
+}
+
+.metric-item:nth-child(2n) {
+    transform: rotate(0.25deg);
+}
+
+.metric-item:nth-child(2n + 1) {
+    transform: rotate(-0.2deg);
+}
+
+.metric-item:hover {
+    transform: translateY(-3px) rotate(0deg);
+    box-shadow: var(--shadow-hover);
+}
+
+.metric-item:active {
+    transform: translateY(1px) rotate(0deg);
+    box-shadow: 0 12px 20px -18px rgba(93, 58, 25, 0.46);
 }
 
 .metric-label {
@@ -118,18 +202,17 @@ body {
 
 .metric-value {
     margin-top: 8px;
-    font-size: 24px;
-    font-weight: 600;
+    font-size: 25px;
+    font-weight: 800;
     font-family: var(--font-mono);
     color: var(--text-primary);
     font-variant-numeric: tabular-nums;
 }
 
 .chart-container {
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    padding: 20px;
-    background: var(--bg-card);
+    padding: 22px 0 18px;
+    margin: 4px 0 2px;
+    background: transparent;
 }
 
 .trend-chart {
@@ -169,34 +252,59 @@ body {
 
 .line-total {
     stroke: var(--color-total);
+    filter: drop-shadow(0 3px 3px var(--total-shadow));
 }
 
 .dot-total {
-    fill: var(--bg-card);
+    fill: var(--bg-paper);
     stroke-width: 2;
     stroke: var(--color-total);
 }
 
 .dot-last.dot-total {
     fill: var(--color-total);
-    stroke: var(--bg-card);
+    stroke: var(--bg-paper);
+}
+
+.bar-piece {
+    filter: drop-shadow(0 4px 4px var(--bar-shadow));
+}
+
+.bar-outline {
+    stroke: var(--row-border);
 }
 
 .chart-legend {
     display: flex;
+    flex-wrap: wrap;
     justify-content: center;
-    margin-top: 16px;
-    padding-top: 16px;
-    border-top: 1px solid var(--border-color);
+    gap: 8px;
+    margin-top: 12px;
 }
 
 .legend-item {
     display: inline-flex;
     align-items: center;
-    margin: 0 16px;
+    padding: 6px 10px;
+    background: var(--bg-legend);
+    border: 1px solid var(--legend-border);
+    border-radius: 999px;
+    box-shadow: 0 10px 16px -14px rgba(93, 58, 25, 0.38);
     font-size: 12px;
     font-weight: 600;
     color: var(--text-secondary);
+    transition:
+        transform 160ms ease,
+        box-shadow 160ms ease;
+}
+
+.legend-item:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 20px -16px rgba(93, 58, 25, 0.5);
+}
+
+.legend-item:active {
+    transform: translateY(1px);
 }
 
 .legend-color-indicator {
@@ -212,6 +320,10 @@ body {
     line-height: 0;
 }
 
+.legend-total-indicator {
+    border-radius: 50%;
+}
+
 .empty-chart {
     display: grid;
     height: 320px;
@@ -222,28 +334,87 @@ body {
     border-radius: 6px;
 }
 
+.plugin-section {
+    margin-top: 24px;
+    padding-top: 22px;
+    border-top: 2px dashed rgba(180, 135, 82, 0.38);
+}
+
+.section-title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+}
+
+.section-title-row h2 {
+    margin: 0;
+    font-size: 22px;
+    line-height: 1.2;
+    color: var(--text-primary);
+}
+
+.sort-chip {
+    padding: 7px 12px;
+    color: var(--text-secondary);
+    background: var(--bg-paper-soft);
+    border: 1px solid var(--border-color);
+    border-radius: 999px 18px 999px 18px;
+    box-shadow: 0 10px 18px -16px rgba(93, 58, 25, 0.45);
+    font-size: 12px;
+    font-weight: 700;
+}
+
 .plugin-table {
     width: 100%;
-    border-collapse: collapse;
-    margin-top: 8px;
+    border-collapse: separate;
+    border-spacing: 0 8px;
+    margin-top: 0;
 }
 
 .plugin-table th,
 .plugin-table td {
-    padding: 12px 16px;
+    padding: 11px 16px;
     text-align: left;
-    border-bottom: 1px solid var(--border-color);
     font-size: 13px;
 }
 
 .plugin-table th {
     font-weight: 600;
     color: var(--text-secondary);
-    background-color: var(--bg-stage);
+    border-bottom: 1px solid rgba(180, 135, 82, 0.35);
 }
 
 .plugin-table td {
+    background: var(--bg-row);
+    border-top: 1px solid var(--row-border);
+    border-bottom: 1px solid var(--row-border);
     color: var(--text-primary);
+}
+
+.plugin-table td:first-child {
+    border-left: 1px solid var(--row-border);
+    border-radius: 16px 0 0 14px;
+}
+
+.plugin-table td:last-child {
+    border-right: 1px solid var(--row-border);
+    border-radius: 0 14px 16px 0;
+}
+
+.plugin-table tbody tr {
+    transition:
+        transform 180ms ease,
+        filter 180ms ease;
+}
+
+.plugin-table tbody tr:hover {
+    transform: translateY(-2px);
+    filter: drop-shadow(0 10px 10px rgba(93, 58, 25, 0.14));
+}
+
+.plugin-table tbody tr:active {
+    transform: translateY(1px);
 }
 
 .plugin-name-cell {
@@ -273,7 +444,7 @@ body {
     width: 100px;
     height: 6px;
     border-radius: 3px;
-    background: var(--grid-line);
+    background: var(--bg-row-track);
     overflow: hidden;
     margin-right: 12px;
 }
@@ -301,15 +472,15 @@ body {
 `
 
 const MODEL_COLORS = [
-    '#4f46e5',
-    '#0891b2',
-    '#ea580c',
-    '#16a34a',
-    '#9333ea',
-    '#db2777',
-    '#059669',
-    '#2563eb',
-    '#d97706'
+    '#7d82f3',
+    '#1aa6b7',
+    '#f47b3f',
+    '#3ab86a',
+    '#a967e8',
+    '#df6f9f',
+    '#34a889',
+    '#4d91df',
+    '#d99a38'
 ]
 
 function formatNum(value: number) {
@@ -507,6 +678,7 @@ function chart(
                                 currentY = y
                                 return (
                                     <rect
+                                        class="bar-piece"
                                         x={x - barWidth / 2}
                                         y={y}
                                         width={barWidth}
@@ -518,12 +690,12 @@ function chart(
                             })}
                             {groupHeight > 0 && (
                                 <rect
+                                    class="bar-outline"
                                     x={x - barWidth / 2}
                                     y={groupY}
                                     width={barWidth}
                                     height={groupHeight}
                                     fill="none"
-                                    stroke="var(--border-color)"
                                     stroke-width="1"
                                     opacity="0.6"
                                 />
@@ -602,15 +774,10 @@ function pluginCard(plugins?: ChatLunaUsage.TokenReport['plugins']) {
     }
 
     return (
-        <section class="card">
-            <div
-                class="card-header"
-                style="border-bottom: 0; padding-bottom: 8px; margin-bottom: 12px;"
-            >
-                <div class="card-title-group">
-                    <h1>各插件用量明细</h1>
-                    <p class="card-subtitle">按 Token 占比降序排列</p>
-                </div>
+        <section class="plugin-section">
+            <div class="section-title-row">
+                <h2>各插件用量明细</h2>
+                <span class="sort-chip">按 Token 占比降序排列</span>
             </div>
             <table class="plugin-table">
                 <thead>
@@ -692,11 +859,11 @@ function renderLegend(
     const showBar = mode === 'both' || mode === 'bar'
 
     return (
-        <div class="chart-legend" style="flex-wrap: wrap; gap: 8px 0;">
+        <div class="chart-legend">
             {showLine && (
                 <div class="legend-item">
                     <span
-                        class="legend-color-indicator"
+                        class="legend-color-indicator legend-total-indicator"
                         style="--legend-color:var(--color-total)"
                     >
                         {' '}
@@ -740,14 +907,20 @@ function pageHtml(
                 </head>
                 <body>
                     <div class={`stage theme-${theme}`}>
-                        <main class="card">
-                            <header class="card-header">
-                                <div class="card-title-group">
-                                    <h1>Chatluna Token 消耗分析</h1>
-                                    <p class="card-subtitle">
-                                        时间跨度：{formatDate(data.start)} 至{' '}
+                        <main class="paper-content">
+                            <header class="hero-header">
+                                <h1 class="hero-title">
+                                    Chatluna Token 消耗分析
+                                </h1>
+                                <div class="time-strip">
+                                    <span class="time-label">统计周期</span>
+                                    <strong class="time-value">
+                                        {formatDate(data.start)}
+                                    </strong>
+                                    <i class="time-sep">至</i>
+                                    <strong class="time-value">
                                         {formatDate(data.end)}
-                                    </p>
+                                    </strong>
                                 </div>
                             </header>
 
@@ -788,8 +961,8 @@ function pageHtml(
                                 {chart(data.points, mode)}
                                 {renderLegend(data.points, mode)}
                             </section>
+                            {pluginCard(data.plugins)}
                         </main>
-                        {pluginCard(data.plugins)}
                     </div>
                 </body>
             </html>
@@ -808,8 +981,8 @@ export async function renderTokenTrend(
     try {
         page = await puppeteer.page()
         await page.setViewport({
-            width: 1040,
-            height: 820,
+            width: 1080,
+            height: 900,
             deviceScaleFactor: 2
         })
         await page.setContent(pageHtml(data, theme, mode), {

--- a/packages/extension-usage/src/renderer.tsx
+++ b/packages/extension-usage/src/renderer.tsx
@@ -483,6 +483,27 @@ const MODEL_COLORS = [
     '#d99a38'
 ]
 
+const CHART = {
+    width: 952,
+    height: 320,
+    left: 60,
+    right: 20,
+    top: 20,
+    bottom: 48,
+    gridLines: 5,
+    maxLabels: 12,
+    maxModels: 5,
+    minBarWidth: 3,
+    maxBarWidth: 28
+} as const
+
+const CURVE_FACTOR = 0.4
+const FLAT_Y_THRESHOLD = 0.1
+const MAX_PLUGIN_ROWS = 6
+const OTHER_COLOR = '#94a3b8'
+const OTHER_MODEL_NAME = '其他模型'
+const OTHER_PLUGIN_NAME = '其他插件'
+
 function formatNum(value: number) {
     if (value >= 1000000) {
         return (value / 1000000).toFixed(2) + 'M'
@@ -534,14 +555,13 @@ function monotonePath(pts: Coord[]) {
     let d = `M${pts[0].x},${pts[0].y}`
     for (let i = 0; i < n - 1; i++) {
         const dx = h[i]
-        const factor = 0.4
 
-        const c1x = pts[i].x + dx * factor
-        let c1y = pts[i].y + t[i] * dx * factor
-        const c2x = pts[i + 1].x - dx * factor
-        let c2y = pts[i + 1].y - t[i + 1] * dx * factor
+        const c1x = pts[i].x + dx * CURVE_FACTOR
+        let c1y = pts[i].y + t[i] * dx * CURVE_FACTOR
+        const c2x = pts[i + 1].x - dx * CURVE_FACTOR
+        let c2y = pts[i + 1].y - t[i + 1] * dx * CURVE_FACTOR
 
-        if (Math.abs(pts[i].y - pts[i + 1].y) < 0.1) {
+        if (Math.abs(pts[i].y - pts[i + 1].y) < FLAT_Y_THRESHOLD) {
             c1y = pts[i].y
             c2y = pts[i + 1].y
         } else if (pts[i].y < pts[i + 1].y) {
@@ -571,206 +591,249 @@ function getTopModels(points: ChatLunaUsage.TokenPoint[]) {
         .sort((a, b) => b[1] - a[1])
         .map(([model]) => model)
 
-    const topModels = sortedModels.slice(0, 5)
+    const topModels = sortedModels.slice(0, CHART.maxModels)
 
     const colorMap: Record<string, string> = {}
     topModels.forEach((model, i) => {
         colorMap[model] = MODEL_COLORS[i % MODEL_COLORS.length]
     })
-    if (sortedModels.length > 5) {
-        colorMap['其他模型'] = '#94a3b8'
+    if (sortedModels.length > CHART.maxModels) {
+        colorMap[OTHER_MODEL_NAME] = OTHER_COLOR
     }
     return { topModels, colorMap }
 }
 
-function chart(
-    points: ChatLunaUsage.TokenPoint[],
-    mode: ChatLunaUsage.TokenRenderMode = 'both'
-) {
-    if (!points.length) return <div class="empty-chart">暂无用量数据</div>
+type ModelInfo = ReturnType<typeof getTopModels>
 
-    const [width, height, left, right, top, bottom] = [952, 320, 60, 20, 20, 48]
-    const plotWidth = width - left - right
-    const plotHeight = height - top - bottom
-    const baseline = top + plotHeight
-    const max = Math.max(1, ...points.flatMap((p) => [p.tokens]))
-
-    const { topModels, colorMap } = getTopModels(points)
+function getChartLayout(points: ChatLunaUsage.TokenPoint[]) {
+    const plotWidth = CHART.width - CHART.left - CHART.right
+    const plotHeight = CHART.height - CHART.top - CHART.bottom
+    const baseline = CHART.top + plotHeight
+    const max = Math.max(1, ...points.map((p) => p.tokens))
     const stepX =
         points.length > 1 ? plotWidth / (points.length - 1) : plotWidth
-    const barWidth = Math.max(3, Math.min(28, stepX * 0.5))
-
+    const barWidth = Math.max(
+        CHART.minBarWidth,
+        Math.min(CHART.maxBarWidth, stepX * 0.5)
+    )
     const safePadding = barWidth / 2 + 4
     const drawWidth = plotWidth - safePadding * 2
-
     const totalCoords = points.map((point, idx) => ({
         x:
             points.length === 1
-                ? left + plotWidth / 2
-                : left + safePadding + (drawWidth * idx) / (points.length - 1),
+                ? CHART.left + plotWidth / 2
+                : CHART.left +
+                  safePadding +
+                  (drawWidth * idx) / (points.length - 1),
         y: baseline - (point.tokens / max) * plotHeight,
         point
     }))
 
-    const totalLine = monotonePath(totalCoords)
+    return {
+        plotWidth,
+        plotHeight,
+        baseline,
+        max,
+        barWidth,
+        safePadding,
+        drawWidth,
+        totalCoords,
+        totalLine: monotonePath(totalCoords),
+        stepLabel: Math.max(1, Math.ceil(points.length / CHART.maxLabels))
+    }
+}
 
-    const maxLabels = 12
-    const stepLabel = Math.max(1, Math.ceil(points.length / maxLabels))
+type ChartLayout = ReturnType<typeof getChartLayout>
+
+function getBarItems(point: ChatLunaUsage.TokenPoint, info: ModelInfo) {
+    const items: { name: string; val: number }[] = []
+    let otherVal = 0
+
+    for (const [name, val] of Object.entries(point.models)) {
+        if (val <= 0) continue
+        if (info.topModels.includes(name)) {
+            items.push({ name, val })
+        } else {
+            otherVal += val
+        }
+    }
+
+    items.sort(
+        (a, b) =>
+            info.topModels.indexOf(a.name) - info.topModels.indexOf(b.name)
+    )
+
+    if (otherVal > 0) {
+        items.push({ name: OTHER_MODEL_NAME, val: otherVal })
+    }
+
+    return items
+}
+
+function renderGrid(layout: ChartLayout) {
+    const last = CHART.gridLines - 1
 
     return (
-        <svg class="trend-chart" viewbox={`0 0 ${width} ${height}`} role="img">
-            <g class="grid">
-                {Array.from({ length: 5 }, (_, idx) => {
-                    const y = top + (plotHeight * idx) / 4
-                    const value = Math.round(max - (max * idx) / 4)
-                    return [
-                        <line x1={left} y1={y} x2={width - right} y2={y} />,
-                        <text x={left - 12} y={y + 4}>
-                            {formatNum(value)}
-                        </text>
-                    ]
-                })}
-            </g>
+        <g class="grid">
+            {Array.from({ length: CHART.gridLines }, (_, idx) => {
+                const y = CHART.top + (layout.plotHeight * idx) / last
+                const value = Math.round(layout.max - (layout.max * idx) / last)
+                return [
+                    <line
+                        x1={CHART.left}
+                        y1={y}
+                        x2={CHART.width - CHART.right}
+                        y2={y}
+                    />,
+                    <text x={CHART.left - 12} y={y + 4}>
+                        {formatNum(value)}
+                    </text>
+                ]
+            })}
+        </g>
+    )
+}
 
-            {(mode === 'both' || mode === 'bar') &&
-                points.map((point, idx) => {
-                    const x =
-                        points.length === 1
-                            ? left + plotWidth / 2
-                            : left +
-                              safePadding +
-                              (drawWidth * idx) / (points.length - 1)
+function renderBars(
+    points: ChatLunaUsage.TokenPoint[],
+    info: ModelInfo,
+    layout: ChartLayout
+) {
+    return points.map((point, idx) => {
+        const x =
+            points.length === 1
+                ? CHART.left + layout.plotWidth / 2
+                : CHART.left +
+                  layout.safePadding +
+                  (layout.drawWidth * idx) / (points.length - 1)
+        const items = getBarItems(point, info)
+        let currentY = layout.baseline
+        const groupHeight = items.reduce(
+            (sum, item) => sum + (item.val / layout.max) * layout.plotHeight,
+            0
+        )
+        const groupY = layout.baseline - groupHeight
 
-                    const activeModels: { name: string; val: number }[] = []
-                    let otherVal = 0
-
-                    for (const [mName, val] of Object.entries(point.models)) {
-                        if (val <= 0) continue
-                        if (topModels.includes(mName)) {
-                            activeModels.push({ name: mName, val })
-                        } else {
-                            otherVal += val
-                        }
-                    }
-
-                    activeModels.sort(
-                        (a, b) =>
-                            topModels.indexOf(a.name) -
-                            topModels.indexOf(b.name)
-                    )
-
-                    if (otherVal > 0) {
-                        activeModels.push({ name: '其他模型', val: otherVal })
-                    }
-
-                    let currentY = baseline
-                    const groupHeight = activeModels.reduce(
-                        (sum, item) => sum + (item.val / max) * plotHeight,
-                        0
-                    )
-                    const groupY = baseline - groupHeight
-
+        return (
+            <g>
+                {items.map((item) => {
+                    const barHeight =
+                        (item.val / layout.max) * layout.plotHeight
+                    const y = currentY - barHeight
+                    currentY = y
                     return (
-                        <g>
-                            {activeModels.map((item) => {
-                                const barHeight = (item.val / max) * plotHeight
-                                const y = currentY - barHeight
-                                currentY = y
-                                return (
-                                    <rect
-                                        class="bar-piece"
-                                        x={x - barWidth / 2}
-                                        y={y}
-                                        width={barWidth}
-                                        height={barHeight}
-                                        fill={colorMap[item.name]}
-                                        opacity="0.85"
-                                    />
-                                )
-                            })}
-                            {groupHeight > 0 && (
-                                <rect
-                                    class="bar-outline"
-                                    x={x - barWidth / 2}
-                                    y={groupY}
-                                    width={barWidth}
-                                    height={groupHeight}
-                                    fill="none"
-                                    stroke-width="1"
-                                    opacity="0.6"
-                                />
-                            )}
-                        </g>
-                    )
-                })}
-
-            {(mode === 'both' || mode === 'line') && totalLine && (
-                <path class="line line-total" d={totalLine} />
-            )}
-
-            {mode === 'line' &&
-                totalCoords.map((c, idx) => {
-                    const last = idx === totalCoords.length - 1
-                    return (
-                        <circle
-                            class={last ? 'dot-total dot-last' : 'dot-total'}
-                            cx={c.x}
-                            cy={c.y}
-                            r={last ? 5.5 : 4}
+                        <rect
+                            class="bar-piece"
+                            x={x - layout.barWidth / 2}
+                            y={y}
+                            width={layout.barWidth}
+                            height={barHeight}
+                            fill={info.colorMap[item.name]}
+                            opacity="0.85"
                         />
                     )
                 })}
+                {groupHeight > 0 && (
+                    <rect
+                        class="bar-outline"
+                        x={x - layout.barWidth / 2}
+                        y={groupY}
+                        width={layout.barWidth}
+                        height={groupHeight}
+                        fill="none"
+                        stroke-width="1"
+                        opacity="0.6"
+                    />
+                )}
+            </g>
+        )
+    })
+}
 
-            {totalCoords.map((c, idx) => {
-                const shouldShowLabel =
-                    idx === 0 ||
-                    idx === totalCoords.length - 1 ||
-                    idx % stepLabel === 0
-                if (!shouldShowLabel) return null
+function renderLineDots(coords: Coord[]) {
+    return coords.map((c, idx) => {
+        const last = idx === coords.length - 1
+        return (
+            <circle
+                class={last ? 'dot-total dot-last' : 'dot-total'}
+                cx={c.x}
+                cy={c.y}
+                r={last ? 5.5 : 4}
+            />
+        )
+    })
+}
 
-                const parts = c.point.label.split(' ')
-                return (
-                    <text
-                        class="axis-x"
-                        x={c.x}
-                        y={height - (parts[1] ? 22 : 18)}
-                    >
-                        {parts[1]
-                            ? parts.map((part, pIdx) => (
-                                  <tspan x={c.x} dy={pIdx ? '13' : '0'}>
-                                      {part}
-                                  </tspan>
-                              ))
-                            : c.point.label}
-                    </text>
-                )
-            })}
+function renderAxisLabels(coords: Coord[], stepLabel: number) {
+    return coords.map((c, idx) => {
+        const shouldShowLabel =
+            idx === 0 || idx === coords.length - 1 || idx % stepLabel === 0
+        if (!shouldShowLabel) return null
+
+        const parts = c.point.label.split(' ')
+        return (
+            <text
+                class="axis-x"
+                x={c.x}
+                y={CHART.height - (parts[1] ? 22 : 18)}
+            >
+                {parts[1]
+                    ? parts.map((part, pIdx) => (
+                          <tspan x={c.x} dy={pIdx ? '13' : '0'}>
+                              {part}
+                          </tspan>
+                      ))
+                    : c.point.label}
+            </text>
+        )
+    })
+}
+
+function chart(
+    points: ChatLunaUsage.TokenPoint[],
+    info: ModelInfo,
+    mode: ChatLunaUsage.TokenRenderMode = 'both'
+) {
+    if (!points.length) return <div class="empty-chart">暂无用量数据</div>
+
+    const layout = getChartLayout(points)
+    const showLine = mode === 'both' || mode === 'line'
+    const showBar = mode === 'both' || mode === 'bar'
+
+    return (
+        <svg
+            class="trend-chart"
+            viewbox={`0 0 ${CHART.width} ${CHART.height}`}
+            role="img"
+        >
+            {renderGrid(layout)}
+            {showBar && renderBars(points, info, layout)}
+            {showLine && layout.totalLine && (
+                <path class="line line-total" d={layout.totalLine} />
+            )}
+            {mode === 'line' && renderLineDots(layout.totalCoords)}
+            {renderAxisLabels(layout.totalCoords, layout.stepLabel)}
         </svg>
     )
 }
 
-function pluginCard(plugins?: ChatLunaUsage.TokenReport['plugins']) {
+function pluginSection(plugins?: ChatLunaUsage.TokenReport['plugins']) {
     if (!plugins?.length) return ''
 
     const total = plugins.reduce((sum, p) => sum + p.tokens, 0) || 1
 
-    const maxDisplay = 6
-    let displayPlugins = plugins.slice(0, maxDisplay)
-    if (plugins.length > maxDisplay) {
-        const otherTokens = plugins
-            .slice(maxDisplay)
-            .reduce((sum, p) => sum + p.tokens, 0)
-        const otherCalls = plugins
-            .slice(maxDisplay)
-            .reduce((sum, p) => sum + p.calls, 0)
-        displayPlugins = [
-            ...displayPlugins,
-            {
-                source: '其他插件',
-                tokens: otherTokens,
-                calls: otherCalls
-            }
-        ]
+    let displayPlugins = plugins.slice(0, MAX_PLUGIN_ROWS)
+    if (plugins.length > MAX_PLUGIN_ROWS) {
+        const other = {
+            source: OTHER_PLUGIN_NAME,
+            tokens: 0,
+            calls: 0
+        }
+        for (const p of plugins.slice(MAX_PLUGIN_ROWS)) {
+            other.tokens += p.tokens
+            other.calls += p.calls
+        }
+        displayPlugins = [...displayPlugins, other]
     }
 
     return (
@@ -796,9 +859,9 @@ function pluginCard(plugins?: ChatLunaUsage.TokenReport['plugins']) {
                 </thead>
                 <tbody>
                     {displayPlugins.map((plugin, idx) => {
-                        const isOther = plugin.source === '其他插件'
+                        const isOther = plugin.source === OTHER_PLUGIN_NAME
                         const color = isOther
-                            ? '#94a3b8'
+                            ? OTHER_COLOR
                             : MODEL_COLORS[idx % MODEL_COLORS.length]
                         const ratio = (plugin.tokens / total) * 100
                         return (
@@ -851,10 +914,9 @@ function pluginCard(plugins?: ChatLunaUsage.TokenReport['plugins']) {
 }
 
 function renderLegend(
-    points: ChatLunaUsage.TokenPoint[],
+    info: ModelInfo,
     mode: ChatLunaUsage.TokenRenderMode = 'both'
 ) {
-    const { colorMap } = getTopModels(points)
     const showLine = mode === 'both' || mode === 'line'
     const showBar = mode === 'both' || mode === 'bar'
 
@@ -872,7 +934,7 @@ function renderLegend(
                 </div>
             )}
             {showBar &&
-                Object.entries(colorMap).map(([model, color]) => (
+                Object.entries(info.colorMap).map(([model, color]) => (
                     <div class="legend-item">
                         <span
                             class="legend-color-indicator"
@@ -892,6 +954,11 @@ function pageHtml(
     theme: RenderTheme,
     mode: ChatLunaUsage.TokenRenderMode = 'both'
 ) {
+    const info: ModelInfo =
+        mode === 'line'
+            ? { topModels: [], colorMap: {} }
+            : getTopModels(data.points)
+
     return (
         '<!doctype html>' +
         String(
@@ -958,10 +1025,10 @@ function pageHtml(
                             </section>
 
                             <section class="chart-container">
-                                {chart(data.points, mode)}
-                                {renderLegend(data.points, mode)}
+                                {chart(data.points, info, mode)}
+                                {renderLegend(info, mode)}
                             </section>
-                            {pluginCard(data.plugins)}
+                            {pluginSection(data.plugins)}
                         </main>
                     </div>
                 </body>

--- a/packages/extension-usage/src/renderer.tsx
+++ b/packages/extension-usage/src/renderer.tsx
@@ -13,29 +13,31 @@ type RenderTheme = Exclude<ChatLunaUsage.TokenTheme, 'auto'>
 
 const CSS = `
 :root {
-    --bg-paper: #fff8ea;
-    --bg-paper-soft: #f9ebd2;
-    --bg-paper-row: #fff1d7;
-    --bg-paper-line: rgba(122, 82, 38, 0.025);
+    --bg-paper: #f8fafc;
+    --bg-paper-soft: #f1f5f9;
+    --bg-paper-row: #e2e8f0;
+    --bg-paper-line: rgba(148, 163, 184, 0.025);
     --bg-paper-dot: rgba(255, 255, 255, 0.65);
     --bg-paper-glow: rgba(255, 255, 255, 0.72);
-    --bg-legend: rgba(255, 242, 216, 0.78);
-    --bg-row: rgba(255, 244, 221, 0.78);
-    --bg-row-track: rgba(165, 128, 82, 0.22);
-    --text-primary: #3d3024;
-    --text-secondary: #6f5b45;
-    --text-muted: #9a7d5e;
-    --border-color: #e7cfaa;
-    --grid-line: #dcc49f;
-    --color-total: #c94f72;
-    --total-shadow: rgba(201, 79, 114, 0.24);
-    --edge-shade: rgba(157, 110, 58, 0.07);
-    --row-border: rgba(218, 183, 132, 0.42);
-    --legend-border: rgba(212, 178, 128, 0.62);
-    --bar-shadow: rgba(88, 56, 27, 0.16);
-    --shadow-paper: 0 22px 46px -28px rgba(107, 72, 36, 0.62), 0 8px 20px -14px rgba(77, 48, 20, 0.42);
-    --shadow-lift: 0 18px 28px -20px rgba(93, 58, 25, 0.48);
-    --shadow-hover: 0 20px 28px -20px rgba(93, 58, 25, 0.58);
+    --bg-legend: rgba(241, 245, 249, 0.78);
+    --bg-row: rgba(241, 245, 249, 0.78);
+    --bg-row-hover: rgba(148, 163, 184, 0.05);
+    --bg-row-track: #e2e8f0;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --text-muted: #64748b;
+    --border-color: #cbd5e1;
+    --grid-line: #e2e8f0;
+    --color-total: #7e1671;
+    --color-input: #1772b4;
+    --color-output: #20894d;
+    --edge-shade: rgba(148, 163, 184, 0.08);
+    --row-border: rgba(203, 213, 225, 0.42);
+    --legend-border: rgba(203, 213, 225, 0.62);
+    --bar-shadow: transparent;
+    --shadow-paper: none;
+    --shadow-lift: none;
+    --shadow-hover: none;
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
     color-scheme: light;
 }
@@ -54,13 +56,7 @@ body {
     display: inline-block;
     width: 1000px;
     padding: 32px 38px 34px;
-    background:
-        radial-gradient(circle at 18% 20%, var(--bg-paper-dot) 0 1px, transparent 1px 9px),
-        linear-gradient(145deg, var(--bg-paper-glow), transparent 36%),
-        var(--bg-paper);
-    border: 1px solid var(--border-color);
-    border-radius: 30px 22px 34px 26px;
-    box-shadow: var(--shadow-paper);
+    background: var(--bg-paper);
     color: var(--text-primary);
     overflow: hidden;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans SC", "Microsoft YaHei", sans-serif;
@@ -68,30 +64,53 @@ body {
 }
 
 .stage.theme-dark {
-    --bg-paper: #1b2436;
-    --bg-paper-soft: #27334b;
-    --bg-paper-row: #222e44;
-    --bg-paper-line: rgba(255, 235, 205, 0.035);
-    --bg-paper-dot: rgba(255, 241, 209, 0.08);
-    --bg-paper-glow: rgba(255, 235, 197, 0.1);
-    --bg-legend: rgba(41, 52, 75, 0.88);
-    --bg-row: rgba(36, 47, 68, 0.86);
-    --bg-row-track: rgba(223, 189, 137, 0.16);
-    --text-primary: #fff0d8;
-    --text-secondary: #dec69f;
-    --text-muted: #b5966a;
-    --border-color: #725d3e;
-    --grid-line: #695944;
-    --color-total: #f2c66d;
-    --total-shadow: rgba(242, 198, 109, 0.3);
-    --edge-shade: rgba(255, 211, 144, 0.08);
-    --row-border: rgba(153, 123, 82, 0.44);
-    --legend-border: rgba(153, 123, 82, 0.55);
-    --bar-shadow: rgba(0, 0, 0, 0.24);
-    --shadow-paper: 0 28px 52px -28px rgba(0, 0, 0, 0.62), 0 8px 20px -12px rgba(0, 0, 0, 0.42);
-    --shadow-lift: 0 20px 30px -18px rgba(0, 0, 0, 0.42);
-    --shadow-hover: 0 22px 30px -18px rgba(0, 0, 0, 0.52);
+    --bg-paper: #1e293b;
+    --bg-paper-soft: #334155;
+    --bg-paper-row: #1e293b;
+    --bg-paper-line: rgba(255, 255, 255, 0.015);
+    --bg-paper-dot: rgba(255, 255, 255, 0.02);
+    --bg-paper-glow: rgba(255, 255, 255, 0.03);
+    --bg-legend: rgba(51, 65, 85, 0.88);
+    --bg-row: rgba(30, 41, 59, 0.86);
+    --bg-row-hover: rgba(255, 255, 255, 0.03);
+    --bg-row-track: #334155;
+    --text-primary: #f8fafc;
+    --text-secondary: #cbd5e1;
+    --text-muted: #94a3b8;
+    --border-color: #475569;
+    --grid-line: #334155;
+    --color-total: #c8709c;
+    --color-input: #4a9eda;
+    --color-output: #4ade80;
+    --edge-shade: rgba(255, 255, 255, 0.03);
+    --row-border: rgba(71, 85, 105, 0.44);
+    --legend-border: rgba(71, 85, 105, 0.55);
+    --bar-shadow: transparent;
+    --shadow-paper: none;
+    --shadow-lift: none;
+    --shadow-hover: none;
     color-scheme: dark;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    background: transparent;
+}
+
+.stage {
+    position: relative;
+    display: inline-block;
+    width: 1000px;
+    padding: 32px 38px 34px;
+    background: var(--bg-paper);
+    color: var(--text-primary);
+    overflow: hidden;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans SC", "Microsoft YaHei", sans-serif;
+    -webkit-font-smoothing: antialiased;
 }
 
 .stage::after {
@@ -99,10 +118,6 @@ body {
     position: absolute;
     inset: 0;
     pointer-events: none;
-    background:
-        linear-gradient(90deg, var(--edge-shade), transparent 12%, transparent 86%, var(--edge-shade)),
-        repeating-linear-gradient(0deg, var(--bg-paper-line) 0 1px, transparent 1px 7px);
-    mix-blend-mode: multiply;
 }
 
 .paper-content {
@@ -134,9 +149,7 @@ body {
     gap: 8px;
     padding: 10px 15px;
     background: var(--bg-paper-soft);
-    border: 1px solid var(--border-color);
-    border-radius: 999px 22px 999px 22px;
-    box-shadow: var(--shadow-lift);
+    border-radius: 10px;
     transform: rotate(0.35deg);
 }
 
@@ -155,58 +168,40 @@ body {
     font-style: normal;
 }
 
-.metrics-grid {
+.stats-row {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
-    gap: 12px;
     margin-bottom: 24px;
 }
 
-.metric-item {
-    position: relative;
-    border: 1px solid var(--border-color);
-    border-radius: 18px 14px 20px 13px;
-    padding: 15px 16px 16px;
-    background: var(--bg-paper-row);
-    box-shadow: var(--shadow-lift);
-    transition:
-        transform 180ms ease,
-        box-shadow 180ms ease;
+.stat-cell {
+    padding: 0 20px;
 }
 
-.metric-item:nth-child(2n) {
-    transform: rotate(0.25deg);
+.stat-cell:first-child {
+    padding-left: 0;
 }
 
-.metric-item:nth-child(2n + 1) {
-    transform: rotate(-0.2deg);
+.stat-cell + .stat-cell {
+    border-left: 1px solid var(--edge-shade);
 }
 
-.metric-item:hover {
-    transform: translateY(-3px) rotate(0deg);
-    box-shadow: var(--shadow-hover);
-}
-
-.metric-item:active {
-    transform: translateY(1px) rotate(0deg);
-    box-shadow: 0 12px 20px -18px rgba(93, 58, 25, 0.46);
-}
-
-.metric-label {
-    font-size: 12px;
-    font-weight: 500;
+.stat-label {
+    font-size: 11px;
+    font-weight: 600;
     color: var(--text-muted);
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.08em;
 }
 
-.metric-value {
-    margin-top: 8px;
-    font-size: 25px;
-    font-weight: 800;
+.stat-value {
+    margin-top: 6px;
+    font-size: 22px;
+    font-weight: 700;
     font-family: var(--font-mono);
     color: var(--text-primary);
     font-variant-numeric: tabular-nums;
+    line-height: 1.1;
 }
 
 .chart-container {
@@ -252,22 +247,43 @@ body {
 
 .line-total {
     stroke: var(--color-total);
-    filter: drop-shadow(0 3px 3px var(--total-shadow));
 }
 
-.dot-total {
+.line-input {
+    stroke: var(--color-input);
+}
+
+.line-output {
+    stroke: var(--color-output);
+}
+
+.line-input {
+    stroke: var(--color-input);
+}
+
+.line-output {
+    stroke: var(--color-output);
+}
+
+.bar-outline {
+    stroke: var(--row-border);
+}
+
+.dot-input {
     fill: var(--bg-paper);
     stroke-width: 2;
-    stroke: var(--color-total);
+    stroke: var(--color-input);
+}
+
+.dot-output {
+    fill: var(--bg-paper);
+    stroke-width: 2;
+    stroke: var(--color-output);
 }
 
 .dot-last.dot-total {
     fill: var(--color-total);
     stroke: var(--bg-paper);
-}
-
-.bar-piece {
-    filter: drop-shadow(0 4px 4px var(--bar-shadow));
 }
 
 .bar-outline {
@@ -285,26 +301,12 @@ body {
 .legend-item {
     display: inline-flex;
     align-items: center;
-    padding: 6px 10px;
+    padding: 6px 12px;
     background: var(--bg-legend);
-    border: 1px solid var(--legend-border);
-    border-radius: 999px;
-    box-shadow: 0 10px 16px -14px rgba(93, 58, 25, 0.38);
+    border-radius: 8px;
     font-size: 12px;
     font-weight: 600;
     color: var(--text-secondary);
-    transition:
-        transform 160ms ease,
-        box-shadow 160ms ease;
-}
-
-.legend-item:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 14px 20px -16px rgba(93, 58, 25, 0.5);
-}
-
-.legend-item:active {
-    transform: translateY(1px);
 }
 
 .legend-color-indicator {
@@ -312,9 +314,8 @@ body {
     flex-shrink: 0;
     width: 12px;
     height: 12px;
-    border-radius: 2px;
+    border-radius: 3px;
     background: var(--legend-color);
-    border: 1px solid rgba(0, 0, 0, 0.05);
     margin-right: 8px;
     font-size: 0;
     line-height: 0;
@@ -330,13 +331,12 @@ body {
     place-items: center;
     color: var(--text-muted);
     font-size: 14px;
-    border: 1px dashed var(--border-color);
-    border-radius: 6px;
+    border-radius: 8px;
 }
 
 .plugin-section {
-    margin-top: 24px;
-    padding-top: 22px;
+    margin-top: 28px;
+    padding-top: 24px;
     border-top: 2px dashed rgba(180, 135, 82, 0.38);
 }
 
@@ -344,7 +344,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 12px;
+    margin-bottom: 16px;
 }
 
 .section-title-row h2 {
@@ -358,63 +358,51 @@ body {
     padding: 7px 12px;
     color: var(--text-secondary);
     background: var(--bg-paper-soft);
-    border: 1px solid var(--border-color);
-    border-radius: 999px 18px 999px 18px;
-    box-shadow: 0 10px 18px -16px rgba(93, 58, 25, 0.45);
+    border-radius: 8px;
     font-size: 12px;
     font-weight: 700;
 }
 
-.plugin-table {
-    width: 100%;
-    border-collapse: separate;
-    border-spacing: 0 8px;
-    margin-top: 0;
-}
-
-.plugin-table th,
-.plugin-table td {
-    padding: 11px 16px;
-    text-align: left;
-    font-size: 13px;
-}
-
-.plugin-table th {
-    font-weight: 600;
-    color: var(--text-secondary);
-    border-bottom: 1px solid rgba(180, 135, 82, 0.35);
-}
-
-.plugin-table td {
+.plugin-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
     background: var(--bg-row);
-    border-top: 1px solid var(--row-border);
-    border-bottom: 1px solid var(--row-border);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.plugin-list-head,
+.plugin-list-row {
+    display: grid;
+    grid-template-columns: 1fr 240px 160px 120px;
+    align-items: center;
+    gap: 16px;
+    padding: 12px 16px;
+}
+
+.plugin-list-head {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+.plugin-list-row {
+    font-size: 13px;
     color: var(--text-primary);
+    background: transparent;
+    transition: background 180ms ease;
 }
 
-.plugin-table td:first-child {
-    border-left: 1px solid var(--row-border);
-    border-radius: 16px 0 0 14px;
+.plugin-list-row + .plugin-list-row {
+    margin-top: 0;
+    border-top: 1px solid var(--row-border);
 }
 
-.plugin-table td:last-child {
-    border-right: 1px solid var(--row-border);
-    border-radius: 0 14px 16px 0;
-}
-
-.plugin-table tbody tr {
-    transition:
-        transform 180ms ease,
-        filter 180ms ease;
-}
-
-.plugin-table tbody tr:hover {
-    transform: translateY(-2px);
-    filter: drop-shadow(0 10px 10px rgba(93, 58, 25, 0.14));
-}
-
-.plugin-table tbody tr:active {
-    transform: translateY(1px);
+.plugin-list-row:hover {
+    background: var(--bg-row-hover);
 }
 
 .plugin-name-cell {
@@ -430,23 +418,24 @@ body {
     height: 8px;
     border-radius: 50%;
     background: var(--accent);
-    margin-right: 8px;
+    margin-right: 10px;
     font-size: 0;
     line-height: 0;
 }
 
 .plugin-progress-wrapper {
-    display: inline-flex;
+    display: flex;
     align-items: center;
+    gap: 12px;
+    width: 100%;
 }
 
 .plugin-progress-bar {
-    width: 100px;
-    height: 6px;
+    flex: 1;
+    height: 5px;
     border-radius: 3px;
     background: var(--bg-row-track);
     overflow: hidden;
-    margin-right: 12px;
 }
 
 .plugin-progress-fill {
@@ -469,18 +458,33 @@ body {
 .text-center {
     text-align: center !important;
 }
+
+.footer {
+    margin-top: 28px;
+    padding-top: 16px;
+    border-top: 1px solid var(--edge-shade);
+    text-align: center;
+    font-size: 11px;
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.footer span {
+    font-weight: 700;
+    color: var(--text-secondary);
+}
 `
 
 const MODEL_COLORS = [
-    '#7d82f3',
-    '#1aa6b7',
-    '#f47b3f',
-    '#3ab86a',
-    '#a967e8',
-    '#df6f9f',
-    '#34a889',
-    '#4d91df',
-    '#d99a38'
+    '#b14b28',
+    '#1772b4',
+    '#20894d',
+    '#ebb10d',
+    '#813c85',
+    '#fb8b05',
+    '#12aa9c',
+    '#eb261a',
+    '#918072'
 ]
 
 const CHART = {
@@ -491,7 +495,7 @@ const CHART = {
     top: 20,
     bottom: 48,
     gridLines: 5,
-    maxLabels: 12,
+    maxLabels: 30,
     maxModels: 5,
     minBarWidth: 3,
     maxBarWidth: 28
@@ -506,9 +510,12 @@ const OTHER_PLUGIN_NAME = '其他插件'
 
 function formatNum(value: number) {
     if (value >= 1000000) {
-        return (value / 1000000).toFixed(2) + 'M'
+        return (value / 1000000).toFixed(1).replace(/\.0$/, '') + 'M'
     }
-    return value.toLocaleString('en-US')
+    if (value >= 1000) {
+        return (value / 1000).toFixed(1).replace(/\.0$/, '') + 'k'
+    }
+    return value.toString()
 }
 
 function monotonePath(pts: Coord[]) {
@@ -609,7 +616,12 @@ function getChartLayout(points: ChatLunaUsage.TokenPoint[]) {
     const plotWidth = CHART.width - CHART.left - CHART.right
     const plotHeight = CHART.height - CHART.top - CHART.bottom
     const baseline = CHART.top + plotHeight
-    const max = Math.max(1, ...points.map((p) => p.tokens))
+    const max = Math.max(
+        1,
+        ...points.map((p) => p.tokens),
+        ...points.map((p) => p.inputTokens),
+        ...points.map((p) => p.outputTokens)
+    )
     const stepX =
         points.length > 1 ? plotWidth / (points.length - 1) : plotWidth
     const barWidth = Math.max(
@@ -618,16 +630,22 @@ function getChartLayout(points: ChatLunaUsage.TokenPoint[]) {
     )
     const safePadding = barWidth / 2 + 4
     const drawWidth = plotWidth - safePadding * 2
-    const totalCoords = points.map((point, idx) => ({
-        x:
-            points.length === 1
-                ? CHART.left + plotWidth / 2
-                : CHART.left +
-                  safePadding +
-                  (drawWidth * idx) / (points.length - 1),
-        y: baseline - (point.tokens / max) * plotHeight,
-        point
-    }))
+
+    const makeCoords = (key: keyof ChatLunaUsage.TokenPoint) =>
+        points.map((point, idx) => ({
+            x:
+                points.length === 1
+                    ? CHART.left + plotWidth / 2
+                    : CHART.left +
+                      safePadding +
+                      (drawWidth * idx) / (points.length - 1),
+            y: baseline - ((point[key] as number) / max) * plotHeight,
+            point
+        }))
+
+    const totalCoords = makeCoords('tokens')
+    const inputCoords = makeCoords('inputTokens')
+    const outputCoords = makeCoords('outputTokens')
 
     return {
         plotWidth,
@@ -639,6 +657,10 @@ function getChartLayout(points: ChatLunaUsage.TokenPoint[]) {
         drawWidth,
         totalCoords,
         totalLine: monotonePath(totalCoords),
+        inputCoords,
+        inputLine: monotonePath(inputCoords),
+        outputCoords,
+        outputLine: monotonePath(outputCoords),
         stepLabel: Math.max(1, Math.ceil(points.length / CHART.maxLabels))
     }
 }
@@ -750,20 +772,6 @@ function renderBars(
     })
 }
 
-function renderLineDots(coords: Coord[]) {
-    return coords.map((c, idx) => {
-        const last = idx === coords.length - 1
-        return (
-            <circle
-                class={last ? 'dot-total dot-last' : 'dot-total'}
-                cx={c.x}
-                cy={c.y}
-                r={last ? 5.5 : 4}
-            />
-        )
-    })
-}
-
 function renderAxisLabels(coords: Coord[], stepLabel: number) {
     return coords.map((c, idx) => {
         const shouldShowLabel =
@@ -807,11 +815,16 @@ function chart(
             role="img"
         >
             {renderGrid(layout)}
-            {showBar && renderBars(points, info, layout)}
-            {showLine && layout.totalLine && (
+            {showBar ? renderBars(points, info, layout) : null}
+            {showLine && layout.totalLine ? (
                 <path class="line line-total" d={layout.totalLine} />
-            )}
-            {mode === 'line' && renderLineDots(layout.totalCoords)}
+            ) : null}
+            {mode === 'line' && layout.inputLine ? (
+                <path class="line line-input" d={layout.inputLine} />
+            ) : null}
+            {mode === 'line' && layout.outputLine ? (
+                <path class="line line-output" d={layout.outputLine} />
+            ) : null}
             {renderAxisLabels(layout.totalCoords, layout.stepLabel)}
         </svg>
     )
@@ -839,76 +852,59 @@ function pluginSection(plugins?: ChatLunaUsage.TokenReport['plugins']) {
     return (
         <section class="plugin-section">
             <div class="section-title-row">
-                <h2>各插件用量明细</h2>
-                <span class="sort-chip">按 Token 占比降序排列</span>
+                <h2>用量明细</h2>
+                <span class="sort-chip">按 Token 使用降序排列</span>
             </div>
-            <table class="plugin-table">
-                <thead>
-                    <tr>
-                        <th style="text-align: left;">来源插件</th>
-                        <th class="text-center" style="width: 220px;">
-                            用量占比
-                        </th>
-                        <th class="text-center" style="width: 180px;">
-                            总 Token 消耗
-                        </th>
-                        <th class="text-center" style="width: 140px;">
-                            调用次数
-                        </th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {displayPlugins.map((plugin, idx) => {
-                        const isOther = plugin.source === OTHER_PLUGIN_NAME
-                        const color = isOther
-                            ? OTHER_COLOR
-                            : MODEL_COLORS[idx % MODEL_COLORS.length]
-                        const ratio = (plugin.tokens / total) * 100
-                        return (
-                            <tr>
-                                <td>
-                                    <div class="plugin-name-cell">
-                                        <span
-                                            class="plugin-indicator"
-                                            style={`--accent:${color}`}
-                                        >
-                                            {' '}
-                                        </span>
-                                        {plugin.source}
-                                    </div>
-                                </td>
-                                <td class="text-center">
+            <div class="plugin-list-head">
+                <span>来源插件</span>
+                <span class="text-center">用量占比</span>
+                <span class="text-right">Token 使用</span>
+                <span class="text-right">请求次数</span>
+            </div>
+            <ul class="plugin-list">
+                {displayPlugins.map((plugin, idx) => {
+                    const isOther = plugin.source === OTHER_PLUGIN_NAME
+                    const color = isOther
+                        ? OTHER_COLOR
+                        : MODEL_COLORS[idx % MODEL_COLORS.length]
+                    const ratio = (plugin.tokens / total) * 100
+                    return (
+                        <li class="plugin-list-row">
+                            <div class="plugin-name-cell">
+                                <span
+                                    class="plugin-indicator"
+                                    style={`--accent:${color}`}
+                                >
+                                    {' '}
+                                </span>
+                                {plugin.source}
+                            </div>
+                            <div class="plugin-progress-wrapper">
+                                <div class="plugin-progress-bar">
                                     <div
-                                        class="plugin-progress-wrapper"
-                                        style="justify-content: center;"
+                                        class="plugin-progress-fill"
+                                        style={`--accent:${color}; width:${Math.max(1, Math.min(100, ratio))}%`}
                                     >
-                                        <div class="plugin-progress-bar">
-                                            <div
-                                                class="plugin-progress-fill"
-                                                style={`--accent:${color}; width:${Math.max(1, Math.min(100, ratio))}%`}
-                                            >
-                                                {' '}
-                                            </div>
-                                        </div>
-                                        <span
-                                            class="plugin-number"
-                                            style="min-width: 45px;"
-                                        >
-                                            {ratio.toFixed(1)}%
-                                        </span>
+                                        {' '}
                                     </div>
-                                </td>
-                                <td class="plugin-number text-center">
-                                    {formatNum(plugin.tokens)}
-                                </td>
-                                <td class="plugin-number text-center">
-                                    {formatNum(plugin.calls)}
-                                </td>
-                            </tr>
-                        )
-                    })}
-                </tbody>
-            </table>
+                                </div>
+                                <span
+                                    class="plugin-number"
+                                    style="min-width: 48px;"
+                                >
+                                    {ratio.toFixed(1)}%
+                                </span>
+                            </div>
+                            <span class="plugin-number text-right">
+                                {formatNum(plugin.tokens)}
+                            </span>
+                            <span class="plugin-number text-right">
+                                {formatNum(plugin.calls)}
+                            </span>
+                        </li>
+                    )
+                })}
+            </ul>
         </section>
     )
 }
@@ -922,7 +918,7 @@ function renderLegend(
 
     return (
         <div class="chart-legend">
-            {showLine && (
+            {mode === 'line' ? (
                 <div class="legend-item">
                     <span
                         class="legend-color-indicator legend-total-indicator"
@@ -932,19 +928,53 @@ function renderLegend(
                     </span>
                     总 Token
                 </div>
-            )}
-            {showBar &&
-                Object.entries(info.colorMap).map(([model, color]) => (
-                    <div class="legend-item">
-                        <span
-                            class="legend-color-indicator"
-                            style={`--legend-color:${color}`}
-                        >
-                            {' '}
-                        </span>
-                        {model}
-                    </div>
-                ))}
+            ) : null}
+            {mode === 'line' ? (
+                <div class="legend-item">
+                    <span
+                        class="legend-color-indicator legend-total-indicator"
+                        style="--legend-color:var(--color-input)"
+                    >
+                        {' '}
+                    </span>
+                    输入 Token
+                </div>
+            ) : null}
+            {mode === 'line' ? (
+                <div class="legend-item">
+                    <span
+                        class="legend-color-indicator legend-total-indicator"
+                        style="--legend-color:var(--color-output)"
+                    >
+                        {' '}
+                    </span>
+                    输出 Token
+                </div>
+            ) : null}
+            {mode === 'both' && showLine ? (
+                <div class="legend-item">
+                    <span
+                        class="legend-color-indicator legend-total-indicator"
+                        style="--legend-color:var(--color-total)"
+                    >
+                        {' '}
+                    </span>
+                    总 Token
+                </div>
+            ) : null}
+            {showBar
+                ? Object.entries(info.colorMap).map(([model, color]) => (
+                      <div class="legend-item">
+                          <span
+                              class="legend-color-indicator"
+                              style={`--legend-color:${color}`}
+                          >
+                              {' '}
+                          </span>
+                          {model}
+                      </div>
+                  ))
+                : null}
         </div>
     )
 }
@@ -969,16 +999,14 @@ function pageHtml(
                         name="viewport"
                         content="width=device-width, initial-scale=1.0"
                     />
-                    <title>Chatluna Token 消耗分析</title>
+                    <title>ChatLuna Token 用量</title>
                     <style>{CSS}</style>
                 </head>
                 <body>
                     <div class={`stage theme-${theme}`}>
                         <main class="paper-content">
                             <header class="hero-header">
-                                <h1 class="hero-title">
-                                    Chatluna Token 消耗分析
-                                </h1>
+                                <h1 class="hero-title">ChatLuna Token 用量</h1>
                                 <div class="time-strip">
                                     <span class="time-label">统计周期</span>
                                     <strong class="time-value">
@@ -991,34 +1019,28 @@ function pageHtml(
                                 </div>
                             </header>
 
-                            <section class="metrics-grid">
-                                <div class="metric-item">
-                                    <div class="metric-label">
-                                        累计消耗 Token
-                                    </div>
-                                    <div class="metric-value">
+                            <section class="stats-row">
+                                <div class="stat-cell">
+                                    <div class="stat-label">使用 Token</div>
+                                    <div class="stat-value">
                                         {formatNum(data.totalTokens)}
                                     </div>
                                 </div>
-                                <div class="metric-item">
-                                    <div class="metric-label">累计请求次数</div>
-                                    <div class="metric-value">
+                                <div class="stat-cell">
+                                    <div class="stat-label">请求次数</div>
+                                    <div class="stat-value">
                                         {formatNum(data.calls)}
                                     </div>
                                 </div>
-                                <div class="metric-item">
-                                    <div class="metric-label">
-                                        TPM 峰值 (每分钟)
-                                    </div>
-                                    <div class="metric-value">
+                                <div class="stat-cell">
+                                    <div class="stat-label">TPM 峰值</div>
+                                    <div class="stat-value">
                                         {formatNum(data.tpm)}
                                     </div>
                                 </div>
-                                <div class="metric-item">
-                                    <div class="metric-label">
-                                        RPM 峰值 (每分钟)
-                                    </div>
-                                    <div class="metric-value">
+                                <div class="stat-cell">
+                                    <div class="stat-label">RPM 峰值</div>
+                                    <div class="stat-value">
                                         {formatNum(data.rpm)}
                                     </div>
                                 </div>
@@ -1029,6 +1051,10 @@ function pageHtml(
                                 {renderLegend(info, mode)}
                             </section>
                             {pluginSection(data.plugins)}
+                            <footer class="footer">
+                                Generated by <span>ChatLuna</span> &amp;{' '}
+                                <span>Koishi</span>
+                            </footer>
                         </main>
                     </div>
                 </body>

--- a/packages/extension-usage/src/renderer.tsx
+++ b/packages/extension-usage/src/renderer.tsx
@@ -13,266 +13,309 @@ type RenderTheme = Exclude<ChatLunaUsage.TokenTheme, 'auto'>
 
 const CSS = `
 :root {
+    --bg-stage: #f8fafc;
+    --bg-card: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #334155;
+    --text-muted: #4b5563;
+    --border-color: #cbd5e1;
+    --grid-line: #cbd5e1;
+    --color-total: #4f46e5;
+    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -2px rgba(0, 0, 0, 0.05);
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
     color-scheme: light;
 }
+
 * {
     box-sizing: border-box;
 }
+
 body {
     margin: 0;
+    background: var(--bg-stage);
 }
+
 .stage {
-    --card: #ffffff;
-    --text: #0f172a;
-    --muted: #64748b;
-    --faint: #94a3b8;
-    --brand: #6366f1;
-    --brand-2: #8b5cf6;
-    --border: #eef0f6;
-    color-scheme: light;
     display: inline-flex;
     flex-direction: column;
-    gap: 24px;
-    padding: 56px;
-    background:
-        radial-gradient(1100px 560px at 10% -10%, #e7e9ff 0%, transparent 55%),
-        radial-gradient(900px 480px at 110% 0%, #f5e9ff 0%, transparent 50%),
-        linear-gradient(180deg, #eef1ff, #f7f8fc);
-    font-family: Inter, "Noto Sans SC", "Microsoft YaHei", system-ui, sans-serif;
+    gap: 16px;
+    padding: 20px;
+    background: var(--bg-stage);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans SC", "Microsoft YaHei", sans-serif;
     -webkit-font-smoothing: antialiased;
 }
+
 .stage.theme-dark {
-    --card: #111827;
-    --text: #e5e7eb;
-    --muted: #94a3b8;
-    --faint: #64748b;
-    --border: #253044;
+    --bg-stage: #0f172a;
+    --bg-card: #1e293b;
+    --text-primary: #f8fafc;
+    --text-secondary: #cbd5e1;
+    --text-muted: #94a3b8;
+    --border-color: #475569;
+    --grid-line: #475569;
+    --color-total: #818cf8;
+    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
+    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4), 0 2px 4px -2px rgba(0, 0, 0, 0.4);
     color-scheme: dark;
-    background:
-        radial-gradient(1100px 560px at 10% -10%, rgba(79, 70, 229, 0.28) 0%, transparent 55%),
-        radial-gradient(900px 480px at 110% 0%, rgba(14, 165, 233, 0.18) 0%, transparent 50%),
-        linear-gradient(180deg, #0b1020, #111827);
 }
-.token-trend-card {
+
+.card {
     position: relative;
-    width: 1040px;
-    padding: 38px 40px 28px;
-    background: var(--card);
-    border: 1px solid var(--border);
-    border-radius: 24px;
-    box-shadow:
-        0 24px 60px -20px rgba(49, 46, 129, 0.30),
-        0 8px 24px -12px rgba(15, 23, 42, 0.12);
-    overflow: hidden;
-    color: var(--text);
+    width: 1000px;
+    padding: 24px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    box-shadow: var(--shadow-sm);
+    color: var(--text-primary);
 }
-.token-trend-card::before {
-    content: "";
-    position: absolute;
-    inset: 0 0 auto;
-    height: 5px;
-    background: linear-gradient(90deg, var(--brand), var(--brand-2));
-}
-.stage.theme-dark .token-trend-card {
-    box-shadow: 0 24px 60px -20px rgba(0, 0, 0, 0.65), 0 8px 24px -12px rgba(0, 0, 0, 0.55);
-}
-.head {
+
+.card-header {
     display: flex;
-    align-items: center;
-    gap: 16px;
-    margin-bottom: 26px;
+    justify-content: space-between;
+    align-items: flex-start;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 16px;
+    margin-bottom: 20px;
 }
-.mark {
-    display: grid;
-    place-items: center;
-    width: 48px;
-    height: 48px;
-    border-radius: 14px;
-    background: linear-gradient(140deg, var(--brand), var(--brand-2));
-    box-shadow: 0 10px 22px -8px rgba(99, 102, 241, 0.65);
-}
-h1 {
+
+.card-title-group h1 {
     margin: 0;
-    font-size: 26px;
-    font-weight: 700;
-    letter-spacing: 0;
-    line-height: 1.25;
+    font-size: 20px;
+    font-weight: 600;
+    letter-spacing: -0.025em;
+    color: var(--text-primary);
 }
-.range {
-    margin: 5px 0 0;
-    color: var(--muted);
-    font-size: 14px;
+
+.card-subtitle {
+    margin: 4px 0 0;
+    color: var(--text-muted);
+    font-size: 13px;
 }
-.chart-wrap {
-    padding: 18px 16px 12px;
-    border: 1px solid var(--border);
-    border-radius: 18px;
-    background: radial-gradient(620px 220px at 82% -10%, rgba(139, 92, 246, 0.07), transparent 60%), linear-gradient(180deg, #ffffff, #fbfcff);
+
+.metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 16px;
+    margin-bottom: 20px;
 }
-.stage.theme-dark .chart-wrap {
-    background: radial-gradient(620px 220px at 82% -10%, rgba(14, 165, 233, 0.10), transparent 60%), linear-gradient(180deg, #111827, #0f172a);
+
+.metric-item {
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 16px;
+    background: var(--bg-card);
 }
+
+.metric-label {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.metric-value {
+    margin-top: 8px;
+    font-size: 24px;
+    font-weight: 600;
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+}
+
+.chart-container {
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 20px;
+    background: var(--bg-card);
+}
+
 .trend-chart {
     display: block;
     width: 100%;
     height: auto;
 }
+
 .grid line {
-    stroke: #eef1f6;
+    stroke: var(--grid-line);
     stroke-width: 1;
+    stroke-dasharray: 3 3;
 }
-.stage.theme-dark .grid line {
-    stroke: #253044;
-}
+
 .grid text {
-    fill: var(--faint);
-    font-size: 12px;
+    fill: var(--text-secondary);
+    font-size: 11px;
+    font-family: var(--font-mono);
     text-anchor: end;
-    font-variant-numeric: tabular-nums;
+    font-weight: 500;
 }
+
 .axis-x {
-    fill: var(--faint);
-    font-size: 12px;
+    fill: var(--text-secondary);
+    font-size: 11px;
+    font-family: var(--font-mono);
     text-anchor: middle;
+    font-weight: 500;
 }
+
 .line {
     fill: none;
-    stroke-width: 3.5;
+    stroke-width: 2.5;
     stroke-linecap: round;
     stroke-linejoin: round;
 }
+
 .line-total {
-    stroke: url(#totalGrad);
+    stroke: var(--color-total);
 }
-.line-input {
-    stroke: #0ea5e9;
-}
-.line-output {
-    stroke: #f59e0b;
-}
-.dot-total,
-.dot-input,
-.dot-output {
-    fill: var(--card);
-    stroke-width: 3;
-}
+
 .dot-total {
-    stroke: #6366f1;
+    fill: var(--bg-card);
+    stroke-width: 2;
+    stroke: var(--color-total);
 }
-.dot-input {
-    stroke: #0ea5e9;
-}
-.dot-output {
-    stroke: #f59e0b;
-}
+
 .dot-last.dot-total {
-    fill: #6366f1;
-    stroke: #fff;
+    fill: var(--color-total);
+    stroke: var(--bg-card);
 }
-.dot-last.dot-input {
-    fill: #0ea5e9;
-    stroke: #fff;
-}
-.dot-last.dot-output {
-    fill: #f59e0b;
-    stroke: #fff;
-}
+
 .chart-legend {
     display: flex;
     justify-content: center;
-    gap: 22px;
-    margin: 12px 0 0;
-    color: var(--muted);
-    font-size: 13px;
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border-color);
 }
+
 .legend-item {
     display: inline-flex;
     align-items: center;
-    gap: 7px;
-    font-variant-numeric: tabular-nums;
+    margin: 0 16px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-secondary);
 }
-.legend-item i {
-    width: 26px;
-    height: 3px;
-    border-radius: 999px;
+
+.legend-color-indicator {
+    display: inline-block;
+    flex-shrink: 0;
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
     background: var(--legend-color);
-    box-shadow: 0 0 0 3px rgba(15, 23, 42, 0.03);
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    margin-right: 8px;
     font-size: 0;
     line-height: 0;
 }
+
 .empty-chart {
     display: grid;
-    height: 360px;
+    height: 320px;
     place-items: center;
-    color: var(--faint);
-    font-size: 16px;
+    color: var(--text-muted);
+    font-size: 14px;
+    border: 1px dashed var(--border-color);
+    border-radius: 6px;
 }
-.plugin-list {
-    display: flex;
-    flex-direction: column;
-    gap: 18px;
+
+.plugin-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 8px;
 }
-.plugin-row {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 6px 12px;
-    align-items: baseline;
+
+.plugin-table th,
+.plugin-table td {
+    padding: 12px 16px;
+    text-align: left;
+    border-bottom: 1px solid var(--border-color);
+    font-size: 13px;
 }
-.plugin-name {
+
+.plugin-table th {
+    font-weight: 600;
+    color: var(--text-secondary);
+    background-color: var(--bg-stage);
+}
+
+.plugin-table td {
+    color: var(--text-primary);
+}
+
+.plugin-name-cell {
+    font-weight: 500;
     display: flex;
     align-items: center;
-    gap: 9px;
-    font-size: 15px;
-    font-weight: 600;
-    color: var(--text);
 }
-.plugin-name i {
-    width: 10px;
-    height: 10px;
+
+.plugin-indicator {
+    display: inline-block;
+    flex-shrink: 0;
+    width: 8px;
+    height: 8px;
     border-radius: 50%;
+    background: var(--accent);
+    margin-right: 8px;
+    font-size: 0;
+    line-height: 0;
+}
+
+.plugin-progress-wrapper {
+    display: inline-flex;
+    align-items: center;
+}
+
+.plugin-progress-bar {
+    width: 100px;
+    height: 6px;
+    border-radius: 3px;
+    background: var(--grid-line);
+    overflow: hidden;
+    margin-right: 12px;
+}
+
+.plugin-progress-fill {
+    height: 100%;
+    border-radius: 3px;
     background: var(--accent);
     font-size: 0;
     line-height: 0;
 }
-.plugin-meta {
-    font-size: 13px;
-    color: var(--muted);
+
+.plugin-number {
+    font-family: var(--font-mono);
     font-variant-numeric: tabular-nums;
 }
-.plugin-meta b {
-    color: var(--text);
-    font-weight: 700;
-    font-size: 15px;
+
+.text-right {
+    text-align: right !important;
 }
-.plugin-track {
-    grid-column: 1 / -1;
-    height: 10px;
-    border-radius: 6px;
-    background: #f1f3f9;
-    overflow: hidden;
-}
-.stage.theme-dark .plugin-track {
-    background: #1f2937;
-}
-.plugin-fill {
-    height: 100%;
-    border-radius: 6px;
-    background: linear-gradient(90deg, var(--accent), var(--accent-2));
-    font-size: 0;
-    line-height: 0;
+
+.text-center {
+    text-align: center !important;
 }
 `
 
-const PLUGIN_COLORS: [string, string][] = [
-    ['#6366f1', '#8b5cf6'],
-    ['#0ea5e9', '#22d3ee'],
-    ['#f43f5e', '#fb7185'],
-    ['#f59e0b', '#fbbf24'],
-    ['#10b981', '#34d399'],
-    ['#a855f7', '#d946ef']
+const MODEL_COLORS = [
+    '#4f46e5',
+    '#0891b2',
+    '#ea580c',
+    '#16a34a',
+    '#9333ea',
+    '#db2777',
+    '#059669',
+    '#2563eb',
+    '#d97706'
 ]
 
-function fmt(value: number) {
+function formatNum(value: number) {
+    if (value >= 1000000) {
+        return (value / 1000000).toFixed(2) + 'M'
+    }
     return value.toLocaleString('en-US')
 }
 
@@ -283,138 +326,246 @@ function monotonePath(pts: Coord[]) {
         return `M${pts[0].x},${pts[0].y} L${pts[1].x},${pts[1].y}`
     }
 
-    const dx: number[] = []
-    const slope: number[] = []
+    const h = new Array(n - 1)
+    const m = new Array(n - 1)
     for (let i = 0; i < n - 1; i++) {
-        dx[i] = pts[i + 1].x - pts[i].x
-        slope[i] = (pts[i + 1].y - pts[i].y) / dx[i]
+        h[i] = pts[i + 1].x - pts[i].x
+        m[i] = (pts[i + 1].y - pts[i].y) / h[i]
     }
 
-    const t: number[] = [slope[0]]
+    const t = new Array(n)
+
+    t[0] = m[0]
+    t[n - 1] = m[n - 2]
+
     for (let i = 1; i < n - 1; i++) {
-        t[i] = slope[i - 1] * slope[i] <= 0 ? 0 : (slope[i - 1] + slope[i]) / 2
-    }
-    t[n - 1] = slope[n - 2]
+        const s0 = m[i - 1]
+        const s1 = m[i]
 
-    for (let i = 0; i < n - 1; i++) {
-        if (slope[i] === 0) {
+        if (s0 * s1 <= 0) {
             t[i] = 0
-            t[i + 1] = 0
-            continue
-        }
-        const a = t[i] / slope[i]
-        const b = t[i + 1] / slope[i]
-        const h = Math.hypot(a, b)
-        if (h > 3) {
-            const k = 3 / h
-            t[i] = k * a * slope[i]
-            t[i + 1] = k * b * slope[i]
+        } else {
+            const h0 = h[i - 1]
+            const h1 = h[i]
+            const p = (s0 * h1 + s1 * h0) / (h0 + h1)
+            t[i] =
+                (Math.sign(s0) + Math.sign(s1)) *
+                Math.min(Math.abs(s0), Math.abs(s1), 0.5 * Math.abs(p))
         }
     }
+
+    t[0] = Math.sign(m[0]) * Math.min(Math.abs(m[0]), Math.abs(t[0]))
+    t[n - 1] =
+        Math.sign(m[n - 2]) * Math.min(Math.abs(m[n - 2]), Math.abs(t[n - 1]))
+
+    const maxY = Math.max(...pts.map((p) => p.y))
 
     let d = `M${pts[0].x},${pts[0].y}`
     for (let i = 0; i < n - 1; i++) {
-        const c1x = pts[i].x + dx[i] / 3
-        const c1y = pts[i].y + (t[i] * dx[i]) / 3
-        const c2x = pts[i + 1].x - dx[i] / 3
-        const c2y = pts[i + 1].y - (t[i + 1] * dx[i]) / 3
+        const dx = h[i]
+        const factor = 0.4
+
+        const c1x = pts[i].x + dx * factor
+        let c1y = pts[i].y + t[i] * dx * factor
+        const c2x = pts[i + 1].x - dx * factor
+        let c2y = pts[i + 1].y - t[i + 1] * dx * factor
+
+        if (Math.abs(pts[i].y - pts[i + 1].y) < 0.1) {
+            c1y = pts[i].y
+            c2y = pts[i + 1].y
+        } else if (pts[i].y < pts[i + 1].y) {
+            c1y = Math.max(pts[i].y, Math.min(pts[i + 1].y, c1y))
+            c2y = Math.max(pts[i].y, Math.min(pts[i + 1].y, c2y))
+        } else {
+            c1y = Math.max(pts[i + 1].y, Math.min(pts[i].y, c1y))
+            c2y = Math.max(pts[i + 1].y, Math.min(pts[i].y, c2y))
+        }
+
+        c1y = Math.min(maxY, c1y)
+        c2y = Math.min(maxY, c2y)
+
         d += ` C${c1x},${c1y} ${c2x},${c2y} ${pts[i + 1].x},${pts[i + 1].y}`
     }
     return d
 }
 
-function chart(points: ChatLunaUsage.TokenPoint[]) {
+function getTopModels(points: ChatLunaUsage.TokenPoint[]) {
+    const modelTotals: Record<string, number> = {}
+    for (const p of points) {
+        for (const [model, val] of Object.entries(p.models)) {
+            modelTotals[model] = (modelTotals[model] || 0) + val
+        }
+    }
+    const sortedModels = Object.entries(modelTotals)
+        .sort((a, b) => b[1] - a[1])
+        .map(([model]) => model)
+
+    const topModels = sortedModels.slice(0, 5)
+
+    const colorMap: Record<string, string> = {}
+    topModels.forEach((model, i) => {
+        colorMap[model] = MODEL_COLORS[i % MODEL_COLORS.length]
+    })
+    if (sortedModels.length > 5) {
+        colorMap['其他模型'] = '#94a3b8'
+    }
+    return { topModels, colorMap }
+}
+
+function chart(
+    points: ChatLunaUsage.TokenPoint[],
+    mode: ChatLunaUsage.TokenRenderMode = 'both'
+) {
     if (!points.length) return <div class="empty-chart">暂无用量数据</div>
 
-    const [width, height, left, right, top, bottom] = [968, 360, 78, 26, 30, 56]
+    const [width, height, left, right, top, bottom] = [952, 320, 60, 20, 20, 48]
     const plotWidth = width - left - right
     const plotHeight = height - top - bottom
     const baseline = top + plotHeight
-    const max = Math.max(
-        1,
-        ...points.flatMap((p) => [p.tokens, p.inputTokens, p.outputTokens])
-    )
-    const [totalCoords, inputCoords, outputCoords] = (
-        ['tokens', 'inputTokens', 'outputTokens'] as const
-    ).map((key) =>
-        points.map((point, idx) => ({
-            x:
-                points.length === 1
-                    ? left + plotWidth / 2
-                    : left + (plotWidth * idx) / (points.length - 1),
-            y: baseline - (point[key] / max) * plotHeight,
-            point
-        }))
-    )
-    const [totalLine, inputLine, outputLine] = [
-        totalCoords,
-        inputCoords,
-        outputCoords
-    ].map(monotonePath)
-    const area = totalLine
-        ? `${totalLine} L${totalCoords[totalCoords.length - 1].x},${baseline} L${totalCoords[0].x},${baseline} Z`
-        : ''
-    const size = points.length > 24 ? 10 : 12
+    const max = Math.max(1, ...points.flatMap((p) => [p.tokens]))
 
-    return [
+    const { topModels, colorMap } = getTopModels(points)
+    const stepX =
+        points.length > 1 ? plotWidth / (points.length - 1) : plotWidth
+    const barWidth = Math.max(3, Math.min(28, stepX * 0.5))
+
+    const safePadding = barWidth / 2 + 4
+    const drawWidth = plotWidth - safePadding * 2
+
+    const totalCoords = points.map((point, idx) => ({
+        x:
+            points.length === 1
+                ? left + plotWidth / 2
+                : left + safePadding + (drawWidth * idx) / (points.length - 1),
+        y: baseline - (point.tokens / max) * plotHeight,
+        point
+    }))
+
+    const totalLine = monotonePath(totalCoords)
+
+    const maxLabels = 12
+    const stepLabel = Math.max(1, Math.ceil(points.length / maxLabels))
+
+    return (
         <svg class="trend-chart" viewbox={`0 0 ${width} ${height}`} role="img">
-            <defs>
-                <linearGradient id="totalGrad" x1="0" y1="0" x2="1" y2="0">
-                    <stop offset="0%" stop-color="#6366f1" />
-                    <stop offset="100%" stop-color="#8b5cf6" />
-                </linearGradient>
-                <linearGradient id="areaGrad" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="0%" stop-color="rgba(99,102,241,0.30)" />
-                    <stop offset="100%" stop-color="rgba(139,92,246,0.02)" />
-                </linearGradient>
-            </defs>
             <g class="grid">
                 {Array.from({ length: 5 }, (_, idx) => {
                     const y = top + (plotHeight * idx) / 4
                     const value = Math.round(max - (max * idx) / 4)
                     return [
                         <line x1={left} y1={y} x2={width - right} y2={y} />,
-                        <text x={left - 14} y={y + 4}>
-                            {fmt(value)}
+                        <text x={left - 12} y={y + 4}>
+                            {formatNum(value)}
                         </text>
                     ]
                 })}
             </g>
-            <path d={area} fill="url(#areaGrad)" />
-            <path class="line line-input" d={inputLine} />
-            <path class="line line-output" d={outputLine} />
-            <path class="line line-total" d={totalLine} />
-            {[
-                ['input', inputCoords] as const,
-                ['output', outputCoords] as const,
-                ['total', totalCoords] as const
-            ].flatMap(([name, coords]) =>
-                coords.map((c, idx) => {
-                    const last = idx === coords.length - 1
+
+            {(mode === 'both' || mode === 'bar') &&
+                points.map((point, idx) => {
+                    const x =
+                        points.length === 1
+                            ? left + plotWidth / 2
+                            : left +
+                              safePadding +
+                              (drawWidth * idx) / (points.length - 1)
+
+                    const activeModels: { name: string; val: number }[] = []
+                    let otherVal = 0
+
+                    for (const [mName, val] of Object.entries(point.models)) {
+                        if (val <= 0) continue
+                        if (topModels.includes(mName)) {
+                            activeModels.push({ name: mName, val })
+                        } else {
+                            otherVal += val
+                        }
+                    }
+
+                    activeModels.sort(
+                        (a, b) =>
+                            topModels.indexOf(a.name) -
+                            topModels.indexOf(b.name)
+                    )
+
+                    if (otherVal > 0) {
+                        activeModels.push({ name: '其他模型', val: otherVal })
+                    }
+
+                    let currentY = baseline
+                    const groupHeight = activeModels.reduce(
+                        (sum, item) => sum + (item.val / max) * plotHeight,
+                        0
+                    )
+                    const groupY = baseline - groupHeight
+
+                    return (
+                        <g>
+                            {activeModels.map((item) => {
+                                const barHeight = (item.val / max) * plotHeight
+                                const y = currentY - barHeight
+                                currentY = y
+                                return (
+                                    <rect
+                                        x={x - barWidth / 2}
+                                        y={y}
+                                        width={barWidth}
+                                        height={barHeight}
+                                        fill={colorMap[item.name]}
+                                        opacity="0.85"
+                                    />
+                                )
+                            })}
+                            {groupHeight > 0 && (
+                                <rect
+                                    x={x - barWidth / 2}
+                                    y={groupY}
+                                    width={barWidth}
+                                    height={groupHeight}
+                                    fill="none"
+                                    stroke="var(--border-color)"
+                                    stroke-width="1"
+                                    opacity="0.6"
+                                />
+                            )}
+                        </g>
+                    )
+                })}
+
+            {(mode === 'both' || mode === 'line') && totalLine && (
+                <path class="line line-total" d={totalLine} />
+            )}
+
+            {mode === 'line' &&
+                totalCoords.map((c, idx) => {
+                    const last = idx === totalCoords.length - 1
                     return (
                         <circle
-                            class={
-                                last ? `dot-${name} dot-last` : `dot-${name}`
-                            }
+                            class={last ? 'dot-total dot-last' : 'dot-total'}
                             cx={c.x}
                             cy={c.y}
                             r={last ? 5.5 : 4}
                         />
                     )
-                })
-            )}
-            {totalCoords.map((c) => {
+                })}
+
+            {totalCoords.map((c, idx) => {
+                const shouldShowLabel =
+                    idx === 0 ||
+                    idx === totalCoords.length - 1 ||
+                    idx % stepLabel === 0
+                if (!shouldShowLabel) return null
+
                 const parts = c.point.label.split(' ')
                 return (
                     <text
                         class="axis-x"
-                        style={`font-size:${size}px`}
                         x={c.x}
-                        y={height - (parts[1] ? 28 : 22)}
+                        y={height - (parts[1] ? 22 : 18)}
                     >
                         {parts[1]
-                            ? parts.map((part, idx) => (
-                                  <tspan x={c.x} dy={idx ? '15' : '0'}>
+                            ? parts.map((part, pIdx) => (
+                                  <tspan x={c.x} dy={pIdx ? '13' : '0'}>
                                       {part}
                                   </tspan>
                               ))
@@ -422,83 +573,6 @@ function chart(points: ChatLunaUsage.TokenPoint[]) {
                     </text>
                 )
             })}
-        </svg>,
-        <div class="chart-legend">
-            <span class="legend-item" style="--legend-color:#6366f1">
-                <i> </i>总 token
-            </span>
-            <span class="legend-item" style="--legend-color:#0ea5e9">
-                <i> </i>输入 token
-            </span>
-            <span class="legend-item" style="--legend-color:#f59e0b">
-                <i> </i>输出 token
-            </span>
-        </div>
-    ]
-}
-
-function trendIcon() {
-    return (
-        <svg width="24" height="24" viewbox="0 0 24 24" fill="none">
-            <path
-                d="M4 16l4.5-5 3.5 3.5L20 7"
-                stroke="white"
-                stroke-width="2.2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-            />
-            <path
-                d="M4 20h15"
-                stroke="white"
-                stroke-width="2.2"
-                stroke-linecap="round"
-                opacity="0.55"
-            />
-        </svg>
-    )
-}
-
-function pluginIcon() {
-    return (
-        <svg width="24" height="24" viewbox="0 0 24 24" fill="none">
-            <rect
-                x="4"
-                y="4"
-                width="7"
-                height="7"
-                rx="2"
-                stroke="white"
-                stroke-width="2.1"
-            />
-            <rect
-                x="13"
-                y="4"
-                width="7"
-                height="7"
-                rx="2"
-                stroke="white"
-                stroke-width="2.1"
-                opacity="0.55"
-            />
-            <rect
-                x="4"
-                y="13"
-                width="7"
-                height="7"
-                rx="2"
-                stroke="white"
-                stroke-width="2.1"
-                opacity="0.55"
-            />
-            <rect
-                x="13"
-                y="13"
-                width="7"
-                height="7"
-                rx="2"
-                stroke="white"
-                stroke-width="2.1"
-            />
         </svg>
     )
 }
@@ -508,51 +582,149 @@ function pluginCard(plugins?: ChatLunaUsage.TokenReport['plugins']) {
 
     const total = plugins.reduce((sum, p) => sum + p.tokens, 0) || 1
 
+    const maxDisplay = 6
+    let displayPlugins = plugins.slice(0, maxDisplay)
+    if (plugins.length > maxDisplay) {
+        const otherTokens = plugins
+            .slice(maxDisplay)
+            .reduce((sum, p) => sum + p.tokens, 0)
+        const otherCalls = plugins
+            .slice(maxDisplay)
+            .reduce((sum, p) => sum + p.calls, 0)
+        displayPlugins = [
+            ...displayPlugins,
+            {
+                source: '其他插件',
+                tokens: otherTokens,
+                calls: otherCalls
+            }
+        ]
+    }
+
     return (
-        <section class="token-trend-card">
-            <header class="head">
-                <div class="mark">{pluginIcon()}</div>
-                <div>
+        <section class="card">
+            <div
+                class="card-header"
+                style="border-bottom: 0; padding-bottom: 8px; margin-bottom: 12px;"
+            >
+                <div class="card-title-group">
                     <h1>各插件用量明细</h1>
-                    <p class="range">按 token 占比排序</p>
+                    <p class="card-subtitle">按 Token 占比降序排列</p>
                 </div>
-            </header>
-            <div class="plugin-list">
-                {plugins.map((plugin, idx) => {
-                    const [accent, accent2] =
-                        PLUGIN_COLORS[idx % PLUGIN_COLORS.length]
-                    const ratio = (plugin.tokens / total) * 100
-                    return (
-                        <div
-                            class="plugin-row"
-                            style={`--accent:${accent};--accent-2:${accent2}`}
-                        >
-                            <div class="plugin-name">
-                                <i> </i>
-                                {plugin.source}
-                            </div>
-                            <div class="plugin-meta">
-                                <b>{ratio.toFixed(1)}%</b> ·{' '}
-                                {fmt(plugin.tokens)} token · {fmt(plugin.calls)}{' '}
-                                次
-                            </div>
-                            <div class="plugin-track">
-                                <div
-                                    class="plugin-fill"
-                                    style={`width:${Math.max(2, Math.min(100, ratio))}%`}
-                                >
-                                    {' '}
-                                </div>
-                            </div>
-                        </div>
-                    )
-                })}
             </div>
+            <table class="plugin-table">
+                <thead>
+                    <tr>
+                        <th style="text-align: left;">来源插件</th>
+                        <th class="text-center" style="width: 220px;">
+                            用量占比
+                        </th>
+                        <th class="text-center" style="width: 180px;">
+                            总 Token 消耗
+                        </th>
+                        <th class="text-center" style="width: 140px;">
+                            调用次数
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {displayPlugins.map((plugin, idx) => {
+                        const isOther = plugin.source === '其他插件'
+                        const color = isOther
+                            ? '#94a3b8'
+                            : MODEL_COLORS[idx % MODEL_COLORS.length]
+                        const ratio = (plugin.tokens / total) * 100
+                        return (
+                            <tr>
+                                <td>
+                                    <div class="plugin-name-cell">
+                                        <span
+                                            class="plugin-indicator"
+                                            style={`--accent:${color}`}
+                                        >
+                                            {' '}
+                                        </span>
+                                        {plugin.source}
+                                    </div>
+                                </td>
+                                <td class="text-center">
+                                    <div
+                                        class="plugin-progress-wrapper"
+                                        style="justify-content: center;"
+                                    >
+                                        <div class="plugin-progress-bar">
+                                            <div
+                                                class="plugin-progress-fill"
+                                                style={`--accent:${color}; width:${Math.max(1, Math.min(100, ratio))}%`}
+                                            >
+                                                {' '}
+                                            </div>
+                                        </div>
+                                        <span
+                                            class="plugin-number"
+                                            style="min-width: 45px;"
+                                        >
+                                            {ratio.toFixed(1)}%
+                                        </span>
+                                    </div>
+                                </td>
+                                <td class="plugin-number text-center">
+                                    {formatNum(plugin.tokens)}
+                                </td>
+                                <td class="plugin-number text-center">
+                                    {formatNum(plugin.calls)}
+                                </td>
+                            </tr>
+                        )
+                    })}
+                </tbody>
+            </table>
         </section>
     )
 }
 
-function pageHtml(data: ChatLunaUsage.TokenReport, theme: RenderTheme) {
+function renderLegend(
+    points: ChatLunaUsage.TokenPoint[],
+    mode: ChatLunaUsage.TokenRenderMode = 'both'
+) {
+    const { colorMap } = getTopModels(points)
+    const showLine = mode === 'both' || mode === 'line'
+    const showBar = mode === 'both' || mode === 'bar'
+
+    return (
+        <div class="chart-legend" style="flex-wrap: wrap; gap: 8px 0;">
+            {showLine && (
+                <div class="legend-item">
+                    <span
+                        class="legend-color-indicator"
+                        style="--legend-color:var(--color-total)"
+                    >
+                        {' '}
+                    </span>
+                    总 Token
+                </div>
+            )}
+            {showBar &&
+                Object.entries(colorMap).map(([model, color]) => (
+                    <div class="legend-item">
+                        <span
+                            class="legend-color-indicator"
+                            style={`--legend-color:${color}`}
+                        >
+                            {' '}
+                        </span>
+                        {model}
+                    </div>
+                ))}
+        </div>
+    )
+}
+
+function pageHtml(
+    data: ChatLunaUsage.TokenReport,
+    theme: RenderTheme,
+    mode: ChatLunaUsage.TokenRenderMode = 'both'
+) {
     return (
         '<!doctype html>' +
         String(
@@ -563,24 +735,58 @@ function pageHtml(data: ChatLunaUsage.TokenReport, theme: RenderTheme) {
                         name="viewport"
                         content="width=device-width, initial-scale=1.0"
                     />
-                    <title>Chatluna token 消耗趋势</title>
+                    <title>Chatluna Token 消耗分析</title>
                     <style>{CSS}</style>
                 </head>
                 <body>
                     <div class={`stage theme-${theme}`}>
-                        <main class="token-trend-card">
-                            <header class="head">
-                                <div class="mark">{trendIcon()}</div>
-                                <div>
-                                    <h1>Chatluna token 消耗趋势</h1>
-                                    <p class="range">
-                                        时间范围：{formatDate(data.start)} 至{' '}
+                        <main class="card">
+                            <header class="card-header">
+                                <div class="card-title-group">
+                                    <h1>Chatluna Token 消耗分析</h1>
+                                    <p class="card-subtitle">
+                                        时间跨度：{formatDate(data.start)} 至{' '}
                                         {formatDate(data.end)}
                                     </p>
                                 </div>
                             </header>
-                            <section class="chart-wrap">
-                                {chart(data.points)}
+
+                            <section class="metrics-grid">
+                                <div class="metric-item">
+                                    <div class="metric-label">
+                                        累计消耗 Token
+                                    </div>
+                                    <div class="metric-value">
+                                        {formatNum(data.totalTokens)}
+                                    </div>
+                                </div>
+                                <div class="metric-item">
+                                    <div class="metric-label">累计请求次数</div>
+                                    <div class="metric-value">
+                                        {formatNum(data.calls)}
+                                    </div>
+                                </div>
+                                <div class="metric-item">
+                                    <div class="metric-label">
+                                        TPM 峰值 (每分钟)
+                                    </div>
+                                    <div class="metric-value">
+                                        {formatNum(data.tpm)}
+                                    </div>
+                                </div>
+                                <div class="metric-item">
+                                    <div class="metric-label">
+                                        RPM 峰值 (每分钟)
+                                    </div>
+                                    <div class="metric-value">
+                                        {formatNum(data.rpm)}
+                                    </div>
+                                </div>
+                            </section>
+
+                            <section class="chart-container">
+                                {chart(data.points, mode)}
+                                {renderLegend(data.points, mode)}
                             </section>
                         </main>
                         {pluginCard(data.plugins)}
@@ -595,12 +801,18 @@ export async function renderTokenTrend(
     ctx: Context,
     puppeteer: Context['puppeteer'],
     data: ChatLunaUsage.TokenReport,
-    theme: RenderTheme = 'light'
+    theme: RenderTheme = 'light',
+    mode: ChatLunaUsage.TokenRenderMode = 'both'
 ) {
     let page: Awaited<ReturnType<Context['puppeteer']['page']>> | undefined
     try {
         page = await puppeteer.page()
-        await page.setContent(pageHtml(data, theme), {
+        await page.setViewport({
+            width: 1040,
+            height: 820,
+            deviceScaleFactor: 2
+        })
+        await page.setContent(pageHtml(data, theme, mode), {
             waitUntil: 'domcontentloaded'
         })
         await page.evaluate(() => document.fonts.ready)

--- a/packages/extension-usage/src/tokens.ts
+++ b/packages/extension-usage/src/tokens.ts
@@ -86,10 +86,8 @@ export function createTokenReport(
             minuteCalls = 1
         }
         totalTokens += tokens
-        if (point) {
-            point.tokens += tokens
-            point.models[row.model] = (point.models[row.model] || 0) + tokens
-        }
+        point.tokens += tokens
+        point.models[row.model] = (point.models[row.model] || 0) + tokens
         if (withPlugins) {
             const plugin = plugins.get(row.source) ?? {
                 source: row.source,

--- a/packages/extension-usage/src/tokens.ts
+++ b/packages/extension-usage/src/tokens.ts
@@ -65,6 +65,8 @@ export function createTokenReport(
                               ? `${label} ${pad(date.getHours())}:00`
                               : label,
                       tokens: 0,
+                      inputTokens: 0,
+                      outputTokens: 0,
                       models: {}
                   }
               }
@@ -87,6 +89,8 @@ export function createTokenReport(
         }
         totalTokens += tokens
         point.tokens += tokens
+        point.inputTokens += row.usageMetadata.input_tokens ?? 0
+        point.outputTokens += row.usageMetadata.output_tokens ?? 0
         point.models[row.model] = (point.models[row.model] || 0) + tokens
         if (withPlugins) {
             const plugin = plugins.get(row.source) ?? {

--- a/packages/extension-usage/src/tokens.ts
+++ b/packages/extension-usage/src/tokens.ts
@@ -65,8 +65,7 @@ export function createTokenReport(
                               ? `${label} ${pad(date.getHours())}:00`
                               : label,
                       tokens: 0,
-                      inputTokens: 0,
-                      outputTokens: 0
+                      models: {}
                   }
               }
           )
@@ -89,8 +88,7 @@ export function createTokenReport(
         totalTokens += tokens
         if (point) {
             point.tokens += tokens
-            point.inputTokens += row.usageMetadata.input_tokens
-            point.outputTokens += row.usageMetadata.output_tokens
+            point.models[row.model] = (point.models[row.model] || 0) + tokens
         }
         if (withPlugins) {
             const plugin = plugins.get(row.source) ?? {

--- a/packages/extension-usage/src/utils.ts
+++ b/packages/extension-usage/src/utils.ts
@@ -260,7 +260,7 @@ export namespace ChatLunaUsage {
             Schema.const('bar').description('仅柱状图')
         ])
             .description('tokens命令渲染出的图表展示模式')
-            .default('bar')
+            .default('line')
             .role('select')
     })
 

--- a/packages/extension-usage/src/utils.ts
+++ b/packages/extension-usage/src/utils.ts
@@ -24,6 +24,11 @@ export function summary(
     }
 }
 
+export function calculateTheme(): Exclude<ChatLunaUsage.TokenTheme, 'auto'> {
+    const currentHours = new Date().getHours()
+    return currentHours < 6 || currentHours >= 18 ? 'dark' : 'light'
+}
+
 export async function queryUsage(ctx: Context, source?: string) {
     const result = await ctx.chatluna_usage.query({ groupBy: 'source' })
     if (!source) return result.groups
@@ -161,6 +166,8 @@ export namespace ChatLunaUsage {
     export interface TokenPoint {
         label: string
         tokens: number
+        inputTokens: number
+        outputTokens: number
         models: { [model: string]: number }
     }
 
@@ -253,7 +260,7 @@ export namespace ChatLunaUsage {
             Schema.const('bar').description('仅柱状图')
         ])
             .description('tokens命令渲染出的图表展示模式')
-            .default('both')
+            .default('bar')
             .role('select')
     })
 

--- a/packages/extension-usage/src/utils.ts
+++ b/packages/extension-usage/src/utils.ts
@@ -156,12 +156,12 @@ export namespace ChatLunaUsage {
 
     export type TokenRange = 'day' | 'week' | 'month' | 'all'
     export type TokenTheme = 'auto' | 'light' | 'dark'
+    export type TokenRenderMode = 'both' | 'line' | 'bar'
 
     export interface TokenPoint {
         label: string
         tokens: number
-        inputTokens: number
-        outputTokens: number
+        models: { [model: string]: number }
     }
 
     export interface PluginUsage {
@@ -214,6 +214,7 @@ export namespace ChatLunaUsage {
         pageSize: number
         webui: boolean
         tokensTheme: TokenTheme
+        tokensRenderMode: TokenRenderMode
     }
 
     export interface TokenCommandOptions {
@@ -245,6 +246,14 @@ export namespace ChatLunaUsage {
         ])
             .description('tokens命令渲染出的图表颜色主题')
             .default('auto')
+            .role('select'),
+        tokensRenderMode: Schema.union([
+            Schema.const('both').description('曲线和柱状图'),
+            Schema.const('line').description('仅曲线'),
+            Schema.const('bar').description('仅柱状图')
+        ])
+            .description('tokens命令渲染出的图表展示模式')
+            .default('both')
             .role('select')
     })
 


### PR DESCRIPTION
## 变更内容

- 优化 `chatluna.tokens` 图表渲染样式，改为纸雕风格的浅色/深色主题。
- 支持 token 图表展示模式配置：曲线、柱形图、曲线与柱形图组合。
- 将图表柱形按模型分层堆叠展示，并为图例区分总 token 与模型标识。
- 移除多余卡片包裹，使图表和插件明细直接融合到主题背景中。
- 重构 `renderer.tsx` 的图表渲染逻辑，拆分布局、网格、柱形、折线点、坐标轴和插件明细渲染。
- 提取图表尺寸、模型数量、曲线参数和插件展示数量等渲染参数，减少函数内部硬编码。
- 修正 `chatluna.tokens` 参数错误提示，保持与 chatluna 的其他指令说明一致。
- 移除 token 点位更新中的多余下游兜底，使汇总数据与图表点位更新保持一致。

## 验证

-  yarn workspace @root/chatluna-koishi fast-build extension-usage
- 浅色模式下 ` chatluna tokens a p` 效果：
<img width="1280" height="1249" alt="6cf57e132f9b7cd749620aa78c359965_720" src="https://github.com/user-attachments/assets/363d7fe0-42d4-43a9-b1a2-fa65fee5fee2" />
- 深色模式下 ` chatluna tokens a p` 效果：
<img width="1280" height="1249" alt="142606d86542a0c89925ad3e833abb61_720" src="https://github.com/user-attachments/assets/d583c602-d803-442e-9259-8a86efaee2de" />
