### PR TITLE
fix(core): skip retries for missing config

### DIFF
--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -473,13 +473,18 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
         maxAttempts: number
     ): boolean {
         return (
-            this._isAbortError(error) || hasChunk || attempt === maxAttempts - 1
+            this._isNonRetryableError(error) ||
+            hasChunk ||
+            attempt === maxAttempts - 1
         )
     }
 
-    private _isAbortError(error: unknown): boolean {
+    private _isNonRetryableError(error: unknown): boolean {
         if (error instanceof ChatLunaError) {
-            return error.errorCode === ChatLunaErrorCode.ABORTED
+            return (
+                error.errorCode === ChatLunaErrorCode.ABORTED ||
+                error.errorCode === ChatLunaErrorCode.NOT_AVAILABLE_CONFIG
+            )
         }
 
         return (error as Error)?.name === 'AbortError'
@@ -674,7 +679,7 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                 } catch (error) {
                     if (
                         options.stream ||
-                        this._isAbortError(error) ||
+                        this._isNonRetryableError(error) ||
                         attempt === maxAttempts - 1
                     ) {
                         throw error


### PR DESCRIPTION
This pr keeps non-retryable configuration errors from being retried by ChatLuna chat models.

## Bug Fixes
- Treat NOT_AVAILABLE_CONFIG as a non-retryable ChatLuna error.
- Keep abort errors and streamed partial responses from retrying as before.
- Reuse the same non-retryable check across streaming and non-streaming generation paths.

## Validation
- yarn lint-fix (0 errors, existing max-len warnings in packages/extension-agent/src/sub-agent/builtin.ts only)