### PR TITLE
fix(adapter): handle unsafe response errors

### DIFF
--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -455,6 +455,13 @@ export class GeminiRequester
     ) {
         const parts = candidate.content?.parts
 
+        if (candidate.finishReason === 'SAFETY') {
+            throw new ChatLunaError(
+                ChatLunaErrorCode.API_UNSAFE_CONTENT,
+                new Error('Unsafe content detected, please try again.' + chunk)
+            )
+        }
+
         if (
             (parts == null || parts.length < 1) &&
             candidate.finishReason !== 'STOP' &&
@@ -557,7 +564,10 @@ export class GeminiRequester
                 }
 
                 if (updatedToolCalling) {
-                    functionIndex++
+                    const fc = chunk['functionCall']
+                    if (fc?.name && fc.name.length > 0) {
+                        functionIndex++
+                    }
                 }
             } catch (e) {
                 if (errorCount > 5) {
@@ -614,7 +624,7 @@ export class GeminiRequester
                     `${hash}.${type}`
                 )
 
-                messagePart.text = '[image]'
+                messagePart.text = `[image:${file.url}]`
                 messageContent = [
                     {
                         type: 'image_url',
@@ -627,9 +637,10 @@ export class GeminiRequester
         const deltaFunctionCall = chatFunctionCallingPart?.functionCall
         let updatedToolCalling: ToolCallChunk
         if (deltaFunctionCall) {
+            const isNew = deltaFunctionCall.name.length > 0
             updatedToolCalling = this._createToolCallChunk(
                 deltaFunctionCall,
-                functionIndex
+                isNew ? functionIndex : functionIndex - 1
             )
         }
 
@@ -642,12 +653,20 @@ export class GeminiRequester
 
     private _createToolCallChunk(
         deltaFunctionCall: ChatFunctionCallingPart['functionCall'],
-        functionIndex: number
+        index: number
     ) {
+        const isNew = deltaFunctionCall.name.length > 0
+        const args =
+            Object.keys(deltaFunctionCall.args ?? {}).length > 0
+                ? JSON.stringify(deltaFunctionCall.args)
+                : undefined
         return {
-            name: deltaFunctionCall?.name,
-            args: JSON.stringify(deltaFunctionCall.args),
-            id: deltaFunctionCall.id ?? `function_call_${functionIndex}`
+            name: isNew ? deltaFunctionCall.name : undefined,
+            args,
+            id: isNew
+                ? (deltaFunctionCall.id ?? `function_call_${index}`)
+                : undefined,
+            index
         } satisfies ToolCallChunk
     }
 

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -637,7 +637,7 @@ export class GeminiRequester
         const deltaFunctionCall = chatFunctionCallingPart?.functionCall
         let updatedToolCalling: ToolCallChunk
         if (deltaFunctionCall) {
-            const isNew = deltaFunctionCall.name.length > 0
+            const isNew = deltaFunctionCall.name?.length > 0
             updatedToolCalling = this._createToolCallChunk(
                 deltaFunctionCall,
                 isNew ? functionIndex : functionIndex - 1
@@ -655,7 +655,7 @@ export class GeminiRequester
         deltaFunctionCall: ChatFunctionCallingPart['functionCall'],
         index: number
     ) {
-        const isNew = deltaFunctionCall.name.length > 0
+        const isNew = deltaFunctionCall.name?.length > 0
         const args =
             Object.keys(deltaFunctionCall.args ?? {}).length > 0
                 ? JSON.stringify(deltaFunctionCall.args)

--- a/packages/core/src/commands/chat.ts
+++ b/packages/core/src/commands/chat.ts
@@ -1,6 +1,7 @@
 import { Context, h } from 'koishi'
 import { Config } from '../config'
 import { ChatChain } from '../chains/chain'
+import { hideSlashGroups } from '../utils/koishi'
 import { RenderType } from '../types'
 
 export function apply(ctx: Context, config: Config, chain: ChatChain) {
@@ -10,17 +11,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
         })
         .alias('chatluna')
 
-    const toJSON = root.toJSON.bind(root)
-    root.toJSON = () => {
-        const data = toJSON()
-        data.children = data.children.filter((cmd) => {
-            return (
-                root.children.find((child) => child.name === cmd.name)?.config
-                    .slash !== false
-            )
-        })
-        return data
-    }
+    hideSlashGroups(root)
 
     ctx.command('chatluna.chat <message:text>')
         .option('conversation', '-c <conversation:string>')

--- a/packages/core/src/commands/chat.ts
+++ b/packages/core/src/commands/chat.ts
@@ -4,9 +4,23 @@ import { ChatChain } from '../chains/chain'
 import { RenderType } from '../types'
 
 export function apply(ctx: Context, config: Config, chain: ChatChain) {
-    ctx.command('chatluna', {
-        authority: 1
-    }).alias('chatluna')
+    const root = ctx
+        .command('chatluna', {
+            authority: 1
+        })
+        .alias('chatluna')
+
+    const toJSON = root.toJSON.bind(root)
+    root.toJSON = () => {
+        const data = toJSON()
+        data.children = data.children.filter((cmd) => {
+            return (
+                root.children.find((child) => child.name === cmd.name)?.config
+                    .slash !== false
+            )
+        })
+        return data
+    }
 
     ctx.command('chatluna.chat <message:text>')
         .option('conversation', '-c <conversation:string>')
@@ -115,6 +129,8 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             await chain.receiveCommand(session, 'wipe')
         }
     )
+
+    ctx.command('chatluna.admin', { authority: 3, slash: false })
 
     ctx.command('chatluna.admin.purge-legacy', { authority: 3 }).action(
         async ({ session }) => {

--- a/packages/core/src/commands/conversation.ts
+++ b/packages/core/src/commands/conversation.ts
@@ -3,10 +3,6 @@ import { Config } from '../config'
 import { ChatChain } from '../chains/chain'
 
 export function apply(ctx: Context, _config: Config, chain: ChatChain) {
-    ctx.command('chatluna.conversation', {
-        authority: 1
-    }).alias('chatluna.session')
-
     ctx.command('chatluna.rule', {
         authority: 3
     })

--- a/packages/core/src/commands/mcp.ts
+++ b/packages/core/src/commands/mcp.ts
@@ -4,7 +4,7 @@ import { Config } from '../config'
 
 export function apply(ctx: Context, config: Config, chain: ChatChain) {
     ctx.inject(['chatluna_agent'], (ctx) => {
-        ctx.command('chatluna.mcp', { authority: 1 })
+        ctx.command('chatluna.mcp', { authority: 1, slash: false })
 
         // List command
         ctx.command('chatluna.mcp.list').action(async ({ session }) => {

--- a/packages/core/src/commands/providers.ts
+++ b/packages/core/src/commands/providers.ts
@@ -3,9 +3,9 @@ import { Config } from '../config'
 import { ChatChain } from '../chains/chain'
 
 export function apply(ctx: Context, config: Config, chain: ChatChain) {
-    ctx.command('chatluna.embeddings', { authority: 1 })
+    ctx.command('chatluna.embeddings', { authority: 1, slash: false })
 
-    ctx.command('chatluna.vectorstore', { authority: 1 })
+    ctx.command('chatluna.vectorstore', { authority: 1, slash: false })
 
     ctx.command('chatluna.embeddings.list')
         .option('page', '-p <page:number>')

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -265,12 +265,12 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                         latestTokenUsage
                     )
                     hasToolCallChunk = hasTool || hasToolCallChunk
-                    hasChunk = true
                     hasResponse =
                         hasResponse ||
                         this._hasResponse(
                             chunk.message as AIMessage | AIMessageChunk
                         )
+                    hasChunk = hasResponse ?? hasChunk
                     response = response != null ? response.concat(chunk) : chunk
                     yield chunk
                 }

--- a/packages/core/src/middlewares/model/test_model.ts
+++ b/packages/core/src/middlewares/model/test_model.ts
@@ -100,7 +100,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
 
                 try {
                     response = await chatModel.invoke('Hello', {
-                        maxTokens: 10,
+                        maxTokens: 50,
                         signal: AbortSignal.timeout(60000)
                     })
                 } catch (error) {

--- a/packages/core/src/utils/koishi.ts
+++ b/packages/core/src/utils/koishi.ts
@@ -1,4 +1,4 @@
-import { ForkScope, h, Session, User } from 'koishi'
+import { Command, ForkScope, h, Session, User } from 'koishi'
 import { PromiseLikeDisposable } from 'koishi-plugin-chatluna/utils/types'
 import { Marked, Token } from 'marked'
 import type { MessageContent } from '@langchain/core/messages'
@@ -243,4 +243,16 @@ export function normalizeForwardMessageId(value: unknown): string | null {
 
     const trimmed = value.trim()
     return trimmed.length > 0 ? trimmed : null
+}
+
+export function hideSlashGroups(root: Command): void {
+    const toJSON = root.toJSON.bind(root)
+    root.toJSON = () => {
+        const data = toJSON()
+        data.children = data.children.filter((child) => {
+            const real = root.children.find((c) => c.name === child.name)
+            return !(real?.config.slash === false && !child.children?.length)
+        })
+        return data
+    }
 }

--- a/packages/core/src/utils/koishi.ts
+++ b/packages/core/src/utils/koishi.ts
@@ -249,9 +249,11 @@ export function hideSlashGroups(root: Command): void {
     const toJSON = root.toJSON.bind(root)
     root.toJSON = () => {
         const data = toJSON()
-        data.children = data.children.filter((child) => {
+        data.children = data.children.flatMap((child) => {
             const real = root.children.find((c) => c.name === child.name)
-            return !(real?.config.slash === false && !child.children?.length)
+            return real?.config.slash === false
+                ? (child.children ?? [])
+                : [child]
         })
         return data
     }

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -86,8 +86,8 @@ function throwIfUnsafeCode(
 
 function throwIfUnsafeBody(body: string): void {
     try {
-        const parsed = JSON.parse(body) as { error?: OpenAIError }
-        throwIfUnsafeCode(parsed.error?.code, body)
+        const parsed = JSON.parse(body) as { error?: OpenAIError } | null
+        if (parsed) throwIfUnsafeCode(parsed.error?.code, body)
     } catch (e) {
         if (e instanceof ChatLunaError) throw e
     }

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -19,10 +19,12 @@ import {
     ChatCompletionResponseMessageRoleEnum,
     CreateEmbeddingResponse,
     CreateRerankResponse,
+    OpenAIError,
     type ResponseBuiltinTool,
     ResponseObject,
     ResponseOutputItem,
-    ResponseStreamEvent
+    ResponseStreamEvent,
+    UNSAFE_OPENAI_ERROR_CODES
 } from './types'
 import {
     convertDeltaToMessageChunk,
@@ -68,6 +70,27 @@ export type ResponseImageProvider = (
 export interface ResponseToolOptions {
     googleSearch?: boolean
     builtinTools?: ResponseBuiltinTool[]
+}
+
+function throwIfUnsafeCode(
+    code: string | undefined | null,
+    detail: string
+): void {
+    if (code != null && UNSAFE_OPENAI_ERROR_CODES.includes(code)) {
+        throw new ChatLunaError(
+            ChatLunaErrorCode.API_UNSAFE_CONTENT,
+            new Error('Unsafe content detected, please try again.' + detail)
+        )
+    }
+}
+
+function throwIfUnsafeBody(body: string): void {
+    try {
+        const parsed = JSON.parse(body) as { error?: OpenAIError }
+        throwIfUnsafeCode(parsed.error?.code, body)
+    } catch (e) {
+        if (e instanceof ChatLunaError) throw e
+    }
 }
 
 export async function buildChatCompletionParams(
@@ -210,8 +233,8 @@ export async function* processStreamResponse<
         try {
             const data = JSON.parse(chunk) as ChatCompletionResponse
 
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            if ((data as any).error) {
+            if (data.error) {
+                throwIfUnsafeCode(data.error.code, chunk)
                 throw new ChatLunaError(
                     ChatLunaErrorCode.API_REQUEST_FAILED,
                     new Error('Error when calling completion, Result: ' + chunk)
@@ -219,6 +242,8 @@ export async function* processStreamResponse<
             }
 
             const choice = data.choices?.[0]
+
+            throwIfUnsafeCode(choice?.finish_reason, chunk)
 
             if (data.usage) {
                 const usageMetadata = openAIUsageToUsageMetadata(data.usage)
@@ -323,6 +348,8 @@ export async function* processStreamResponse<
                 text: getMessageContent(messageChunk.content)
             })
         } catch (e) {
+            if (e instanceof ChatLunaError) throw e
+
             if (
                 chunk.includes('tool_calls') ||
                 chunk.includes('function_call') ||
@@ -376,6 +403,9 @@ export async function processResponse<
     R extends ChatLunaPlugin.Config
 >(requestContext: RequestContext<T, R>, response: Response) {
     if (response.status !== 200) {
+        const responseText = await response.text()
+        throwIfUnsafeBody(responseText)
+
         throw new ChatLunaError(
             ChatLunaErrorCode.API_REQUEST_FAILED,
             new Error(
@@ -384,7 +414,7 @@ export async function processResponse<
                     ' ' +
                     response.statusText +
                     ', Response: ' +
-                    (await response.text())
+                    responseText
             )
         )
     }
@@ -394,8 +424,8 @@ export async function processResponse<
     try {
         const data = JSON.parse(responseText) as ChatCompletionResponse
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        if ((data as any).error) {
+        if (data.error) {
+            throwIfUnsafeCode(data.error.code, responseText)
             throw new ChatLunaError(
                 ChatLunaErrorCode.API_REQUEST_FAILED,
                 new Error(
@@ -405,6 +435,8 @@ export async function processResponse<
         }
 
         const choice = data.choices?.[0]
+
+        throwIfUnsafeCode(choice?.finish_reason, responseText)
 
         if (!choice) {
             throw new ChatLunaError(
@@ -456,11 +488,14 @@ export async function responseToChatGeneration(
     imageProvider?: ResponseImageProvider
 ) {
     if (response.error) {
+        throwIfUnsafeCode(response.error.code, response.error.message ?? '')
         throw new ChatLunaError(
             ChatLunaErrorCode.API_REQUEST_FAILED,
             new Error(response.error.message ?? JSON.stringify(response.error))
         )
     }
+
+    throwIfUnsafeCode(response.incomplete_details?.reason, '')
 
     const text = responseOutputText(response)
     const toolCalls = responseOutputToolCalls(response)
@@ -516,6 +551,9 @@ export async function processResponseApiResponse(
     imageProvider?: ResponseImageProvider
 ) {
     if (response.status !== 200) {
+        const responseText = await response.text()
+        throwIfUnsafeBody(responseText)
+
         throw new ChatLunaError(
             ChatLunaErrorCode.API_REQUEST_FAILED,
             new Error(
@@ -524,7 +562,7 @@ export async function processResponseApiResponse(
                     ' ' +
                     response.statusText +
                     ', Response: ' +
-                    (await response.text())
+                    responseText
             )
         )
     }
@@ -574,6 +612,14 @@ export async function* processResponseApiStream<
 
         try {
             const data = JSON.parse(chunk) as ResponseStreamEvent
+
+            if (data.type === 'error') {
+                throwIfUnsafeCode(data.code, data.message ?? chunk)
+                throw new ChatLunaError(
+                    ChatLunaErrorCode.API_REQUEST_FAILED,
+                    new Error(chunk)
+                )
+            }
 
             if (data.type === 'response.output_text.delta' && data.delta) {
                 yield new ChatGenerationChunk({
@@ -682,6 +728,9 @@ export async function* processResponseApiStream<
                 data.type === 'response.incomplete' ||
                 data.type === 'response.error'
             ) {
+                throwIfUnsafeCode(data.response?.incomplete_details?.reason, '')
+                throwIfUnsafeCode(data.response?.error?.code, '')
+
                 throw new ChatLunaError(
                     ChatLunaErrorCode.API_REQUEST_FAILED,
                     new Error(chunk)

--- a/packages/shared-adapter/src/types.ts
+++ b/packages/shared-adapter/src/types.ts
@@ -1,3 +1,14 @@
+export interface OpenAIError {
+    code?: string
+    message?: string
+}
+
+export const UNSAFE_OPENAI_ERROR_CODES = [
+    'content_filter',
+    'content_policy_violation',
+    'image_content_policy_violation'
+]
+
 export interface ChatCompletionResponse {
     choices: {
         index: number
@@ -16,6 +27,7 @@ export interface ChatCompletionResponse {
     created: number
     model: string
     usage?: ChatCompletionUsage
+    error?: OpenAIError
 }
 
 export interface ChatCompletionPromptTokensDetails {
@@ -178,7 +190,8 @@ export interface ResponseObject {
     output_text?: string
     output?: ResponseOutputItem[]
     usage?: ResponseUsage
-    error?: { message?: string } | null
+    error?: OpenAIError | null
+    incomplete_details?: { reason?: string } | null
     conversation?: { id: string } | null
 }
 
@@ -225,6 +238,8 @@ export type ResponseOutputContent =
 export interface ResponseStreamEvent {
     type: string
     sequence_number?: number
+    code?: string | null
+    message?: string
     item_id?: string
     output_index?: number
     content_index?: number


### PR DESCRIPTION
This pr improves unsafe-content error handling and command visibility behavior.

## Bug Fixes
- Map Gemini SAFETY finish reasons to API_UNSAFE_CONTENT errors.
- Map OpenAI-compatible content filter and policy violation errors to API_UNSAFE_CONTENT across chat completions and responses APIs.
- Preserve Gemini streamed tool-call chunk indexes when function arguments arrive separately from function names.
- Keep Gemini image placeholders tied to the uploaded file URL for better multimodal context.
- Hide command group placeholders from slash command listings while keeping their child commands available.

## Other Changes
- Increase model test maxTokens to allow short responses to complete reliably.

## Validation
- yarn lint-fix (0 errors, existing max-len warnings in packages/extension-agent/src/sub-agent/builtin.ts only)