### PR TITLE
chore(packages): bump alpha versions

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -46,7 +46,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.41",
+        "@chatluna/v1-shared-adapter": "^1.0.42",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -47,7 +47,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.41",
+        "@chatluna/v1-shared-adapter": "^1.0.42",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.41",
+        "@chatluna/v1-shared-adapter": "^1.0.42",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-deepseek-adapter",
     "description": "deepseek adapter for chatluna",
-    "version": "1.4.0-alpha.10",
+    "version": "1.4.0-alpha.11",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.41",
+        "@chatluna/v1-shared-adapter": "^1.0.42",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.4.0-alpha.5",
+    "version": "1.4.0-alpha.6",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
     ],
     "dependencies": {
         "@anatine/zod-openapi": "^2.2.8",
-        "@chatluna/v1-shared-adapter": "^1.0.41",
+        "@chatluna/v1-shared-adapter": "^1.0.42",
         "@langchain/core": "^0.3.80",
         "openapi3-ts": "^4.5.0",
         "zod": "3.25.76",
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.41",
+        "@chatluna/v1-shared-adapter": "^1.0.42",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.41",
+        "@chatluna/v1-shared-adapter": "^1.0.42",
         "@langchain/core": "^0.3.80"
     },
     "devDependencies": {
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-like-adapter",
     "description": "openai style api adapter for chatluna",
-    "version": "1.4.0-alpha.8",
+    "version": "1.4.0-alpha.9",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.41",
+        "@chatluna/v1-shared-adapter": "^1.0.42",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-adapter",
     "description": "openai adapter for chatluna",
-    "version": "1.4.0-alpha.8",
+    "version": "1.4.0-alpha.9",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.41",
+        "@chatluna/v1-shared-adapter": "^1.0.42",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.41",
+        "@chatluna/v1-shared-adapter": "^1.0.42",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "1.0.41",
+        "@chatluna/v1-shared-adapter": "1.0.42",
         "@langchain/core": "^0.3.80",
         "zod-to-json-schema": "3.23.5"
     },
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -61,7 +61,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.41",
+        "@chatluna/v1-shared-adapter": "^1.0.42",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.41",
+        "@chatluna/v1-shared-adapter": "^1.0.42",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.41",
+        "@chatluna/v1-shared-adapter": "^1.0.42",
         "@langchain/core": "^0.3.80",
         "jsonwebtoken": "^9.0.2",
         "zod": "3.25.76",
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.4.0-alpha.24",
+    "version": "1.4.0-alpha.25",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -89,7 +89,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25",
         "koishi-plugin-chatluna-agent": "^1.0.34",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },

--- a/packages/extension-usage/package.json
+++ b/packages/extension-usage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-usage",
     "description": "Usage records for ChatLuna model calls",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -61,7 +61,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25",
         "koishi-plugin-puppeteer": "^3.9.0"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "koishi": {
         "description": {

--- a/packages/service-multimodal/package.json
+++ b/packages/service-multimodal/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25",
         "koishi-plugin-ffmpeg-path": "^2.0.0"
     },
     "peerDependenciesMeta": {

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25",
         "koishi-plugin-chatluna-agent": "^1.0.34"
     },
     "peerDependenciesMeta": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@chatluna/v1-shared-adapter",
     "description": "chatluna shared adapter",
-    "version": "1.0.41",
+    "version": "1.0.42",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.24"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
     }
 }


### PR DESCRIPTION
This pr bumps package alpha versions for the next ChatLuna release.

## Other Changes
- Bump adapter package alpha versions.
- Bump core and extension package alpha versions.
- Bump renderer, service, and shared package alpha versions.

## Validation
- yarn lint-fix (0 errors, existing max-len warnings in packages/extension-agent/src/sub-agent/builtin.ts only)