### PR TITLE
fix(core): use package utils import

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.4.0-alpha.25",
+    "version": "1.4.0-alpha.27",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/core/src/commands/chat.ts
+++ b/packages/core/src/commands/chat.ts
@@ -1,7 +1,7 @@
 import { Context, h } from 'koishi'
 import { Config } from '../config'
 import { ChatChain } from '../chains/chain'
-import { hideSlashGroups } from '../utils/koishi'
+import { hideSlashGroups } from 'koishi-plugin-chatluna/utils/koishi'
 import { RenderType } from '../types'
 
 export function apply(ctx: Context, config: Config, chain: ChatChain) {

--- a/packages/core/src/middlewares/model/test_model.ts
+++ b/packages/core/src/middlewares/model/test_model.ts
@@ -99,10 +99,13 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 let testError: Error | null = null
 
                 try {
-                    response = await chatModel.invoke('Hello', {
-                        maxTokens: 50,
-                        signal: AbortSignal.timeout(60000)
-                    })
+                    response = await chatModel.invoke(
+                        'Hellom Just reply "world"',
+                        {
+                            maxTokens: 50,
+                            signal: AbortSignal.timeout(60000)
+                        }
+                    )
                 } catch (error) {
                     testError = error
                 }


### PR DESCRIPTION
This pr fixes a core import path and makes model testing more deterministic.

## Bug Fixes
- Use the package utils import for hideSlashGroups in the core chat command.
- Make the model test prompt ask for a deterministic short response.

## Other Changes
- Bump the core package alpha version.

## Validation
- yarn lint-fix (0 errors, existing max-len warnings in packages/extension-agent/src/sub-agent/builtin.ts only)