### PR TITLE
feat(core): track model usage timing

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-azure-openai-adapter",
     "description": "azure openai adapter for chatluna",
-    "version": "1.4.0-alpha.2",
+    "version": "1.4.0-alpha.3",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-claude-adapter",
     "description": "claude adapter for chatluna",
-    "version": "1.4.0-alpha.4",
+    "version": "1.4.0-alpha.5",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-deepseek-adapter",
     "description": "deepseek adapter for chatluna",
-    "version": "1.4.0-alpha.11",
+    "version": "1.4.0-alpha.12",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-dify-adapter",
     "description": "dify adapter for chatluna",
-    "version": "1.4.0-alpha.2",
+    "version": "1.4.0-alpha.3",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-doubao-adapter",
     "description": "doubao adapter for chatluna",
-    "version": "1.4.0-alpha.5",
+    "version": "1.4.0-alpha.6",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.4.0-alpha.6",
+    "version": "1.4.0-alpha.7",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-gemini/src/client.ts
+++ b/packages/adapter-gemini/src/client.ts
@@ -32,6 +32,7 @@ import {
 // #region GeminiClient
 
 import type { ModelUsageReporter } from 'koishi-plugin-chatluna/llm-core/platform/usage'
+import { getModelMaxContextSize } from '@chatluna/v1-shared-adapter'
 
 export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig> {
     platform = 'gemini'
@@ -163,12 +164,16 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
 
             const isEmbedding = name.includes('embedding')
 
-            items.push({
+            const info = {
                 name: model.name,
                 maxTokens: model.inputTokenLimit,
                 type: isEmbedding ? ModelType.embeddings : ModelType.llm,
                 capabilities: createGeminiCapabilities(name, isEmbedding)
-            })
+            }
+
+            info.maxTokens = info.maxTokens ?? getModelMaxContextSize(info)
+
+            items.push(info)
         }
 
         const models: ModelInfo[] = []

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -5,6 +5,8 @@ import {
 } from '@langchain/core/messages'
 import { ChatGeneration, ChatGenerationChunk } from '@langchain/core/outputs'
 import {
+    attachInvocationMetrics,
+    createModelUsageTiming,
     EmbeddingsRequester,
     EmbeddingsRequestParams,
     EmbeddingsResult,
@@ -98,7 +100,6 @@ export class GeminiRequester
             modelConfig,
             this._pluginConfig
         )
-
         try {
             const response = await this._post(
                 `models/${modelConfig.model}:streamGenerateContent?alt=sse`,
@@ -132,6 +133,7 @@ export class GeminiRequester
     ): Promise<ChatGeneration> {
         const modelConfig = prepareModelConfig(params, this._pluginConfig)
 
+        const start = Date.now()
         const chatGenerationParams = await createChatGenerationParams(
             params,
             this._plugin,
@@ -150,7 +152,13 @@ export class GeminiRequester
 
             await checkResponse(response)
 
-            return await this._processResponse(response)
+            const result = await this._processResponse(response)
+            const usage = (result.message as AIMessageChunk).usage_metadata
+            attachInvocationMetrics(result, {
+                usageMetadata: usage,
+                timing: createModelUsageTiming(start, undefined, usage)
+            })
+            return result
         } catch (e) {
             if (this.ctx.chatluna.currentConfig.isLog) {
                 await trackLogToLocal(

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-hunyuan-adapter",
     "description": "hunyuan adapter for chatluna",
-    "version": "1.4.0-alpha.3",
+    "version": "1.4.0-alpha.4",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-ollama-adapter",
     "description": "ollama adapter for chatluna",
-    "version": "1.4.0-alpha.3",
+    "version": "1.4.0-alpha.4",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-like-adapter",
     "description": "openai style api adapter for chatluna",
-    "version": "1.4.0-alpha.9",
+    "version": "1.4.0-alpha.10",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-adapter",
     "description": "openai adapter for chatluna",
-    "version": "1.4.0-alpha.9",
+    "version": "1.4.0-alpha.10",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-qwen-adapter",
     "description": "qwen adapter for chatluna",
-    "version": "1.4.0-alpha.5",
+    "version": "1.4.0-alpha.6",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-rmkv-adapter",
     "description": "rwkv adapter for chatluna",
-    "version": "1.4.0-alpha.2",
+    "version": "1.4.0-alpha.3",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-spark-adapter",
     "description": "spark adapter for chatluna",
-    "version": "1.4.0-alpha.2",
+    "version": "1.4.0-alpha.3",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-wenxin-adapter",
     "description": "wenxin adapter for chatluna",
-    "version": "1.4.0-alpha.2",
+    "version": "1.4.0-alpha.3",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-zhipu-adapter",
     "description": "zhipu(chatglm) adapter for chatluna",
-    "version": "1.4.0-alpha.3",
+    "version": "1.4.0-alpha.4",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.4.0-alpha.27",
+    "version": "1.4.0-alpha.28",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/core/src/llm-core/platform/api.ts
+++ b/packages/core/src/llm-core/platform/api.ts
@@ -1,4 +1,4 @@
-import { BaseMessage } from '@langchain/core/messages'
+import { AIMessageChunk, BaseMessage } from '@langchain/core/messages'
 import { StructuredTool } from '@langchain/core/tools'
 import { ChatGeneration, ChatGenerationChunk } from '@langchain/core/outputs'
 import {
@@ -16,8 +16,15 @@ import type {
     EmbeddingsResult,
     RerankerUsageResult
 } from 'koishi-plugin-chatluna/llm-core/platform/usage'
+import { StreamMetricsTracker } from './metrics'
 
 export type { EmbeddingsResult, RerankerUsageResult }
+export type { ChatLunaInvocationMetrics } from './metrics'
+export {
+    attachInvocationMetrics,
+    createModelUsageTiming,
+    readInvocationMetrics
+} from './metrics'
 
 export interface BaseRequestParams {
     /**
@@ -129,10 +136,19 @@ export abstract class ModelRequester<
         // refresh config
         this._configPool.getConfig(false)
         const config = this._config
+        const tracker = new StreamMetricsTracker()
         try {
             for await (const chunk of this.completionStreamInternal(params)) {
+                tracker.observe(chunk)
                 yield chunk
             }
+
+            yield tracker.attachTo(
+                new ChatGenerationChunk({
+                    message: new AIMessageChunk({ content: '' }),
+                    text: ''
+                })
+            )
         } catch (e) {
             if (
                 (e instanceof ChatLunaError &&

--- a/packages/core/src/llm-core/platform/metrics.ts
+++ b/packages/core/src/llm-core/platform/metrics.ts
@@ -1,0 +1,119 @@
+import { AIMessageChunk } from '@langchain/core/messages'
+import type { UsageMetadata } from '@langchain/core/messages'
+import { ChatGeneration, ChatGenerationChunk } from '@langchain/core/outputs'
+import type { ModelUsageTiming } from 'koishi-plugin-chatluna/llm-core/platform/usage'
+
+/**
+ * Typed carrier for ChatLuna invocation metrics (usage + timing). Attached to
+ * generation results by requesters and read by the model for reporting. The
+ * raw key is encapsulated by attachInvocationMetrics/readInvocationMetrics so
+ * adapters never touch it directly.
+ */
+export interface ChatLunaInvocationMetrics {
+    usageMetadata?: UsageMetadata
+    timing?: ModelUsageTiming
+}
+
+const chatlunaMetricsKey = 'chatluna_invocation_metrics'
+
+type MetricsCarrier = { [chatlunaMetricsKey]?: ChatLunaInvocationMetrics }
+
+export function attachInvocationMetrics(
+    chunk: ChatGeneration | ChatGenerationChunk,
+    metrics: ChatLunaInvocationMetrics
+): void {
+    chunk.generationInfo = {
+        ...chunk.generationInfo,
+        [chatlunaMetricsKey]: metrics
+    }
+    const message = chunk.message as AIMessageChunk | undefined
+    if (message != null) {
+        message.response_metadata = {
+            ...message.response_metadata,
+            [chatlunaMetricsKey]: metrics
+        }
+    }
+}
+
+export function readInvocationMetrics(
+    chunk?: ChatGeneration
+): ChatLunaInvocationMetrics {
+    const message = chunk?.message as AIMessageChunk | undefined
+    const info = chunk?.generationInfo as MetricsCarrier | undefined
+    const metadata = message?.response_metadata as MetricsCarrier | undefined
+    const metrics = info?.[chatlunaMetricsKey] ?? metadata?.[chatlunaMetricsKey]
+    return {
+        usageMetadata: metrics?.usageMetadata ?? message?.usage_metadata,
+        timing: metrics?.timing
+    }
+}
+
+export function createModelUsageTiming(
+    start: number,
+    firstAt?: number,
+    usage?: UsageMetadata
+): ModelUsageTiming {
+    const totalMs = Math.max(0, Date.now() - start)
+    const ttftMs = firstAt == null ? totalMs : Math.max(0, firstAt - start)
+    const genMs = Math.max(0, totalMs - ttftMs)
+    // TPS denominator excludes the first-token latency (prefill); only the
+    // post-TTFT generation span counts as output time. Non-streaming calls
+    // pass no firstAt, so the full elapsed time is used.
+    const tpsMs = firstAt == null ? totalMs : genMs
+    // TPS numerator covers the full generation throughput: visible completion
+    // output plus reasoning tokens.
+    const tpsTokens = usage?.output_tokens ?? 0
+    return {
+        ttftMs,
+        totalMs,
+        tps: Math.min(tpsMs > 0 ? (tpsTokens * 1000) / tpsMs : 0, tpsTokens)
+    }
+}
+
+function hasResponseChunk(chunk: ChatGenerationChunk) {
+    const message = chunk.message as AIMessageChunk | undefined
+    const content = message?.content
+    const kwargs = message?.additional_kwargs
+
+    return (
+        chunk.text.length > 0 ||
+        (typeof content === 'string'
+            ? content.trim().length > 0
+            : Array.isArray(content) && content.length > 0) ||
+        (message?.tool_call_chunks?.length ?? 0) > 0 ||
+        (message?.tool_calls?.length ?? 0) > 0 ||
+        (message?.invalid_tool_calls?.length ?? 0) > 0 ||
+        ((kwargs?.tool_calls as unknown[] | undefined)?.length ?? 0) > 0 ||
+        kwargs?.function_call != null ||
+        kwargs?.thought_data != null
+    )
+}
+
+/**
+ * Collects timing + usage across a streaming completion and attaches a single
+ * ChatLunaInvocationMetrics payload to the trailing chunk. Encapsulates the
+ * mutable state and BaseMessage->AIMessageChunk casts out of completionStream.
+ */
+export class StreamMetricsTracker {
+    private readonly start = Date.now()
+    private firstAt?: number
+    private usage?: UsageMetadata
+
+    observe(chunk: ChatGenerationChunk): void {
+        const message = chunk.message as AIMessageChunk | undefined
+        if (message?.usage_metadata != null) {
+            this.usage = message.usage_metadata
+        }
+        if (this.firstAt == null && hasResponseChunk(chunk)) {
+            this.firstAt = Date.now()
+        }
+    }
+
+    attachTo(chunk: ChatGenerationChunk): ChatGenerationChunk {
+        attachInvocationMetrics(chunk, {
+            usageMetadata: this.usage,
+            timing: createModelUsageTiming(this.start, this.firstAt, this.usage)
+        })
+        return chunk
+    }
+}

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -22,7 +22,8 @@ import {
     EmbeddingsRequester,
     EmbeddingsRequestParams,
     ModelRequester,
-    ModelRequestParams
+    ModelRequestParams,
+    readInvocationMetrics
 } from 'koishi-plugin-chatluna/llm-core/platform/api'
 import type { FileHandlingConfig } from 'koishi-plugin-chatluna/llm-core/platform/client'
 import {
@@ -46,7 +47,8 @@ import { isChatLunaUserMessage } from 'koishi-plugin-chatluna/utils/langchain'
 import { logger } from 'koishi-plugin-chatluna'
 import type {
     ModelUsageContext,
-    ModelUsageReporter
+    ModelUsageReporter,
+    ModelUsageTiming
 } from 'koishi-plugin-chatluna/llm-core/platform/usage'
 import { estimateTextTokens } from 'koishi-plugin-chatluna/llm-core/platform/usage'
 
@@ -316,7 +318,8 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                         await this._reportFailedUsage(
                             options,
                             promptTokens,
-                            latestTokenUsage.output_tokens
+                            latestTokenUsage.output_tokens,
+                            readInvocationMetrics(response).timing
                         )
                     }
                     throw error
@@ -430,8 +433,11 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
         response: ChatGenerationChunk | undefined,
         options: this['ParsedCallOptions']
     ) {
+        const metrics = readInvocationMetrics(response)
+        usage = metrics.usageMetadata ?? usage
+
         if (usage.total_tokens > 0) {
-            await this._reportUsage(usage, false, options)
+            await this._reportUsage(usage, false, options, metrics.timing)
             return
         }
 
@@ -445,7 +451,8 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                 total_tokens: promptTokens + outputTokens
             },
             true,
-            options
+            options,
+            metrics.timing
         )
     }
 
@@ -518,40 +525,8 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
             throw new ChatLunaError(ChatLunaErrorCode.API_REQUEST_FAILED)
         }
 
-        const message = response.message as AIMessage | AIMessageChunk
-        let usageMetadata = message.usage_metadata
-
-        if (!usageMetadata?.total_tokens) {
-            const metadata = message.response_metadata as
-                | {
-                      tokenUsage?: {
-                          promptTokens?: number
-                          completionTokens?: number
-                          totalTokens?: number
-                      }
-                      usage?: {
-                          prompt_tokens?: number
-                          completion_tokens?: number
-                          total_tokens?: number
-                      }
-                  }
-                | undefined
-            const tokenUsage = metadata?.tokenUsage
-            const usage = metadata?.usage
-            if (tokenUsage?.totalTokens != null) {
-                usageMetadata = {
-                    input_tokens: tokenUsage.promptTokens ?? 0,
-                    output_tokens: tokenUsage.completionTokens ?? 0,
-                    total_tokens: tokenUsage.totalTokens
-                }
-            } else if (usage?.total_tokens != null) {
-                usageMetadata = {
-                    input_tokens: usage.prompt_tokens ?? 0,
-                    output_tokens: usage.completion_tokens ?? 0,
-                    total_tokens: usage.total_tokens
-                }
-            }
-        }
+        const metrics = readInvocationMetrics(response)
+        let usageMetadata = metrics.usageMetadata
 
         const estimated = !usageMetadata?.total_tokens
 
@@ -578,7 +553,12 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
             usage_metadata: usageMetadata
         }
 
-        await this._reportUsage(usageMetadata, estimated, options)
+        await this._reportUsage(
+            usageMetadata,
+            estimated,
+            options,
+            metrics.timing
+        )
 
         return {
             generations: [response],
@@ -589,7 +569,8 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
     private async _reportUsage(
         usage: UsageMetadata,
         estimated: boolean,
-        options: this['ParsedCallOptions']
+        options: this['ParsedCallOptions'],
+        timing?: ModelUsageTiming
     ) {
         if (this._report == null) return
 
@@ -599,6 +580,7 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                 usageMetadata: usage,
                 estimated,
                 success: true,
+                timing,
                 context: usageContextFromOptions(options)
             })
         } catch (e) {
@@ -609,7 +591,8 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
     private async _reportFailedUsage(
         options: this['ParsedCallOptions'],
         promptTokens = 0,
-        outputTokens = 0
+        outputTokens = 0,
+        timing?: ModelUsageTiming
     ) {
         if (this._report == null) return
 
@@ -623,6 +606,7 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                 },
                 estimated: promptTokens > 0 || outputTokens > 0,
                 success: false,
+                timing,
                 context: usageContextFromOptions(options)
             })
         } catch (e) {
@@ -827,6 +811,7 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
         const conversationRounds = buildConversationRounds(messages)
         const selectedRounds: BaseMessage[][] = []
         let truncated = false
+        let overflowTokens = 0
         const hasLimit = maxTokenLimit != null && maxTokenLimit > 0
 
         // Find baseline: last AI message with usage_metadata
@@ -863,6 +848,7 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
             // If we hit the baseline region, bulk-add everything up to it
             if (baselineRoundIdx >= 0 && i <= baselineRoundIdx) {
                 if (hasLimit && totalTokens + baselineTokens > maxTokenLimit) {
+                    overflowTokens = totalTokens + baselineTokens
                     truncated = true
                     break
                 }
@@ -876,6 +862,7 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                 hasLimit && totalTokens + roundTokens > maxTokenLimit
 
             if (exceeds && selectedRounds.length > 0) {
+                overflowTokens = totalTokens + roundTokens
                 truncated = true
                 break
             }
@@ -884,6 +871,7 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
             selectedRounds.unshift(conversationRounds[i])
 
             if (exceeds) {
+                overflowTokens = totalTokens
                 truncated = true
                 break
             }
@@ -893,7 +881,8 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
             const round = conversationRounds[conversationRounds.length - 1]
             totalTokens += await countRoundTokens(round)
             selectedRounds.unshift(round)
-            truncated = maxTokenLimit != null && maxTokenLimit > 0
+            truncated = hasLimit && totalTokens > maxTokenLimit
+            overflowTokens = truncated ? totalTokens : overflowTokens
         }
 
         const flattenedRounds = selectedRounds.reduce<BaseMessage[]>(
@@ -903,9 +892,10 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
 
         const result = systemMessages.concat(flattenedRounds)
 
-        if (truncated) {
+        if (truncated && hasLimit) {
             logger?.warn(
-                `Message length exceeds token limit. ${totalTokens} > ${maxTokenLimit}. Try increasing the adapter token limit or reducing the message length.`
+                `Message length exceeds token limit. ${overflowTokens} > ${maxTokenLimit}. ` +
+                    `Truncated to ${totalTokens}. Try increasing the adapter token limit or reducing the message length.`
             )
         }
 

--- a/packages/core/src/llm-core/platform/usage.ts
+++ b/packages/core/src/llm-core/platform/usage.ts
@@ -108,7 +108,14 @@ export interface ModelUsagePayload {
     estimated: boolean
     success: boolean
     createdAt: Date
+    timing?: ModelUsageTiming
     context?: ModelUsageContext
+}
+
+export interface ModelUsageTiming {
+    ttftMs?: number
+    totalMs?: number
+    tps?: number
 }
 
 export type ModelUsageInput = Omit<

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -89,7 +89,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28",
         "koishi-plugin-chatluna-agent": "^1.0.34",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },

--- a/packages/extension-usage/client/charts/model-success.vue
+++ b/packages/extension-usage/client/charts/model-success.vue
@@ -107,7 +107,10 @@ const rows = computed(() =>
     (usage.value?.models ?? [])
         .slice()
         .filter((row) => row.calls > 0)
-        .sort((a, b) => b.calls - a.calls)
+        .sort(
+            (a, b) =>
+                b.successRate - a.successRate || b.calls - a.calls
+        )
 )
 
 const totalCalls = computed(() => usage.value?.totals.calls ?? 0)

--- a/packages/extension-usage/client/home.vue
+++ b/packages/extension-usage/client/home.vue
@@ -192,17 +192,84 @@
                     <el-table-column
                         prop="source"
                         label="插件来源"
-                        :min-width="sourceWidth"
+                        :width="sourceWidth"
                         sortable
                     />
                     <el-table-column
                         prop="callType"
                         label="类型"
-                        width="128"
+                        :min-width="128"
                         sortable
                     >
                         <template #default="scope">
                             {{ typeText(scope.row.callType) }}
+                        </template>
+                    </el-table-column>
+                    <el-table-column
+                        prop="totalMs"
+                        label="性能"
+                        width="220"
+                        align="right"
+                        header-align="left"
+                        sortable="custom"
+                    >
+                        <template #default="scope">
+                            <el-tooltip
+                                placement="right"
+                                effect="dark"
+                                popper-class="chatluna-usage-token-popper"
+                            >
+                                <template #content>
+                                    <div class="token-detail">
+                                        <p class="token-detail-title">
+                                            性能明细
+                                        </p>
+                                        <div class="token-detail-row">
+                                            <span>首字延迟 TTFT</span>
+                                            <strong>
+                                                {{ dur(scope.row.ttftMs) }}
+                                            </strong>
+                                        </div>
+                                        <div class="token-detail-row">
+                                            <span>输出速度 TPS</span>
+                                            <strong>
+                                                {{ rate(scope.row.tps) }}
+                                            </strong>
+                                        </div>
+                                        <div class="token-detail-divider"></div>
+                                        <div class="token-detail-row total">
+                                            <span>总耗时 Total</span>
+                                            <strong>
+                                                {{ dur(scope.row.totalMs) }}
+                                            </strong>
+                                        </div>
+                                    </div>
+                                </template>
+                                <div class="token-cell perf-cell">
+                                    <div class="token-row">
+                                        <span class="token-item perf-ttft">
+                                            <span>TTFT</span>
+                                            <strong>
+                                                {{ dur(scope.row.ttftMs) }}
+                                            </strong>
+                                        </span>
+                                        <span class="token-item perf-tps">
+                                            <span>TPS</span>
+                                            <strong>
+                                                {{ rate(scope.row.tps) }}
+                                            </strong>
+                                        </span>
+                                    </div>
+                                    <div class="token-row">
+                                        <span class="token-item perf-total">
+                                            <span>Total</span>
+                                            <strong>
+                                                {{ dur(scope.row.totalMs) }}
+                                            </strong>
+                                        </span>
+                                    </div>
+                                </div>
+                            </el-tooltip>
                         </template>
                     </el-table-column>
                     <el-table-column
@@ -435,6 +502,7 @@ import SourceList from './sources/index.vue'
 import {
     changeListRange,
     clearHistory,
+    dur,
     fmt,
     list,
     listLoading,
@@ -442,6 +510,7 @@ import {
     listRange,
     loading,
     refreshList,
+    rate,
     resetFilters as resetQuery,
     scope,
     scopes,
@@ -1362,6 +1431,24 @@ function changeSort(data: {
 
 .token-reasoning {
     color: var(--el-color-info);
+}
+
+.perf-cell .token-item span {
+    color: var(--k-text-light);
+    font-size: 0.78rem;
+    font-weight: 500;
+}
+
+.perf-ttft strong {
+    color: var(--el-color-warning);
+}
+
+.perf-tps strong {
+    color: var(--el-color-success);
+}
+
+.perf-total strong {
+    color: var(--k-color-primary);
 }
 
 .chatluna-usage-token-popper.el-popper {

--- a/packages/extension-usage/client/state.ts
+++ b/packages/extension-usage/client/state.ts
@@ -203,6 +203,16 @@ export function time(value?: string | Date) {
     return value ? new Date(value).toLocaleString() : '-'
 }
 
+export function dur(value?: number | null) {
+    if (value == null) return '-'
+    if (value >= 1000) return `${(value / 1000).toFixed(2)}s`
+    return `${Math.round(value)}ms`
+}
+
+export function rate(value?: number | null) {
+    return value == null ? '-' : `${value.toFixed(2)} t/s`
+}
+
 watch(
     () => [
         query.period,

--- a/packages/extension-usage/package.json
+++ b/packages/extension-usage/package.json
@@ -61,7 +61,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28",
         "koishi-plugin-puppeteer": "^3.9.0"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-usage/src/index.ts
+++ b/packages/extension-usage/src/index.ts
@@ -40,6 +40,9 @@ class ChatLunaUsageService extends DataService<ChatLunaUsage.Payload> {
                 estimated: 'boolean',
                 success: 'boolean',
                 createdAt: { type: 'timestamp', nullable: false },
+                ttftMs: { type: 'integer', nullable: true },
+                totalMs: { type: 'integer', nullable: true },
+                tps: { type: 'float', nullable: true },
                 conversationId: { type: 'char', length: 255, nullable: true },
                 requestId: { type: 'char', length: 255, nullable: true },
                 userId: { type: 'char', length: 255, nullable: true },
@@ -64,6 +67,9 @@ class ChatLunaUsageService extends DataService<ChatLunaUsage.Payload> {
                     estimated: usage.estimated,
                     success: usage.success,
                     createdAt: usage.createdAt,
+                    ttftMs: usage.timing?.ttftMs ?? null,
+                    totalMs: usage.timing?.totalMs ?? null,
+                    tps: usage.timing?.tps ?? null,
                     conversationId: usage.context?.conversationId ?? null,
                     requestId: usage.context?.requestId ?? null,
                     userId: usage.context?.userId ?? null,
@@ -471,12 +477,23 @@ class ChatLunaUsageService extends DataService<ChatLunaUsage.Payload> {
             row.usageMetadata.output_token_details?.reasoning ?? 0
         if (row.estimated)
             item.estimatedTokens += row.usageMetadata.total_tokens
+        if (row.totalMs != null) {
+            item.timedCalls += 1
+            item.ttftMs += row.ttftMs ?? 0
+            item.totalMs += row.totalMs
+            item.tps += row.tps ?? 0
+        }
         if (!item.lastSeen || row.createdAt > item.lastSeen)
             item.lastSeen = row.createdAt
     }
 
     private finish(item: ChatLunaUsage.Summary) {
         item.successRate = item.calls ? item.successfulCalls / item.calls : 0
+        if (item.timedCalls > 0) {
+            item.ttftMs /= item.timedCalls
+            item.totalMs /= item.timedCalls
+            item.tps /= item.timedCalls
+        }
         return item
     }
 

--- a/packages/extension-usage/src/utils.ts
+++ b/packages/extension-usage/src/utils.ts
@@ -20,6 +20,10 @@ export function summary(
         estimatedTokens: 0,
         cachedTokens: 0,
         reasoningTokens: 0,
+        timedCalls: 0,
+        ttftMs: 0,
+        totalMs: 0,
+        tps: 0,
         successRate: 0
     }
 }
@@ -52,6 +56,9 @@ export namespace ChatLunaUsage {
         estimated: boolean
         success: boolean
         createdAt: Date
+        ttftMs?: number | null
+        totalMs?: number | null
+        tps?: number | null
         conversationId?: string | null
         requestId?: string | null
         userId?: string | null
@@ -85,6 +92,9 @@ export namespace ChatLunaUsage {
         | 'estimatedTokens'
         | 'cachedTokens'
         | 'reasoningTokens'
+        | 'ttftMs'
+        | 'totalMs'
+        | 'tps'
         | 'successRate'
     export type ListSortBy =
         | 'createdAt'
@@ -93,6 +103,9 @@ export namespace ChatLunaUsage {
         | 'totalTokens'
         | 'cachedTokens'
         | 'reasoningTokens'
+        | 'ttftMs'
+        | 'totalMs'
+        | 'tps'
 
     export interface Query {
         period?: Period
@@ -130,6 +143,10 @@ export namespace ChatLunaUsage {
         estimatedTokens: number
         cachedTokens: number
         reasoningTokens: number
+        timedCalls: number
+        ttftMs: number
+        totalMs: number
+        tps: number
         successRate: number
         lastSeen?: Date
     }

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "koishi": {
         "description": {

--- a/packages/service-multimodal/package.json
+++ b/packages/service-multimodal/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28",
         "koishi-plugin-ffmpeg-path": "^2.0.0"
     },
     "peerDependenciesMeta": {

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28",
         "koishi-plugin-chatluna-agent": "^1.0.34"
     },
     "peerDependenciesMeta": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.25"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.28"
     }
 }

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -1,5 +1,7 @@
 import { ChatGenerationChunk } from '@langchain/core/outputs'
 import {
+    attachInvocationMetrics,
+    createModelUsageTiming,
     EmbeddingsRequestParams,
     EmbeddingsResult,
     ModelRequester,
@@ -61,6 +63,20 @@ interface RequestContext<
     pluginConfig: R
     plugin: ChatLunaPlugin
     modelRequester: ModelRequester<T, R>
+}
+
+function attachUsage(
+    chunk: ChatGenerationChunk,
+    start: number,
+    usageMetadata = chunk.message instanceof AIMessageChunk
+        ? chunk.message.usage_metadata
+        : undefined
+) {
+    attachInvocationMetrics(chunk, {
+        usageMetadata,
+        timing: createModelUsageTiming(start, undefined, usageMetadata)
+    })
+    return chunk
 }
 
 export type ResponseImageProvider = (
@@ -808,6 +824,7 @@ export async function completion<
     supportImageInput?: boolean
 ): Promise<ChatGenerationChunk> {
     const { modelRequester } = requestContext
+    const start = Date.now()
 
     const chatCompletionParams = await buildChatCompletionParams(
         params,
@@ -827,7 +844,10 @@ export async function completion<
             }
         )
 
-        return await processResponse(requestContext, response)
+        return attachUsage(
+            await processResponse(requestContext, response),
+            start
+        )
     } catch (e) {
         if (requestContext.ctx.chatluna.currentConfig.isLog) {
             await trackLogToLocal(
@@ -897,6 +917,7 @@ export async function responseApiCompletion<
     imageProvider?: ResponseImageProvider
 ): Promise<ChatGenerationChunk> {
     const { modelRequester } = requestContext
+    const start = Date.now()
     const request = await buildResponseParams(
         params,
         requestContext.plugin,
@@ -912,7 +933,10 @@ export async function responseApiCompletion<
             signal: params.signal
         })
 
-        return await processResponseApiResponse(response, imageProvider)
+        return attachUsage(
+            await processResponseApiResponse(response, imageProvider),
+            start
+        )
     } catch (e) {
         if (requestContext.ctx.chatluna.currentConfig.isLog) {
             await trackLogToLocal(


### PR DESCRIPTION
This pr adds model invocation timing metrics and exposes them in the usage dashboard.

## New Features
- Track TTFT, total latency, and TPS for model calls.
- Attach invocation metrics to streaming and non-streaming model responses.
- Store timing metrics in extension-usage history records.
- Show performance metrics in the usage dashboard list.

## Bug Fixes
- Preserve usage metadata on trailing stream metric chunks.
- Improve token-limit truncation warnings with the actual overflow amount.
- Fill Gemini model max token defaults from shared context-size data.

## Other Changes
- Bump package alpha versions for this metrics update.

## Validation
- yarn lint-fix (0 errors, existing max-len warnings in packages/extension-agent/src/sub-agent/builtin.ts only)