### PR TITLE
fix(core): stabilize usage timing metrics

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.4.0-alpha.29",
+    "version": "1.4.0-alpha.30",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/core/src/llm-core/platform/api.ts
+++ b/packages/core/src/llm-core/platform/api.ts
@@ -21,6 +21,7 @@ import { StreamMetricsTracker } from './metrics'
 export type { EmbeddingsResult, RerankerUsageResult }
 export type { ChatLunaInvocationMetrics } from './metrics'
 export {
+    MIN_LATENCY_MS,
     attachInvocationMetrics,
     createModelUsageTiming,
     readInvocationMetrics

--- a/packages/core/src/llm-core/platform/metrics.ts
+++ b/packages/core/src/llm-core/platform/metrics.ts
@@ -48,23 +48,30 @@ export function readInvocationMetrics(
     }
 }
 
+export const MIN_LATENCY_MS = 10
+
 export function createModelUsageTiming(
     start: number,
     firstAt?: number,
     usage?: UsageMetadata
 ): ModelUsageTiming {
-    const totalMs = Math.max(0, Date.now() - start)
-    const ttftMs = firstAt == null ? totalMs : Math.max(0, firstAt - start)
-    // post-TTFT span is the generation window; non-stream calls use full time
-    const genMs = firstAt == null ? totalMs : Math.max(0, totalMs - ttftMs)
+    const totalMs = Math.max(Date.now() - start, MIN_LATENCY_MS)
     const outputTokens = usage?.output_tokens
+    if (firstAt == null) {
+        return {
+            totalMs,
+            tps:
+                outputTokens == null
+                    ? undefined
+                    : (outputTokens * 1000) / totalMs
+        }
+    }
+    const ttftMs = Math.max(firstAt - start, MIN_LATENCY_MS)
+    const genMs = Math.max(totalMs - ttftMs, MIN_LATENCY_MS)
     return {
         ttftMs,
         totalMs,
-        tps:
-            outputTokens == null || genMs <= 0
-                ? undefined
-                : Math.min((outputTokens * 1000) / genMs, outputTokens)
+        tps: outputTokens == null ? undefined : (outputTokens * 1000) / genMs
     }
 }
 

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -21,6 +21,7 @@ import { sleep } from 'koishi'
 import {
     EmbeddingsRequester,
     EmbeddingsRequestParams,
+    MIN_LATENCY_MS,
     ModelRequester,
     ModelRequestParams,
     readInvocationMetrics
@@ -446,10 +447,13 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
             : 0
         let timing = metrics.timing
         if (timing != null && outputTokens > 0) {
-            const genMs = Math.max(timing.totalMs - timing.ttftMs, 1)
+            const genMs = Math.max(
+                (timing.totalMs ?? 0) - (timing.ttftMs ?? 0),
+                MIN_LATENCY_MS
+            )
             timing = {
                 ...timing,
-                tps: Math.min((outputTokens * 1000) / genMs, outputTokens)
+                tps: (outputTokens * 1000) / genMs
             }
         }
         await this._reportUsage(

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -89,7 +89,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30",
         "koishi-plugin-chatluna-agent": "^1.0.34",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },

--- a/packages/extension-usage/package.json
+++ b/packages/extension-usage/package.json
@@ -61,7 +61,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30",
         "koishi-plugin-puppeteer": "^3.9.0"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "koishi": {
         "description": {

--- a/packages/service-multimodal/package.json
+++ b/packages/service-multimodal/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30",
         "koishi-plugin-ffmpeg-path": "^2.0.0"
     },
     "peerDependenciesMeta": {

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30",
         "koishi-plugin-chatluna-agent": "^1.0.34"
     },
     "peerDependenciesMeta": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.29"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
     }
 }


### PR DESCRIPTION
This pr stabilizes model usage timing metrics and bumps package alpha versions.

## Bug Fixes
- Add a minimum latency floor for TTFT, total duration, and TPS calculation.
- Avoid clamping TPS to output token count so throughput remains accurate.
- Recompute estimated-response TPS with the same latency floor.

## Other Changes
- Bump package alpha versions for the timing metrics fix.

## Validation
- yarn lint-fix (0 errors, existing max-len warnings in packages/extension-agent/src/sub-agent/builtin.ts only)