### PR TITLE
fix(core): calculate usage tps from total time

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.4.0-alpha.8",
+    "version": "1.4.0-alpha.9",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -884,7 +884,10 @@ export function getModalityTokens(
 
 function getCompletionTokens(data: ChatResponse) {
     if (data.usageMetadata?.candidatesTokenCount != null) {
-        return data.usageMetadata.candidatesTokenCount
+        return (
+            data.usageMetadata.candidatesTokenCount +
+            (data.usageMetadata.thoughtsTokenCount ?? 0)
+        )
     }
 
     let total = 0

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.4.0-alpha.31",
+    "version": "1.4.0-alpha.32",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.4.0-alpha.30",
+    "version": "1.4.0-alpha.31",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/core/src/llm-core/platform/metrics.ts
+++ b/packages/core/src/llm-core/platform/metrics.ts
@@ -56,7 +56,8 @@ export function createModelUsageTiming(
     usage?: UsageMetadata
 ): ModelUsageTiming {
     const totalMs = Math.max(Date.now() - start, MIN_LATENCY_MS)
-    const outputTokens = usage?.output_tokens
+    const outputTokens =
+        usage?.output_tokens + (usage?.output_token_details?.reasoning ?? 0)
     if (firstAt == null) {
         return {
             totalMs,

--- a/packages/core/src/llm-core/platform/metrics.ts
+++ b/packages/core/src/llm-core/platform/metrics.ts
@@ -67,11 +67,10 @@ export function createModelUsageTiming(
         }
     }
     const ttftMs = Math.max(firstAt - start, MIN_LATENCY_MS)
-    const genMs = Math.max(totalMs - ttftMs, MIN_LATENCY_MS)
     return {
         ttftMs,
         totalMs,
-        tps: outputTokens == null ? undefined : (outputTokens * 1000) / genMs
+        tps: outputTokens == null ? undefined : (outputTokens * 1000) / totalMs
     }
 }
 

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -21,7 +21,6 @@ import { sleep } from 'koishi'
 import {
     EmbeddingsRequester,
     EmbeddingsRequestParams,
-    MIN_LATENCY_MS,
     ModelRequester,
     ModelRequestParams,
     readInvocationMetrics
@@ -447,13 +446,12 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
             : 0
         let timing = metrics.timing
         if (timing != null && outputTokens > 0) {
-            const genMs = Math.max(
-                (timing.totalMs ?? 0) - (timing.ttftMs ?? 0),
-                MIN_LATENCY_MS
-            )
             timing = {
                 ...timing,
-                tps: (outputTokens * 1000) / genMs
+                tps:
+                    timing.totalMs == null
+                        ? undefined
+                        : (outputTokens * 1000) / timing.totalMs
             }
         }
         await this._reportUsage(

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -89,7 +89,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -89,7 +89,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31",
         "koishi-plugin-chatluna-agent": "^1.0.34",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32",
         "koishi-plugin-chatluna-agent": "^1.0.34",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },

--- a/packages/extension-usage/package.json
+++ b/packages/extension-usage/package.json
@@ -61,7 +61,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32",
         "koishi-plugin-puppeteer": "^3.9.0"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-usage/package.json
+++ b/packages/extension-usage/package.json
@@ -61,7 +61,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31",
         "koishi-plugin-puppeteer": "^3.9.0"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "koishi": {
         "description": {

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "koishi": {
         "description": {

--- a/packages/service-multimodal/package.json
+++ b/packages/service-multimodal/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31",
         "koishi-plugin-ffmpeg-path": "^2.0.0"
     },
     "peerDependenciesMeta": {

--- a/packages/service-multimodal/package.json
+++ b/packages/service-multimodal/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32",
         "koishi-plugin-ffmpeg-path": "^2.0.0"
     },
     "peerDependenciesMeta": {

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32",
         "koishi-plugin-chatluna-agent": "^1.0.34"
     },
     "peerDependenciesMeta": {

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31",
         "koishi-plugin-chatluna-agent": "^1.0.34"
     },
     "peerDependenciesMeta": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.30"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
     }
 }

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.31"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.32"
     }
 }


### PR DESCRIPTION
This pr refines usage TPS calculation and Gemini completion token accounting.

## Bug Fixes
- Calculate usage TPS from total model call duration.
- Apply the same total-duration TPS calculation to estimated token reports.
- Include Gemini thinking tokens in completion token usage.

## Other Changes
- Bump package alpha versions for the timing metrics follow-up.

## Validation
- yarn lint-fix (0 errors, existing max-len warnings in packages/extension-agent/src/sub-agent/builtin.ts only)