### PR TITLE
feat(core): add compression instructions

### DIFF
--- a/packages/core/src/commands/conversation.ts
+++ b/packages/core/src/commands/conversation.ts
@@ -180,16 +180,18 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
         })
 
     const compressCommand = ctx.command(
-        'chatluna.compress [conversation:string]',
+        'chatluna.compress [instruction:text]',
         {
             authority: 1
         }
     )
     compressCommand
+        .alias('chatluna.compact')
+        .option('conversation', '-c <conversation:string>')
         .option('preset', '-p <preset:string>')
         .option('archived', '-a')
         .option('all', '--all')
-        .action(async ({ options, session }, conversation) => {
+        .action(async ({ options, session }, instruction) => {
             const presetLane = options.preset?.trim() || undefined
             const includeArchived =
                 options.archived === true || options.all === true
@@ -200,9 +202,13 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
                     force: true,
                     allPresetLanes: presetLane == null,
                     conversation_manage: {
-                        targetConversation: conversation?.trim() || undefined,
+                        targetConversation:
+                            options.conversation?.trim() || undefined,
                         presetLane,
                         includeArchived
+                    },
+                    conversation_compress: {
+                        instruction: instruction?.trim() || undefined
                     },
                     i18n_base: 'commands.chatluna.compress.messages'
                 },
@@ -439,6 +445,9 @@ declare module '../chains/chain' {
             force?: boolean
             newOnly?: boolean
             clear?: boolean
+        }
+        conversation_compress?: {
+            instruction?: string
         }
         i18n_base?: string
     }

--- a/packages/core/src/llm-core/chain/infinite_context_chain.ts
+++ b/packages/core/src/llm-core/chain/infinite_context_chain.ts
@@ -22,6 +22,9 @@ Focus on information that would be helpful for continuing the conversation, incl
 - Important technical decisions and why they were made
 - Tool calls that were made and their results (summarize the key outcomes)
 
+Additional user instructions for this compression:
+{instruction}
+
 Some old tool result messages may say that the original tool output expired and was removed.
 Treat those as intentional retention placeholders, not as meaningful tool output.
 
@@ -36,7 +39,8 @@ export async function compressChunk(
     model: ChatLunaChatModel,
     transcript: string,
     conversationId: string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    instruction?: string
 ): Promise<CompressChunkResult | null> {
     const trimmed = transcript?.trim()
 
@@ -48,6 +52,7 @@ export async function compressChunk(
 
     const result = await chain.invoke({
         conversation_chunk: trimmed,
+        instruction: instruction?.trim() || 'None',
         id: conversationId,
         stream: false,
         signal

--- a/packages/core/src/llm-core/chat/app.ts
+++ b/packages/core/src/llm-core/chat/app.ts
@@ -393,7 +393,10 @@ export class ChatInterface {
         await this._chain?.value?.model.clearContext(this._input.conversationId)
     }
 
-    async compressContext(force = false): Promise<CompressContextResult> {
+    async compressContext(
+        force = false,
+        instruction?: string
+    ): Promise<CompressContextResult> {
         const wrapper = await this.getChatLunaLLMChainWrapper()
         if (!this._chatHistory) {
             throw new ChatLunaError(
@@ -408,7 +411,8 @@ export class ChatInterface {
             conversationId: this._input.conversationId,
             preset: this._input.preset,
             threshold: this.chatluna.currentConfig.infiniteContextThreshold,
-            force
+            force,
+            instruction
         })
         if (result.messages) {
             await this._chatHistory.replaceMessages(result.messages)

--- a/packages/core/src/llm-core/chat/infinite_context.ts
+++ b/packages/core/src/llm-core/chat/infinite_context.ts
@@ -33,6 +33,7 @@ export interface CompressContextOptions {
     threshold?: number
     force?: boolean
     signal?: AbortSignal
+    instruction?: string
 }
 
 /**
@@ -108,7 +109,8 @@ export async function compressIfNeeded(
         model,
         transcript,
         conversationId,
-        opts.signal
+        opts.signal,
+        opts.instruction
     )
     if (!summary?.text.trim()) return noCompressResult()
 

--- a/packages/core/src/locales/en-US.yml
+++ b/packages/core/src/locales/en-US.yml
@@ -102,8 +102,9 @@ commands:
         compress:
             description: Compress a conversation without referencing rooms.
             arguments:
-                conversation: Target conversation by seq, ID, or title.
+                instruction: Extra compression instruction.
             options:
+                conversation: Target conversation by seq, ID, or title.
                 preset: Preset lane.
                 archived: Include archived conversations.
                 all: Include archived conversations.

--- a/packages/core/src/locales/zh-CN.yml
+++ b/packages/core/src/locales/zh-CN.yml
@@ -102,8 +102,9 @@ commands:
         compress:
             description: 在不引用房间的情况下压缩一个会话。
             arguments:
-                conversation: 目标会话，可使用序号、ID 或标题。
+                instruction: 额外压缩要求。
             options:
+                conversation: 目标会话，可使用序号、ID 或标题。
                 preset: 预设分流。
                 archived: 包含已归档会话。
                 all: 包含已归档会话。

--- a/packages/core/src/middlewares/conversation/resolve_conversation.ts
+++ b/packages/core/src/middlewares/conversation/resolve_conversation.ts
@@ -116,7 +116,7 @@ const TARGET_SUFFIX_BY_COMMAND: Record<string, string> = {
     conversation_archive: 'commands.chatluna.archive.arguments.conversation',
     conversation_restore: 'commands.chatluna.restore.arguments.conversation',
     conversation_export: 'commands.chatluna.export.arguments.conversation',
-    conversation_compress: 'commands.chatluna.compress.arguments.conversation',
+    conversation_compress: 'commands.chatluna.compress.options.conversation',
     conversation_delete: 'commands.chatluna.delete.arguments.conversation'
 }
 

--- a/packages/core/src/middlewares/system/conversation_manage.ts
+++ b/packages/core/src/middlewares/system/conversation_manage.ts
@@ -742,7 +742,8 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             const result =
                 await ctx.chatluna.conversationRuntime.compressConversation(
                     conversation,
-                    context.options.force === true
+                    context.options.force === true,
+                    context.options.conversation_compress?.instruction
                 )
 
             context.message = session.text(

--- a/packages/core/src/services/conversation_runtime.ts
+++ b/packages/core/src/services/conversation_runtime.ts
@@ -428,11 +428,12 @@ export class ConversationRuntime {
 
     async compressConversation(
         conversation: ConversationRecord,
-        force = false
+        force = false,
+        instruction?: string
     ) {
         return this.withConversationAndPlatformLock(conversation, async () => {
             const chatInterface = await this.ensureChatInterface(conversation)
-            return await chatInterface.compressContext(force)
+            return await chatInterface.compressContext(force, instruction)
         })
     }
 


### PR DESCRIPTION
This pr lets users pass extra instructions when manually compressing a conversation.

## New Features
- Add an optional instruction argument to chatluna.compress.
- Add chatluna.compact as an alias for compression.
- Move the target conversation selector to the -c/--conversation option.
- Forward compression instructions through conversation runtime into the infinite-context summarizer prompt.

## Other Changes
- Update English and Chinese command locale text for the new argument and option layout.

## Validation
- yarn lint-fix (0 errors, existing max-len warnings in packages/extension-agent/src/sub-agent/builtin.ts only)