### PR TITLE
fix(search): serialize browser evaluate scripts

### DIFF
--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-search-service",
     "description": "search support for chatluna",
-    "version": "1.4.0-alpha.2",
+    "version": "1.4.0-alpha.3",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -85,8 +85,8 @@
     },
     "koishi": {
         "description": {
-            "zh": "ChatLuna 的网络搜索服务插件，支持多源聚合搜索，包括 `Bing` | `Google` | `DuckDuckGo` | `Serper` | `Tavily` | `MediaWiki`",
-            "en": "Web search service plugin for ChatLuna. Support multi-source aggregation search, including `Bing` | `Google` | `DuckDuckGo` | `Serper` | `Tavily` | `MediaWiki`"
+            "zh": "ChatLuna 的网络搜索服务和浏览器功能插件，依赖 Puppeteer",
+            "en": "Web search service and browser functionality plugin for ChatLuna, depends on puppeteer"
         },
         "service": {
             "required": [

--- a/packages/service-search/src/providers/bing_web.ts
+++ b/packages/service-search/src/providers/bing_web.ts
@@ -14,27 +14,31 @@ class BingWebSearchProvider extends SearchProvider {
 
         try {
             // webdriver
-            await page.evaluateOnNewDocument(() => {
-                const newProto = navigator['__proto__']
-                delete newProto.webdriver
-                navigator['__proto__'] = newProto
+            await page.evaluateOnNewDocument(
+                // eslint-disable-next-line no-new-func
+                new Function(
+                    `const newProto = navigator['__proto__']
+                    delete newProto.webdriver
+                    navigator['__proto__'] = newProto
 
-                window['chrome'] = {}
-                window['chrome'].app = {
-                    InstallState: 'hehe',
-                    RunningState: 'haha',
-                    getDetails: 'xixi',
-                    getIsInstalled: 'ohno'
-                }
-                window['chrome'].csi = function () {}
-                window['chrome'].loadTimes = function () {}
-                window['chrome'].runtime = function () {}
+                    window['chrome'] = {}
+                    window['chrome'].app = {
+                        InstallState: 'hehe',
+                        RunningState: 'haha',
+                        getDetails: 'xixi',
+                        getIsInstalled: 'ohno'
+                    }
+                    window['chrome'].csi = function () {}
+                    window['chrome'].loadTimes = function () {}
+                    window['chrome'].runtime = function () {}
 
-                Object.defineProperty(navigator, 'userAgent', {
-                    get: () =>
-                        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.4044.113 Safari/537.36'
-                })
-            })
+                    Object.defineProperty(navigator, 'userAgent', {
+                        get: function () {
+                            return 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.4044.113 Safari/537.36'
+                        }
+                    })`
+                ) as () => unknown
+            )
 
             await page.goto(
                 `https://cn.bing.com/search?form=QBRE&q=${encodeURIComponent(
@@ -45,27 +49,30 @@ class BingWebSearchProvider extends SearchProvider {
                 }
             )
 
-            const summaries = await page.evaluate(() => {
-                const liElements = Array.from(
-                    document.querySelectorAll('#b_results > .b_algo')
-                )
+            const summaries = await page.evaluate(
+                // eslint-disable-next-line no-new-func
+                new Function(
+                    `const liElements = Array.from(
+                        document.querySelectorAll('#b_results > .b_algo')
+                    )
 
-                return liElements
-                    .map((li) => {
-                        const abstractElement =
-                            li.querySelector('.b_caption > p')
-                        const linkElement = li.querySelector('a')
-                        const imageElement = li.querySelector('img')
+                    return liElements
+                        .map((li) => {
+                            const abstractElement =
+                                li.querySelector('.b_caption > p')
+                            const linkElement = li.querySelector('a')
+                            const imageElement = li.querySelector('img')
 
-                        const href = linkElement?.getAttribute('href') ?? ''
-                        const title = linkElement?.textContent ?? ''
-                        const description = abstractElement?.textContent ?? ''
-                        const image = imageElement?.getAttribute('src') ?? ''
+                            const href = linkElement?.getAttribute('href') ?? ''
+                            const title = linkElement?.textContent ?? ''
+                            const description = abstractElement?.textContent ?? ''
+                            const image = imageElement?.getAttribute('src') ?? ''
 
-                        return { url: href, title, description, image }
-                    })
-                    .filter((summary) => summary.url && summary.title)
-            })
+                            return { url: href, title, description, image }
+                        })
+                        .filter((summary) => summary.url && summary.title)`
+                ) as () => SearchResult[]
+            )
 
             return summaries.slice(0, limit)
         } finally {

--- a/packages/service-search/src/providers/google_web.ts
+++ b/packages/service-search/src/providers/google_web.ts
@@ -20,25 +20,28 @@ class GoogleWebSearchProvider extends SearchProvider {
                 waitUntil: 'networkidle2'
             }
         )
-        const summaries = await page.evaluate(() => {
-            const liElements = Array.from(
-                document.querySelector('#search > div > div').childNodes
-            ) as HTMLElement[]
-
-            return liElements.map((li) => {
-                const linkElement = li.querySelector('a')
-                const href = linkElement.getAttribute('href')
-                const title = linkElement.querySelector('a > h3').textContent
-                const abstract = Array.from(
-                    li.querySelectorAll(
-                        'div > div > div > div > div > div > span'
-                    )
+        const summaries = await page.evaluate(
+            // eslint-disable-next-line no-new-func
+            new Function(
+                `const liElements = Array.from(
+                    document.querySelector('#search > div > div').childNodes
                 )
-                    .map((e) => e.textContent)
-                    .join('')
-                return { url: href, title, description: abstract }
-            })
-        })
+
+                return liElements.map((li) => {
+                    const linkElement = li.querySelector('a')
+                    const href = linkElement.getAttribute('href')
+                    const title = linkElement.querySelector('a > h3').textContent
+                    const abstract = Array.from(
+                        li.querySelectorAll(
+                            'div > div > div > div > div > div > span'
+                        )
+                    )
+                        .map((e) => e.textContent)
+                        .join('')
+                    return { url: href, title, description: abstract }
+                })`
+            ) as () => SearchResult[]
+        )
         await page.close()
 
         return summaries.slice(0, limit)

--- a/packages/service-search/src/tools/browser/manager.ts
+++ b/packages/service-search/src/tools/browser/manager.ts
@@ -231,13 +231,7 @@ export class BrowserManager {
         const page = input.url
             ? await this.open({ url: input.url }, runConfig)
             : this.getPage(runConfig, input.pageId)
-        const html = await page.page.evaluate(
-            (selector) =>
-                selector
-                    ? (document.querySelector(selector)?.outerHTML ?? '')
-                    : document.documentElement.outerHTML,
-            input.selector
-        )
+        const html = await page.page.evaluate(readBrowserHtml, input.selector)
         return await this.formatOutput({
             name: 'browser-html',
             text: html,
@@ -426,20 +420,23 @@ If a focus is provided and the page is unrelated, output exactly: [none].
 Include important facts, numbers, names, and source links when present.`
 }
 
-function readBrowserText(selector?: string, includeLinks = false) {
-    const root = selector
+// eslint-disable-next-line no-new-func
+const readBrowserText = new Function(
+    'selector',
+    'includeLinks',
+    String.raw`const root = selector
         ? document.querySelector(selector)
         : (document.querySelector('article, main, [role="main"]') ??
           document.body)
     if (!root) return ''
 
-    const copy = root.cloneNode(true) as Element
+    const copy = root.cloneNode(true)
     copy.querySelectorAll(
         'script, style, noscript, svg, nav, header, footer'
     ).forEach((el) => el.remove())
 
-    const lines: string[] = []
-    const walk = (node: Node) => {
+    const lines = []
+    function walk(node) {
         if (node.nodeType === Node.TEXT_NODE) {
             const text = node.textContent?.replace(/\s+/g, ' ').trim()
             if (text) lines.push(text)
@@ -447,7 +444,7 @@ function readBrowserText(selector?: string, includeLinks = false) {
         }
         if (node.nodeType !== Node.ELEMENT_NODE) return
 
-        const el = node as Element
+        const el = node
         const tag = el.tagName.toLowerCase()
         if (/^h[1-6]$/.test(tag)) {
             lines.push(
@@ -460,7 +457,9 @@ function readBrowserText(selector?: string, includeLinks = false) {
         if (tag === 'li') lines.push('\n- ')
         if (tag === 'br') lines.push('\n')
         if (tag === 'pre') {
-            lines.push('\n```\n' + el.textContent?.trim() + '\n```\n')
+            lines.push(
+                '\n\x60\x60\x60\n' + el.textContent?.trim() + '\n\x60\x60\x60\n'
+            )
             return
         }
         if (tag === 'tr') lines.push('\n| ')
@@ -480,7 +479,7 @@ function readBrowserText(selector?: string, includeLinks = false) {
                 const text = a.textContent?.replace(/\s+/g, ' ').trim()
                 const href = a.getAttribute('href')
                 return text && href
-                    ? `- [${text}](${new URL(href, location.href).href})`
+                    ? \`- [\${text}](\${new URL(href, location.href).href})\`
                     : ''
             })
             .filter(Boolean)
@@ -494,20 +493,29 @@ function readBrowserText(selector?: string, includeLinks = false) {
         .replace(/\n[ \t]+/g, '\n')
         .replace(/[ \t]{2,}/g, ' ')
         .replace(/\n{3,}/g, '\n\n')
-        .trim()
-}
+        .trim()`
+) as (selector?: string, includeLinks?: boolean) => string
 
-function readBrowserLinks() {
-    const current = new URL(location.href)
+// eslint-disable-next-line no-new-func
+const readBrowserHtml = new Function(
+    'selector',
+    String.raw`return selector
+        ? (document.querySelector(selector)?.outerHTML ?? '')
+        : document.documentElement.outerHTML`
+) as (selector?: string) => string
+
+// eslint-disable-next-line no-new-func
+const readBrowserLinks = new Function(
+    String.raw`const current = new URL(location.href)
     const host = current.hostname
-    const result: Record<string, { text: string; url: string }[]> = {
+    const result = {
         sameSite: [],
         external: []
     }
     for (const a of Array.from(document.querySelectorAll('a[href]'))) {
         const text = a.textContent?.replace(/\s+/g, ' ').trim()
         if (!text) continue
-        const url = new URL(a.getAttribute('href')!, current.href)
+        const url = new URL(a.getAttribute('href'), current.href)
         if (
             url.hash &&
             url.origin === current.origin &&
@@ -522,8 +530,8 @@ function readBrowserLinks() {
     }
     result.sameSite = result.sameSite.slice(0, 100)
     result.external = result.external.slice(0, 100)
-    return result
-}
+    return result`
+) as () => Record<string, { text: string; url: string }[]>
 
 export interface BrowserManagerConfig {
     browserTimeout: number

--- a/packages/service-search/src/tools/browser/tools.ts
+++ b/packages/service-search/src/tools/browser/tools.ts
@@ -383,9 +383,8 @@ class BrowserWaitForTool extends StructuredTool {
     ) {
         const page = this.manager.getPage(cfg, input.pageId)
         await page.page.waitForFunction(
-            (text) => document.body?.innerText?.includes(text),
-            { timeout: input.timeout ?? this.manager.config.browserTimeout },
-            input.text
+            `document.body?.innerText?.includes(${JSON.stringify(input.text)})`,
+            { timeout: input.timeout ?? this.manager.config.browserTimeout }
         )
         return `Text found: ${input.text}`
     }
@@ -697,11 +696,12 @@ class BrowserEvaluateTool extends StructuredTool {
                 handles.push(await this.manager.getElement(page, uid))
             }
             const result = await page.page.evaluate(
-                async (fnText, ...args) => {
-                    // eslint-disable-next-line no-new-func
-                    const fn = new Function(`return (${fnText})`)()
-                    return await fn(...args)
-                },
+                // eslint-disable-next-line no-new-func
+                new Function(
+                    'fnText',
+                    '...args',
+                    "const fn = new Function('return (' + fnText + ')')()\nreturn fn(...args)"
+                ) as (fnText: string, ...args: unknown[]) => unknown,
                 input.function,
                 ...handles
             )
@@ -799,29 +799,35 @@ async function fillElement(
 ) {
     const el = await manager.getElement(page, uid)
     try {
-        await el.evaluate((node, value) => {
-            if (node instanceof HTMLInputElement) {
-                if (node.type === 'checkbox' || node.type === 'radio') {
-                    node.checked = value === 'true'
-                } else {
-                    node.value = value
+        await el.evaluate(
+            // eslint-disable-next-line no-new-func
+            new Function(
+                'node',
+                'value',
+                `if (node instanceof HTMLInputElement) {
+                    if (node.type === 'checkbox' || node.type === 'radio') {
+                        node.checked = value === 'true'
+                    } else {
+                        node.value = value
+                    }
+                    node.dispatchEvent(new Event('input', { bubbles: true }))
+                    node.dispatchEvent(new Event('change', { bubbles: true }))
+                    return
                 }
-                node.dispatchEvent(new Event('input', { bubbles: true }))
-                node.dispatchEvent(new Event('change', { bubbles: true }))
-                return
-            }
-            if (
-                node instanceof HTMLTextAreaElement ||
-                node instanceof HTMLSelectElement
-            ) {
-                node.value = value
-                node.dispatchEvent(new Event('input', { bubbles: true }))
-                node.dispatchEvent(new Event('change', { bubbles: true }))
-                return
-            }
-            ;(node as HTMLElement).innerText = value
-            node.dispatchEvent(new Event('input', { bubbles: true }))
-        }, value)
+                if (
+                    node instanceof HTMLTextAreaElement ||
+                    node instanceof HTMLSelectElement
+                ) {
+                    node.value = value
+                    node.dispatchEvent(new Event('input', { bubbles: true }))
+                    node.dispatchEvent(new Event('change', { bubbles: true }))
+                    return
+                }
+                node.innerText = value
+                node.dispatchEvent(new Event('input', { bubbles: true }))`
+            ) as (node: Element, value: string) => void,
+            value
+        )
     } finally {
         await el.dispose()
     }


### PR DESCRIPTION
This pr fixes browser tool scripts so they can run reliably through Puppeteer evaluate calls.

## Bug Fixes
- Serialize browser page helper functions with Function constructors for Puppeteer execution contexts.
- Update Bing and Google web providers to evaluate self-contained page scripts.
- Fix browser wait, evaluate, and fill tools to pass serializable browser-side functions.

## Other Changes
- Bump the search service alpha version.
- Update the search service package description to mention browser functionality and Puppeteer dependency.

## Validation
- yarn lint-fix (0 errors, 0 warnings)