### PR TITLE
fix(search): use browser evaluate helpers

### DIFF
--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-search-service",
     "description": "search support for chatluna",
-    "version": "1.4.0-alpha.3",
+    "version": "1.4.0-alpha.4",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/service-search/src/providers/bing_web.ts
+++ b/packages/service-search/src/providers/bing_web.ts
@@ -14,31 +14,7 @@ class BingWebSearchProvider extends SearchProvider {
 
         try {
             // webdriver
-            await page.evaluateOnNewDocument(
-                // eslint-disable-next-line no-new-func
-                new Function(
-                    `const newProto = navigator['__proto__']
-                    delete newProto.webdriver
-                    navigator['__proto__'] = newProto
-
-                    window['chrome'] = {}
-                    window['chrome'].app = {
-                        InstallState: 'hehe',
-                        RunningState: 'haha',
-                        getDetails: 'xixi',
-                        getIsInstalled: 'ohno'
-                    }
-                    window['chrome'].csi = function () {}
-                    window['chrome'].loadTimes = function () {}
-                    window['chrome'].runtime = function () {}
-
-                    Object.defineProperty(navigator, 'userAgent', {
-                        get: function () {
-                            return 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.4044.113 Safari/537.36'
-                        }
-                    })`
-                ) as () => unknown
-            )
+            await page.evaluateOnNewDocument(patchBrowserFingerprint)
 
             await page.goto(
                 `https://cn.bing.com/search?form=QBRE&q=${encodeURIComponent(
@@ -49,30 +25,7 @@ class BingWebSearchProvider extends SearchProvider {
                 }
             )
 
-            const summaries = await page.evaluate(
-                // eslint-disable-next-line no-new-func
-                new Function(
-                    `const liElements = Array.from(
-                        document.querySelectorAll('#b_results > .b_algo')
-                    )
-
-                    return liElements
-                        .map((li) => {
-                            const abstractElement =
-                                li.querySelector('.b_caption > p')
-                            const linkElement = li.querySelector('a')
-                            const imageElement = li.querySelector('img')
-
-                            const href = linkElement?.getAttribute('href') ?? ''
-                            const title = linkElement?.textContent ?? ''
-                            const description = abstractElement?.textContent ?? ''
-                            const image = imageElement?.getAttribute('src') ?? ''
-
-                            return { url: href, title, description, image }
-                        })
-                        .filter((summary) => summary.url && summary.title)`
-                ) as () => SearchResult[]
-            )
+            const summaries = await page.evaluate(readBingResults)
 
             return summaries.slice(0, limit)
         } finally {
@@ -85,6 +38,50 @@ class BingWebSearchProvider extends SearchProvider {
     })
 
     name = 'bing-web'
+}
+
+function patchBrowserFingerprint() {
+    const newProto = navigator['__proto__']
+    delete newProto.webdriver
+    navigator['__proto__'] = newProto
+
+    window['chrome'] = {}
+    window['chrome'].app = {
+        InstallState: 'hehe',
+        RunningState: 'haha',
+        getDetails: 'xixi',
+        getIsInstalled: 'ohno'
+    }
+    window['chrome'].csi = function () {}
+    window['chrome'].loadTimes = function () {}
+    window['chrome'].runtime = function () {}
+
+    Object.defineProperty(navigator, 'userAgent', {
+        get: function () {
+            return 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.4044.113 Safari/537.36'
+        }
+    })
+}
+
+function readBingResults() {
+    const liElements = Array.from(
+        document.querySelectorAll('#b_results > .b_algo')
+    )
+
+    return liElements
+        .map((li) => {
+            const abstractElement = li.querySelector('.b_caption > p')
+            const linkElement = li.querySelector('a')
+            const imageElement = li.querySelector('img')
+
+            const href = linkElement?.getAttribute('href') ?? ''
+            const title = linkElement?.textContent ?? ''
+            const description = abstractElement?.textContent ?? ''
+            const image = imageElement?.getAttribute('src') ?? ''
+
+            return { url: href, title, description, image }
+        })
+        .filter((summary) => summary.url && summary.title)
 }
 
 export function apply(

--- a/packages/service-search/src/providers/google_web.ts
+++ b/packages/service-search/src/providers/google_web.ts
@@ -20,28 +20,7 @@ class GoogleWebSearchProvider extends SearchProvider {
                 waitUntil: 'networkidle2'
             }
         )
-        const summaries = await page.evaluate(
-            // eslint-disable-next-line no-new-func
-            new Function(
-                `const liElements = Array.from(
-                    document.querySelector('#search > div > div').childNodes
-                )
-
-                return liElements.map((li) => {
-                    const linkElement = li.querySelector('a')
-                    const href = linkElement.getAttribute('href')
-                    const title = linkElement.querySelector('a > h3').textContent
-                    const abstract = Array.from(
-                        li.querySelectorAll(
-                            'div > div > div > div > div > div > span'
-                        )
-                    )
-                        .map((e) => e.textContent)
-                        .join('')
-                    return { url: href, title, description: abstract }
-                })`
-            ) as () => SearchResult[]
-        )
+        const summaries = await page.evaluate(readGoogleResults)
         await page.close()
 
         return summaries.slice(0, limit)
@@ -52,6 +31,24 @@ class GoogleWebSearchProvider extends SearchProvider {
     })
 
     name = 'google-web'
+}
+
+function readGoogleResults() {
+    const liElements = Array.from(
+        document.querySelector('#search > div > div').children
+    )
+
+    return liElements.map((li) => {
+        const linkElement = li.querySelector('a')
+        const href = linkElement.getAttribute('href')
+        const title = linkElement.querySelector('a > h3').textContent
+        const abstract = Array.from(
+            li.querySelectorAll('div > div > div > div > div > div > span')
+        )
+            .map((el) => el.textContent)
+            .join('')
+        return { url: href, title, description: abstract }
+    })
 }
 
 export function apply(

--- a/packages/service-search/src/tools/browser/manager.ts
+++ b/packages/service-search/src/tools/browser/manager.ts
@@ -420,23 +420,20 @@ If a focus is provided and the page is unrelated, output exactly: [none].
 Include important facts, numbers, names, and source links when present.`
 }
 
-// eslint-disable-next-line no-new-func
-const readBrowserText = new Function(
-    'selector',
-    'includeLinks',
-    String.raw`const root = selector
+function readBrowserText(selector?: string, includeLinks?: boolean) {
+    const root = selector
         ? document.querySelector(selector)
         : (document.querySelector('article, main, [role="main"]') ??
           document.body)
     if (!root) return ''
 
-    const copy = root.cloneNode(true)
+    const copy = root.cloneNode(true) as Element
     copy.querySelectorAll(
         'script, style, noscript, svg, nav, header, footer'
     ).forEach((el) => el.remove())
 
     const lines = []
-    function walk(node) {
+    function walk(node: Node) {
         if (node.nodeType === Node.TEXT_NODE) {
             const text = node.textContent?.replace(/\s+/g, ' ').trim()
             if (text) lines.push(text)
@@ -444,7 +441,7 @@ const readBrowserText = new Function(
         }
         if (node.nodeType !== Node.ELEMENT_NODE) return
 
-        const el = node
+        const el = node as Element
         const tag = el.tagName.toLowerCase()
         if (/^h[1-6]$/.test(tag)) {
             lines.push(
@@ -479,7 +476,11 @@ const readBrowserText = new Function(
                 const text = a.textContent?.replace(/\s+/g, ' ').trim()
                 const href = a.getAttribute('href')
                 return text && href
-                    ? \`- [\${text}](\${new URL(href, location.href).href})\`
+                    ? '- [' +
+                          text +
+                          '](' +
+                          new URL(href, location.href).href +
+                          ')'
                     : ''
             })
             .filter(Boolean)
@@ -493,24 +494,21 @@ const readBrowserText = new Function(
         .replace(/\n[ \t]+/g, '\n')
         .replace(/[ \t]{2,}/g, ' ')
         .replace(/\n{3,}/g, '\n\n')
-        .trim()`
-) as (selector?: string, includeLinks?: boolean) => string
+        .trim()
+}
 
-// eslint-disable-next-line no-new-func
-const readBrowserHtml = new Function(
-    'selector',
-    String.raw`return selector
+function readBrowserHtml(selector?: string) {
+    return selector
         ? (document.querySelector(selector)?.outerHTML ?? '')
-        : document.documentElement.outerHTML`
-) as (selector?: string) => string
+        : document.documentElement.outerHTML
+}
 
-// eslint-disable-next-line no-new-func
-const readBrowserLinks = new Function(
-    String.raw`const current = new URL(location.href)
+function readBrowserLinks() {
+    const current = new URL(location.href)
     const host = current.hostname
     const result = {
-        sameSite: [],
-        external: []
+        sameSite: [] as { text: string; url: string }[],
+        external: [] as { text: string; url: string }[]
     }
     for (const a of Array.from(document.querySelectorAll('a[href]'))) {
         const text = a.textContent?.replace(/\s+/g, ' ').trim()
@@ -530,8 +528,8 @@ const readBrowserLinks = new Function(
     }
     result.sameSite = result.sameSite.slice(0, 100)
     result.external = result.external.slice(0, 100)
-    return result`
-) as () => Record<string, { text: string; url: string }[]>
+    return result
+}
 
 export interface BrowserManagerConfig {
     browserTimeout: number

--- a/packages/service-search/src/tools/browser/tools.ts
+++ b/packages/service-search/src/tools/browser/tools.ts
@@ -799,36 +799,32 @@ async function fillElement(
 ) {
     const el = await manager.getElement(page, uid)
     try {
-        await el.evaluate(
-            // eslint-disable-next-line no-new-func
-            new Function(
-                'node',
-                'value',
-                `if (node instanceof HTMLInputElement) {
-                    if (node.type === 'checkbox' || node.type === 'radio') {
-                        node.checked = value === 'true'
-                    } else {
-                        node.value = value
-                    }
-                    node.dispatchEvent(new Event('input', { bubbles: true }))
-                    node.dispatchEvent(new Event('change', { bubbles: true }))
-                    return
-                }
-                if (
-                    node instanceof HTMLTextAreaElement ||
-                    node instanceof HTMLSelectElement
-                ) {
-                    node.value = value
-                    node.dispatchEvent(new Event('input', { bubbles: true }))
-                    node.dispatchEvent(new Event('change', { bubbles: true }))
-                    return
-                }
-                node.innerText = value
-                node.dispatchEvent(new Event('input', { bubbles: true }))`
-            ) as (node: Element, value: string) => void,
-            value
-        )
+        await el.evaluate(fillBrowserElement, value)
     } finally {
         await el.dispose()
     }
+}
+
+function fillBrowserElement(node: Element, value: string) {
+    if (node instanceof HTMLInputElement) {
+        if (node.type === 'checkbox' || node.type === 'radio') {
+            node.checked = value === 'true'
+        } else {
+            node.value = value
+        }
+        node.dispatchEvent(new Event('input', { bubbles: true }))
+        node.dispatchEvent(new Event('change', { bubbles: true }))
+        return
+    }
+    if (
+        node instanceof HTMLTextAreaElement ||
+        node instanceof HTMLSelectElement
+    ) {
+        node.value = value
+        node.dispatchEvent(new Event('input', { bubbles: true }))
+        node.dispatchEvent(new Event('change', { bubbles: true }))
+        return
+    }
+    ;(node as HTMLElement).innerText = value
+    node.dispatchEvent(new Event('input', { bubbles: true }))
 }


### PR DESCRIPTION
This pr replaces string-built browser scripts with typed helper functions for search providers and browser tools.

## Bug Fixes
- Use browser-side helper functions for Bing and Google page evaluation.
- Replace string-based browser text/html/link readers with typed helpers.
- Update browser fill handling to evaluate a reusable helper function.

## Other Changes
- Bump the search service alpha version.

## Validation
- yarn lint-fix (0 errors, 0 warnings)