### PR TITLE
feat(agent): add sub-agent stop controls

### DIFF
--- a/packages/core/src/llm-core/agent/legacy-executor.ts
+++ b/packages/core/src/llm-core/agent/legacy-executor.ts
@@ -157,6 +157,8 @@ async function executeTools(
                     await tool.invoke(action.toolInput, config),
                     tool.name
                 )
+                checkAborted(signal)
+
                 return {
                     action,
                     observation: applyLoopGuidance(
@@ -181,6 +183,8 @@ async function executeTools(
                         )
                     } as AgentStep
                 }
+
+                checkAborted(signal)
 
                 if (handleToolRuntimeErrors != null) {
                     const observation = coerceToAgentObservation(

--- a/packages/core/src/llm-core/agent/legacy-executor.ts
+++ b/packages/core/src/llm-core/agent/legacy-executor.ts
@@ -169,6 +169,8 @@ async function executeTools(
                     )
                 } as AgentStep
             } catch (e) {
+                checkAborted(signal)
+
                 if (e instanceof ToolInputParsingException) {
                     const observation = coerceToAgentObservation(
                         toToolInputErrorObservation(handleParsingErrors, e)
@@ -183,8 +185,6 @@ async function executeTools(
                         )
                     } as AgentStep
                 }
-
-                checkAborted(signal)
 
                 if (handleToolRuntimeErrors != null) {
                     const observation = coerceToAgentObservation(

--- a/packages/core/src/llm-core/agent/sub-agent.ts
+++ b/packages/core/src/llm-core/agent/sub-agent.ts
@@ -8,6 +8,7 @@ export type {
     AgentTaskDescriptor,
     AgentTaskTarget,
     AgentTaskSession,
+    AgentTaskSessionRouting,
     AgentTaskRunTraceEntry,
     AgentTaskRun,
     AgentTaskSessionSnapshot,

--- a/packages/core/src/llm-core/agent/sub-agent/executor.ts
+++ b/packages/core/src/llm-core/agent/sub-agent/executor.ts
@@ -87,15 +87,10 @@ export async function runAgentTask(options: {
     }
 
     const isBg = options.input.background
-    const abort = isBg ? new AbortController() : undefined
+    const abort = new AbortController()
     const queue = isBg ? new MessageQueue() : undefined
-    const activeRun: ActiveAgentTaskRun | undefined =
-        abort && queue ? { abort, queue } : undefined
-    const onAbort =
-        abort && options.signal
-            ? () => abort.abort(options.signal?.reason)
-            : undefined
-    const signal = abort?.signal ?? options.signal
+    const activeRun: ActiveAgentTaskRun = { abort, queue }
+    const signal = abort.signal
     const promptMessage = new HumanMessage(options.prompt)
     const snapshot: AgentTaskSessionSnapshot | undefined = isBg
         ? {
@@ -115,7 +110,7 @@ export async function runAgentTask(options: {
     options.task.activeRunId = runId
     options.runs.set(runId, run)
     if (snapshot) options.snapshots.set(runId, snapshot)
-    if (activeRun) options.active.set(runId, activeRun)
+    options.active.set(runId, activeRun)
     options.scheduleTaskCleanup(options.task.id)
 
     run.trace.push({
@@ -134,15 +129,16 @@ export async function runAgentTask(options: {
     }
 
     const exec = async () => {
+        const abortByParent = () => abort.abort(options.signal?.reason)
+        if (!isBg && options.signal?.aborted) abortByParent()
+        if (!isBg) {
+            options.signal?.addEventListener('abort', abortByParent, {
+                once: true
+            })
+        }
+
         try {
             await options.runtime.refresh?.()
-
-            if (abort && options.signal?.aborted)
-                abort.abort(options.signal.reason)
-            if (onAbort)
-                options.signal?.addEventListener('abort', onAbort, {
-                    once: true
-                })
 
             const result = await options.target.agent.generate({
                 prompt: options.prompt,
@@ -206,7 +202,11 @@ export async function runAgentTask(options: {
             )
         } catch (err) {
             run.state = signal?.aborted ? 'aborted' : 'failed'
-            run.error = err instanceof Error ? err.message : String(err)
+            run.error = signal?.aborted
+                ? '用户已停止任务。'
+                : err instanceof Error
+                  ? err.message
+                  : String(err)
             run.trace.push({
                 id: `${runId}:error`,
                 type: 'error',
@@ -223,13 +223,18 @@ export async function runAgentTask(options: {
             await options.runtime.refresh?.()
             throw err
         } finally {
-            if (onAbort) options.signal?.removeEventListener('abort', onAbort)
+            if (!isBg) {
+                options.signal?.removeEventListener('abort', abortByParent)
+            }
             options.active.delete(runId)
         }
     }
 
     if (isBg) {
-        exec().catch((err) => logger.error('[SubagentBgTaskError]', err))
+        exec().catch((err) => {
+            if (run.state === 'aborted' || signal.aborted) return
+            logger.error('[SubagentBgTaskError]', err)
+        })
         return formatTaskStart(options.task, options.toolName)
     }
 

--- a/packages/core/src/llm-core/agent/sub-agent/executor.ts
+++ b/packages/core/src/llm-core/agent/sub-agent/executor.ts
@@ -95,15 +95,7 @@ export async function runAgentTask(options: {
     const snapshot: AgentTaskSessionSnapshot | undefined = isBg
         ? {
               session: options.session,
-              routing: {
-                  platform: options.session.platform,
-                  selfId: options.session.selfId,
-                  userId: options.session.userId,
-                  username: options.session.username ?? undefined,
-                  guildId: options.session.guildId ?? undefined,
-                  channelId: options.session.channelId ?? undefined,
-                  isDirect: options.session.isDirect ?? false
-              }
+              routing: createTaskRouting(options.session)
           }
         : undefined
 
@@ -381,6 +373,7 @@ async function onTaskEvent(
 export function createTaskSession(
     agent: ChatLunaAgent,
     parentConversationId: string,
+    session: Session,
     parent?: SubagentContext,
     maxDepth = 1
 ): AgentTaskSession {
@@ -397,12 +390,25 @@ export function createTaskSession(
         agentName: agent.name,
         conversationId: `subagent:${id}`,
         parentConversationId,
+        routing: createTaskRouting(session),
         depth,
         maxDepth: limit,
         parentAgent: parent?.agentName ?? 'main',
         messages: [],
         startedAt: now,
         updatedAt: now
+    }
+}
+
+function createTaskRouting(session: Session) {
+    return {
+        platform: session.platform,
+        selfId: session.selfId,
+        userId: session.userId,
+        username: session.username ?? undefined,
+        guildId: session.guildId ?? undefined,
+        channelId: session.channelId ?? undefined,
+        isDirect: session.isDirect ?? false
     }
 }
 

--- a/packages/core/src/llm-core/agent/sub-agent/executor.ts
+++ b/packages/core/src/llm-core/agent/sub-agent/executor.ts
@@ -122,9 +122,9 @@ export async function runAgentTask(options: {
 
     const exec = async () => {
         const abortByParent = () => abort.abort(options.signal?.reason)
-        if (!isBg && options.signal?.aborted) abortByParent()
-        if (!isBg) {
-            options.signal?.addEventListener('abort', abortByParent, {
+        if (!isBg && options.signal) {
+            if (options.signal.aborted) abortByParent()
+            options.signal.addEventListener('abort', abortByParent, {
                 once: true
             })
         }
@@ -143,24 +143,22 @@ export async function runAgentTask(options: {
                 history: [...options.task.messages],
                 signal,
                 messageQueue: queue,
-                pauseGate: activeRun
-                    ? async (sig) => {
-                          while (activeRun.paused) {
-                              if (sig?.aborted) return
-                              await new Promise<void>((resolve) => {
-                                  const done = () => {
-                                      sig?.removeEventListener('abort', done)
-                                      activeRun.resume = undefined
-                                      resolve()
-                                  }
-                                  activeRun.resume = done
-                                  sig?.addEventListener('abort', done, {
-                                      once: true
-                                  })
-                              })
-                          }
-                      }
-                    : undefined,
+                pauseGate: async (sig) => {
+                    while (activeRun.paused) {
+                        if (sig?.aborted) return
+                        await new Promise<void>((resolve) => {
+                            const done = () => {
+                                sig?.removeEventListener('abort', done)
+                                activeRun.resume = undefined
+                                resolve()
+                            }
+                            activeRun.resume = done
+                            sig?.addEventListener('abort', done, {
+                                once: true
+                            })
+                        })
+                    }
+                },
                 toolMask,
                 subagentContext: subCtx,
                 source: options.source,

--- a/packages/core/src/llm-core/agent/sub-agent/runtime.ts
+++ b/packages/core/src/llm-core/agent/sub-agent/runtime.ts
@@ -306,6 +306,7 @@ export function createTaskTool(
                 createTaskSession(
                     target.agent,
                     conversationId,
+                    session,
                     parent,
                     options.maxDepth
                 )

--- a/packages/core/src/llm-core/agent/sub-agent/runtime.ts
+++ b/packages/core/src/llm-core/agent/sub-agent/runtime.ts
@@ -352,15 +352,14 @@ export function createTaskTool(
                 const run = getLatestTaskRun(runs, next.id)
                 if (!run) throw err
                 if (run.state === 'aborted') {
-                    return formatTaskResult(
-                        next,
-                        run,
-                        [
-                            'The user manually stopped this sub-agent task. Do not continue it.',
-                            'If needed, ask the user to clarify the task requirements.'
-                        ].join('\n'),
-                        toolName
-                    )
+                    return [
+                        'The user manually stopped this sub-agent task. Do not continue it.',
+                        'If needed, ask the user to clarify the task requirements.',
+                        '',
+                        `task_id: ${next.id}`,
+                        `agent: ${next.agentName}`,
+                        `state: ${run.state}`
+                    ].join('\n')
                 }
                 return formatTaskResult(
                     next,

--- a/packages/core/src/llm-core/agent/sub-agent/runtime.ts
+++ b/packages/core/src/llm-core/agent/sub-agent/runtime.ts
@@ -1,5 +1,9 @@
 import { logger } from 'koishi-plugin-chatluna'
 import { HumanMessage } from '@langchain/core/messages'
+import {
+    ChatLunaError,
+    ChatLunaErrorCode
+} from 'koishi-plugin-chatluna/utils/error'
 import { createTaskSession, runAgentTask } from './executor'
 import { AgentTaskTool, buildTaskToolDescription } from './tool'
 import {
@@ -81,7 +85,9 @@ export function createTaskTool(
         if (run) run.paused = false
         item.paused = false
         item.resume?.()
-        item.abort.abort()
+        item.abort.abort(
+            new ChatLunaError(ChatLunaErrorCode.ABORTED, undefined, true)
+        )
         return true
     }
 
@@ -163,7 +169,7 @@ export function createTaskTool(
 
             const runId = task.activeRunId
             const item = runId ? active.get(runId) : undefined
-            if (runId && item) {
+            if (runId && item?.queue) {
                 item.queue.push(new HumanMessage(prompt))
                 task.updatedAt = Date.now()
                 scheduleTaskCleanup(task.id)
@@ -261,7 +267,7 @@ export function createTaskTool(
                 if (!task.activeRunId)
                     return `Task '${task.id}' is not running. Use action=run with the same id to continue it.`
                 const item = active.get(task.activeRunId)
-                if (!item)
+                if (!item?.queue)
                     return `Task '${task.id}' is not accepting live messages because it was not started in background.`
                 item.queue.push(new HumanMessage(input.message.trim()))
                 task.updatedAt = Date.now()
@@ -345,6 +351,17 @@ export function createTaskTool(
             } catch (err) {
                 const run = getLatestTaskRun(runs, next.id)
                 if (!run) throw err
+                if (run.state === 'aborted') {
+                    return formatTaskResult(
+                        next,
+                        run,
+                        [
+                            'The user manually stopped this sub-agent task. Do not continue it.',
+                            'If needed, ask the user to clarify the task requirements.'
+                        ].join('\n'),
+                        toolName
+                    )
+                }
                 return formatTaskResult(
                     next,
                     run,

--- a/packages/core/src/llm-core/agent/sub-agent/tool.ts
+++ b/packages/core/src/llm-core/agent/sub-agent/tool.ts
@@ -12,9 +12,6 @@ import type { ChatLunaToolRunnable } from '../../platform/types'
 export function buildTaskToolDescription() {
     return [
         'Delegate focused work to a specialist agent (exact name required).',
-        'If the user explicitly asks you to use a sub-agent for a task, ' +
-            'delegate it. If that sub-agent task fails or is stopped, do ' +
-            'not try to complete the same task yourself.',
         'Set background=true for long tasks; results are delivered to you automatically - never poll status.',
         'Actions: run (new task, or resume with id), status, list, list_all, message (guide a running background task), stop (abort a running background task).'
     ].join('\n')
@@ -28,9 +25,9 @@ export function renderAvailableAgents(
     const lines = [
         '<available_sub_agents>',
         'Delegate via the task tool. background=true for long work; results arrive automatically - do not poll status.',
-        'If the user explicitly asks you to use a sub-agent for a task, ' +
-            'delegate it. If that sub-agent task fails or is stopped, do ' +
-            'not try to complete the same task yourself.',
+        'If the user explicitly asks you to use a sub-agent, delegate it. ' +
+            'If that task fails or is stopped, do not attempt the same ' +
+            'task yourself.',
         ''
     ]
     if (dir) {

--- a/packages/core/src/llm-core/agent/sub-agent/tool.ts
+++ b/packages/core/src/llm-core/agent/sub-agent/tool.ts
@@ -12,6 +12,9 @@ import type { ChatLunaToolRunnable } from '../../platform/types'
 export function buildTaskToolDescription() {
     return [
         'Delegate focused work to a specialist agent (exact name required).',
+        'If the user explicitly asks you to use a sub-agent for a task, ' +
+            'delegate it. If that sub-agent task fails or is stopped, do ' +
+            'not try to complete the same task yourself.',
         'Set background=true for long tasks; results are delivered to you automatically - never poll status.',
         'Actions: run (new task, or resume with id), status, list, list_all, message (guide a running background task), stop (abort a running background task).'
     ].join('\n')
@@ -25,6 +28,9 @@ export function renderAvailableAgents(
     const lines = [
         '<available_sub_agents>',
         'Delegate via the task tool. background=true for long work; results arrive automatically - do not poll status.',
+        'If the user explicitly asks you to use a sub-agent for a task, ' +
+            'delegate it. If that sub-agent task fails or is stopped, do ' +
+            'not try to complete the same task yourself.',
         ''
     ]
     if (dir) {

--- a/packages/core/src/llm-core/agent/sub-agent/types.ts
+++ b/packages/core/src/llm-core/agent/sub-agent/types.ts
@@ -22,6 +22,7 @@ export interface AgentTaskSession {
     agentName: string
     conversationId: string
     parentConversationId: string
+    routing: AgentTaskSessionRouting
     depth: number
     maxDepth: number
     parentAgent: string
@@ -29,6 +30,16 @@ export interface AgentTaskSession {
     messages: BaseMessage[]
     startedAt: number
     updatedAt: number
+}
+
+export interface AgentTaskSessionRouting {
+    platform: string
+    selfId: string
+    userId: string
+    username?: string
+    guildId?: string
+    channelId?: string
+    isDirect: boolean
 }
 
 export interface AgentTaskRunTraceEntry {
@@ -71,15 +82,7 @@ export interface AgentTaskRun {
 
 export interface AgentTaskSessionSnapshot {
     session?: Session
-    routing?: {
-        platform: string
-        selfId: string
-        userId: string
-        username?: string
-        guildId?: string
-        channelId?: string
-        isDirect: boolean
-    }
+    routing?: AgentTaskSessionRouting
     bindingKey?: string
 }
 

--- a/packages/core/src/llm-core/agent/sub-agent/types.ts
+++ b/packages/core/src/llm-core/agent/sub-agent/types.ts
@@ -153,7 +153,7 @@ export interface AgentTaskToolRuntime {
 
 interface ActiveAgentTaskRun {
     abort: AbortController
-    queue: MessageQueue
+    queue?: MessageQueue
     paused?: boolean
     resume?: () => void
 }

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -300,6 +300,10 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
             } catch (error) {
                 await this._closeStream(stream)
 
+                if (options.signal?.aborted) {
+                    throw options.signal.reason ?? error
+                }
+
                 if (
                     this._shouldRethrowStreamError(
                         error,

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -671,6 +671,10 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
 
                     return response
                 } catch (error) {
+                    if (options.signal?.aborted) {
+                        throw options.signal.reason ?? error
+                    }
+
                     if (
                         options.stream ||
                         this._isNonRetryableError(error) ||

--- a/packages/extension-agent/client/components/sub-agent/sub-agent-runs.vue
+++ b/packages/extension-agent/client/components/sub-agent/sub-agent-runs.vue
@@ -10,36 +10,58 @@
         </div>
 
         <div v-if="runs.length > 0" class="runs-list">
-            <button
+            <div
                 v-for="item in runs"
                 :key="item.runId"
-                type="button"
                 class="run-row"
+                role="button"
+                tabindex="0"
                 @click="selectedRunId = item.runId"
+                @keydown.enter.prevent="selectedRunId = item.runId"
+                @keydown.space.prevent="selectedRunId = item.runId"
             >
                 <div class="run-main">
-                    <div class="run-title">{{ item.agentName }}</div>
+                    <div class="run-header">
+                        <div class="run-title">{{ item.agentName }}</div>
+                        <el-tag
+                            size="small"
+                            effect="plain"
+                            :type="runTag(item.state)"
+                        >
+                            {{ item.state }}
+                        </el-tag>
+                    </div>
                     <div class="run-meta">
-                        {{ formatTime(item.startedAt) }}
-                        · 深度 {{ item.depth }} · 工具 {{ item.toolCount }} ·
-                        回合 {{ item.turnCount }} · 耗时 {{ formatDuration(item) }}
+                        <span>{{ formatTime(item.startedAt) }}</span>
+                        <span class="meta-divider">·</span>
+                        <span>深度 {{ item.depth }}</span>
+                        <span class="meta-divider">·</span>
+                        <span>工具 {{ item.toolCount }}</span>
+                        <span class="meta-divider">·</span>
+                        <span>回合 {{ item.turnCount }}</span>
+                        <span class="meta-divider">·</span>
+                        <span>耗时 {{ formatDuration(item) }}</span>
+                    </div>
+                    <div class="run-last">
+                        <span class="last-label">最后工具:</span>
+                        <code class="last-tool">{{ item.lastTool || '无' }}</code>
                     </div>
                 </div>
 
-                <div class="run-side">
-                    <el-tag
+                <div class="run-actions">
+                    <el-button
+                        v-if="item.state === 'running'"
                         size="small"
-                        effect="plain"
-                        :type="runTag(item.state)"
+                        :loading="stoppingId === item.taskId"
+                        @click.stop="stopRun(item)"
                     >
-                        {{ item.state }}
-                    </el-tag>
-                    <div class="run-last">
-                        {{ item.lastTool || '尚未调用工具' }}
-                    </div>
-                    <div class="run-link">查看详情</div>
+                        停止
+                    </el-button>
+                    <el-button size="small" @click.stop="selectedRunId = item.runId">
+                        详情
+                    </el-button>
                 </div>
-            </button>
+            </div>
         </div>
 
         <div v-else class="empty-state">
@@ -76,13 +98,23 @@
                             · 耗时 {{ formatDuration(selectedRun) }}
                         </div>
                     </div>
-                    <el-tag
-                        size="small"
-                        effect="plain"
-                        :type="runTag(selectedRun.state)"
-                    >
-                        {{ selectedRun.state }}
-                    </el-tag>
+                    <div class="dialog-actions">
+                        <el-button
+                            v-if="selectedRun.state === 'running'"
+                            size="small"
+                            :loading="stoppingId === selectedRun.taskId"
+                            @click="stopRun(selectedRun)"
+                        >
+                            停止
+                        </el-button>
+                        <el-tag
+                            size="small"
+                            effect="plain"
+                            :type="runTag(selectedRun.state)"
+                        >
+                            {{ selectedRun.state }}
+                        </el-tag>
+                    </div>
                 </div>
             </template>
 
@@ -136,7 +168,7 @@
                     <el-empty description="该次运行暂时没有可展示的详情。" />
                 </div>
 
-                <div v-if="selectedRun.error" class="error-box">
+                <div v-if="selectedRun.error && selectedRun.state !== 'aborted'" class="error-box">
                     <div class="trace-title">运行错误</div>
                     <pre class="trace-content">{{ selectedRun.error }}</pre>
                 </div>
@@ -146,6 +178,7 @@
 </template>
 
 <script setup lang="ts">
+import { send } from '@koishijs/client'
 import { CopyDocument } from '@element-plus/icons-vue'
 import { ElMessage } from 'element-plus'
 import { computed, ref } from 'vue'
@@ -156,6 +189,7 @@ const props = defineProps<{
 }>()
 
 const selectedRunId = ref('')
+const stoppingId = ref('')
 
 const selectedRun = computed(() => {
     return props.runs.find((item) => item.runId === selectedRunId.value)
@@ -298,6 +332,22 @@ async function copyTrace(
         '已复制该条运行记录 Markdown'
     )
 }
+
+async function stopRun(run: SubAgentRunInfo) {
+    try {
+        stoppingId.value = run.taskId
+        const count = await send('chatluna-agent/stopSubAgentTask', run.taskId)
+        if (count > 0) {
+            ElMessage.success(`已发送停止请求，共 ${count} 个任务。`)
+        } else {
+            ElMessage.warning('该任务当前不可停止。')
+        }
+    } catch {
+        ElMessage.error('停止 Agent 任务失败。')
+    } finally {
+        stoppingId.value = ''
+    }
+}
 </script>
 
 <style scoped>
@@ -354,50 +404,101 @@ async function copyTrace(
 
 .run-row {
     display: flex;
-    gap: 12px;
+    gap: 16px;
     justify-content: space-between;
-    align-items: flex-start;
+    align-items: center;
     width: 100%;
-    padding: 14px;
-    border: 1px solid
-        var(--trace-border);
-    border-radius: 14px;
+    padding: 16px;
+    border: 1px solid var(--trace-border);
+    border-radius: 12px;
     background: var(--trace-surface);
     text-align: left;
     cursor: pointer;
-    transition: border-color 0.2s ease, background-color 0.2s ease;
+    transition: all 0.2s ease;
+    box-sizing: border-box;
 }
 
 .run-row:hover {
     border-color: color-mix(in srgb, var(--k-text-light), transparent 60%);
-    background: color-mix(in srgb, var(--trace-surface), white 2%);
+    background: color-mix(in srgb, var(--trace-surface), var(--k-text-dark) 4%);
 }
 
 .run-main {
     min-width: 0;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
 }
 
-.run-side {
-    min-width: 120px;
-    text-align: right;
+.run-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.run-meta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--k-text-light);
+}
+
+.meta-divider {
+    opacity: 0.5;
 }
 
 .run-last {
-    margin-top: 8px;
+    font-size: 12px;
+    color: var(--k-text-light);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
 }
 
-.run-link {
-    margin-top: 10px;
-    font-size: 12px;
-    color: var(--el-color-primary);
+.last-label {
+    flex-shrink: 0;
+}
+
+.last-tool {
+    background: color-mix(in srgb, var(--k-text-light), transparent 90%);
+    padding: 2px 6px;
+    border-radius: 4px;
+    color: var(--k-text-dark);
+    font-family: monospace;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.run-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    opacity: 0.8;
+    transition: opacity 0.2s;
+}
+
+.run-row:hover .run-actions {
+    opacity: 1;
 }
 
 .dialog-header {
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
-    gap: 12px;
+    gap: 16px;
     padding-right: 8px;
+}
+
+.dialog-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
 }
 
 .dialog-title {
@@ -413,7 +514,6 @@ async function copyTrace(
 }
 
 .dialog-meta,
-.trace-meta,
 .summary-label {
     margin-top: 4px;
     font-size: 12px;
@@ -423,10 +523,13 @@ async function copyTrace(
 
 .trace-wrap {
     max-height: 76vh;
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
     padding-right: 6px;
     scrollbar-width: thin;
     scrollbar-color: var(--trace-scrollbar) transparent;
+    display: flex;
+    flex-direction: column;
 }
 
 .trace-wrap::-webkit-scrollbar {
@@ -465,11 +568,15 @@ async function copyTrace(
     background: var(--trace-surface);
     padding: 16px;
     transition: border-color 0.2s ease, background 0.2s ease;
+    min-width: 0;
+    width: 100%;
+    box-sizing: border-box;
+    overflow: hidden;
 }
 
 .trace-item:hover {
     border-color: color-mix(in srgb, var(--k-text-light), transparent 60%);
-    background: color-mix(in srgb, var(--trace-surface), white 2%);
+    background: color-mix(in srgb, var(--trace-surface), var(--k-text-dark) 4%);
 }
 
 .summary-card code {
@@ -483,6 +590,8 @@ async function copyTrace(
     display: flex;
     flex-direction: column;
     gap: 12px;
+    min-width: 0;
+    width: 100%;
 }
 
 .trace-head {
@@ -490,12 +599,29 @@ async function copyTrace(
     align-items: flex-start;
     justify-content: space-between;
     gap: 12px;
+    width: 100%;
+}
+
+.trace-head > div:first-child {
+    min-width: 0;
+    flex: 1;
 }
 
 .trace-title {
     font-size: 14px;
     font-weight: 600;
     color: var(--k-text-dark);
+    word-break: break-all;
+    overflow-wrap: anywhere;
+}
+
+.trace-meta {
+    margin-top: 4px;
+    font-size: 12px;
+    line-height: 1.6;
+    color: var(--k-text-light);
+    word-break: break-all;
+    overflow-wrap: anywhere;
 }
 
 .icon-btn {
@@ -525,7 +651,8 @@ async function copyTrace(
 .trace-content {
     margin: 12px 0 0;
     white-space: pre-wrap;
-    word-break: break-word;
+    word-break: break-all;
+    overflow-wrap: anywhere;
     font-size: 12px;
     line-height: 1.7;
     color: var(--k-text-dark);
@@ -607,11 +734,12 @@ async function copyTrace(
     .run-row {
         flex-direction: column;
         align-items: flex-start;
+        gap: 12px;
     }
 
-    .run-side {
-        min-width: 0;
-        text-align: left;
+    .run-actions {
+        width: 100%;
+        justify-content: flex-end;
     }
 
     .dialog-header,

--- a/packages/extension-agent/src/commands/task.ts
+++ b/packages/extension-agent/src/commands/task.ts
@@ -87,20 +87,22 @@ export function apply(ctx: Context) {
                 ? await findTask(ctx, session, id, conversationId)
                 : service.subAgent
                       .getTasks()
-                      .filter((task) => {
-                          const run = latest(runs, task.id)
+                      .map((task) => ({ task, run: latest(runs, task.id) }))
+                      .filter((item) => {
                           return (
-                              matchTaskScope(task, session, conversationId) &&
-                              task.activeRunId &&
-                              run?.state === 'running'
+                              matchTaskScope(
+                                  item.task,
+                                  session,
+                                  conversationId
+                              ) &&
+                              item.task.activeRunId &&
+                              item.run?.state === 'running'
                           )
                       })
-                      .sort((a, b) => b.startedAt - a.startedAt)[0]
+                      .sort((a, b) => b.run!.startedAt - a.run!.startedAt)[0]
+                      ?.task
             if (typeof task === 'string') return task
             if (!task) return 'No running sub-agent task.'
-
-            const run = latest(runs, task.id)
-            if (run?.state !== 'running') return 'Task is not running.'
 
             const count = await service.subAgent.stopTaskTree(task.id)
             if (count < 1) {
@@ -243,19 +245,20 @@ function matchTaskScope(
         return true
     }
 
-    const routing = task.routing
-    if (!routing) return false
-    if (routing.platform !== session.platform) return false
-    if (routing.selfId !== session.selfId) return false
+    if (task.routing.platform !== session.platform) return false
+    if (task.routing.selfId !== session.selfId) return false
 
     if (session.isDirect) {
-        return routing.isDirect === true && routing.userId === session.userId
+        return (
+            task.routing.isDirect === true &&
+            task.routing.userId === session.userId
+        )
     }
 
     return (
-        routing.isDirect !== true &&
-        routing.guildId === session.guildId &&
-        routing.channelId === session.channelId
+        task.routing.isDirect !== true &&
+        task.routing.guildId === session.guildId &&
+        task.routing.channelId === session.channelId
     )
 }
 

--- a/packages/extension-agent/src/commands/task.ts
+++ b/packages/extension-agent/src/commands/task.ts
@@ -82,17 +82,31 @@ export function apply(ctx: Context) {
                 return `已停止 ${count} 个 Sub Agent 任务。`
             }
 
-            if (!conversationId && !id?.trim()) return 'No active conversation.'
+            const conversationIds = conversationId
+                ? [conversationId]
+                : (
+                      await ctx.chatluna.conversation.listConversationEntries(
+                          session,
+                          {
+                              allPresetLanes: true,
+                              useRoutePresetLane: true
+                          }
+                      )
+                  ).map((item) => item.conversation.id)
+
+            if (conversationIds.length < 1) return 'No active conversation.'
 
             const runs = service.subAgent.getRuns()
             const task = id?.trim()
-                ? await findTask(ctx, session, id, conversationId)
+                ? await findTask(ctx, session, id, conversationIds)
                 : service.subAgent
                       .getTasks()
                       .filter((task) => {
                           const run = latest(runs, task.id)
                           return (
-                              task.parentConversationId === conversationId &&
+                              conversationIds.includes(
+                                  task.parentConversationId
+                              ) &&
                               task.activeRunId &&
                               run?.state === 'running'
                           )
@@ -132,7 +146,7 @@ export function apply(ctx: Context) {
         const conversationId = resolved.conversation?.id
         if (!conversationId) return 'No active conversation.'
 
-        const task = await findTask(ctx, session, id, conversationId)
+        const task = await findTask(ctx, session, id, [conversationId])
         if (typeof task === 'string') return task
 
         const run = latest(service.subAgent.getRuns(), task.id)
@@ -161,7 +175,7 @@ export function apply(ctx: Context) {
         const conversationId = resolved.conversation?.id
         if (!conversationId) return 'No active conversation.'
 
-        const task = await findTask(ctx, session, id, conversationId)
+        const task = await findTask(ctx, session, id, [conversationId])
         if (typeof task === 'string') return task
 
         return (await service.subAgent.resumeTask(task.id))
@@ -187,7 +201,7 @@ export function apply(ctx: Context) {
         const conversationId = resolved.conversation?.id
         if (!conversationId) return 'No active conversation.'
 
-        const task = await findTask(ctx, session, id, conversationId)
+        const task = await findTask(ctx, session, id, [conversationId])
         if (typeof task === 'string') return task
 
         const run = latest(service.subAgent.getRuns(), task.id)
@@ -215,17 +229,17 @@ async function findTask(
     ctx: Context,
     session: Session,
     id: string | undefined,
-    conversationId?: string
+    conversationIds: string[]
 ) {
     if (!id?.trim()) return 'Task id is required.'
 
     const service = ctx.chatluna_agent
     const all = await checkAdmin(session)
-    if (!all && !conversationId) return 'No active conversation.'
+    if (!all && conversationIds.length < 1) return 'No active conversation.'
     const tasks = service.subAgent
         .getTasks()
         .filter((task) =>
-            all ? true : task.parentConversationId === conversationId
+            all ? true : conversationIds.includes(task.parentConversationId)
         )
     const matches = tasks.filter((task) => task.id.startsWith(id.trim()))
     if (matches.length < 1) return `Task '${id}' was not found.`

--- a/packages/extension-agent/src/commands/task.ts
+++ b/packages/extension-agent/src/commands/task.ts
@@ -78,20 +78,21 @@ export function apply(ctx: Context) {
                 const count =
                     await service.subAgent.abortByParentConversation(
                         conversationId
-                    )
+                )
                 return `已停止 ${count} 个 Sub Agent 任务。`
             }
 
+            if (!conversationId && !id?.trim()) return 'No active conversation.'
+
+            const runs = service.subAgent.getRuns()
             const task = id?.trim()
                 ? await findTask(ctx, session, id, conversationId)
                 : service.subAgent
                       .getTasks()
                       .filter((task) => {
-                          const run = latest(service.subAgent.getRuns(), task.id)
+                          const run = latest(runs, task.id)
                           return (
-                              (!conversationId ||
-                                  task.parentConversationId ===
-                                      conversationId) &&
+                              task.parentConversationId === conversationId &&
                               task.activeRunId &&
                               run?.state === 'running'
                           )
@@ -100,7 +101,7 @@ export function apply(ctx: Context) {
             if (typeof task === 'string') return task
             if (!task) return 'No running sub-agent task.'
 
-            const run = latest(service.subAgent.getRuns(), task.id)
+            const run = latest(runs, task.id)
             if (run?.state !== 'running') return 'Task is not running.'
 
             const count = await service.subAgent.stopTaskTree(task.id)
@@ -220,12 +221,11 @@ async function findTask(
 
     const service = ctx.chatluna_agent
     const all = await checkAdmin(session)
+    if (!all && !conversationId) return 'No active conversation.'
     const tasks = service.subAgent
         .getTasks()
         .filter((task) =>
-            all || !conversationId
-                ? true
-                : task.parentConversationId === conversationId
+            all ? true : task.parentConversationId === conversationId
         )
     const matches = tasks.filter((task) => task.id.startsWith(id.trim()))
     if (matches.length < 1) return `Task '${id}' was not found.`
@@ -240,9 +240,7 @@ async function findTask(
 }
 
 function latest(runs: AgentTaskRun[], taskId: string) {
-    return runs
-        .filter((run) => run.taskId === taskId)
-        .sort((a, b) => b.startedAt - a.startedAt)[0]
+    return runs.find((run) => run.taskId === taskId)
 }
 
 function state(task: AgentTaskSession, run?: AgentTaskRun) {

--- a/packages/extension-agent/src/commands/task.ts
+++ b/packages/extension-agent/src/commands/task.ts
@@ -24,7 +24,9 @@ export function apply(ctx: Context) {
                 ? undefined
                 : await ctx.chatluna.conversation.resolveConversation(session, {
                       permission: 'manage',
-                      mode: 'target'
+                      mode: 'target',
+                      allPresetLanes: true,
+                      useRoutePresetLane: true
                   })
             const id = resolved?.conversation?.id
             if (!options.all && !id) return 'No active conversation.'
@@ -61,35 +63,54 @@ export function apply(ctx: Context) {
             const service = ctx.chatluna_agent
             if (!service) return 'ChatLuna agent service is not ready.'
 
-            const resolved =
-                await ctx.chatluna.conversation.resolveConversation(session, {
+            const resolved = await ctx.chatluna.conversation
+                .resolveConversation(session, {
                     permission: 'manage',
-                    mode: 'target'
+                    mode: 'target',
+                    allPresetLanes: true,
+                    useRoutePresetLane: true
                 })
-            const conversationId = resolved.conversation?.id
-            if (!conversationId) return 'No active conversation.'
+                .catch(() => undefined)
+            const conversationId = resolved?.conversation?.id
 
             if (options.all) {
+                if (!conversationId) return 'No active conversation.'
                 const count =
                     await service.subAgent.abortByParentConversation(
                         conversationId
                     )
-                return `Stopped ${count} background sub-agent task(s).`
+                return `已停止 ${count} 个 Sub Agent 任务。`
             }
 
-            const task = await findTask(ctx, session, id, conversationId)
+            const task = id?.trim()
+                ? await findTask(ctx, session, id, conversationId)
+                : service.subAgent
+                      .getTasks()
+                      .filter((task) => {
+                          const run = latest(service.subAgent.getRuns(), task.id)
+                          return (
+                              (!conversationId ||
+                                  task.parentConversationId ===
+                                      conversationId) &&
+                              task.activeRunId &&
+                              run?.state === 'running'
+                          )
+                      })
+                      .sort((a, b) => b.startedAt - a.startedAt)[0]
             if (typeof task === 'string') return task
+            if (!task) return 'No running sub-agent task.'
 
             const run = latest(service.subAgent.getRuns(), task.id)
-            if (!run?.background)
-                return 'Foreground tasks stop with chatluna.stop.'
+            if (run?.state !== 'running') return 'Task is not running.'
 
-            if (!(await service.subAgent.stopTask(task.id))) {
+            const count = await service.subAgent.stopTaskTree(task.id)
+            if (count < 1) {
                 return 'Task is not running or not stoppable.'
             }
 
-            service.subAgent.detachAttachedTask(task.id)
-            return `Stopped sub-agent task ${task.id.slice(0, 8)}.`
+            return id?.trim()
+                ? '已停止该 Sub Agent 任务及其子任务。'
+                : `已停止 ${count} 个 Sub Agent 任务。`
         })
 
     ctx.command('chatluna.agent.pause <id:string>', 'Pause sub-agent task', {
@@ -100,7 +121,12 @@ export function apply(ctx: Context) {
 
         const resolved = await ctx.chatluna.conversation.resolveConversation(
             session,
-            { permission: 'manage', mode: 'target' }
+            {
+                permission: 'manage',
+                mode: 'target',
+                allPresetLanes: true,
+                useRoutePresetLane: true
+            }
         )
         const conversationId = resolved.conversation?.id
         if (!conversationId) return 'No active conversation.'
@@ -124,7 +150,12 @@ export function apply(ctx: Context) {
 
         const resolved = await ctx.chatluna.conversation.resolveConversation(
             session,
-            { permission: 'manage', mode: 'target' }
+            {
+                permission: 'manage',
+                mode: 'target',
+                allPresetLanes: true,
+                useRoutePresetLane: true
+            }
         )
         const conversationId = resolved.conversation?.id
         if (!conversationId) return 'No active conversation.'
@@ -145,7 +176,12 @@ export function apply(ctx: Context) {
 
         const resolved = await ctx.chatluna.conversation.resolveConversation(
             session,
-            { permission: 'manage', mode: 'target' }
+            {
+                permission: 'manage',
+                mode: 'target',
+                allPresetLanes: true,
+                useRoutePresetLane: true
+            }
         )
         const conversationId = resolved.conversation?.id
         if (!conversationId) return 'No active conversation.'
@@ -178,7 +214,7 @@ async function findTask(
     ctx: Context,
     session: Session,
     id: string | undefined,
-    conversationId: string
+    conversationId?: string
 ) {
     if (!id?.trim()) return 'Task id is required.'
 
@@ -187,7 +223,9 @@ async function findTask(
     const tasks = service.subAgent
         .getTasks()
         .filter((task) =>
-            all ? true : task.parentConversationId === conversationId
+            all || !conversationId
+                ? true
+                : task.parentConversationId === conversationId
         )
     const matches = tasks.filter((task) => task.id.startsWith(id.trim()))
     if (matches.length < 1) return `Task '${id}' was not found.`
@@ -202,7 +240,9 @@ async function findTask(
 }
 
 function latest(runs: AgentTaskRun[], taskId: string) {
-    return runs.filter((run) => run.taskId === taskId).at(-1)
+    return runs
+        .filter((run) => run.taskId === taskId)
+        .sort((a, b) => b.startedAt - a.startedAt)[0]
 }
 
 function state(task: AgentTaskSession, run?: AgentTaskRun) {

--- a/packages/extension-agent/src/commands/task.ts
+++ b/packages/extension-agent/src/commands/task.ts
@@ -7,6 +7,13 @@ import type {
 } from 'koishi-plugin-chatluna/llm-core/agent'
 import { checkAdmin } from 'koishi-plugin-chatluna/utils/koishi'
 
+const TARGET_RESOLVE = {
+    permission: 'manage',
+    mode: 'target',
+    allPresetLanes: true,
+    useRoutePresetLane: true
+} as const
+
 export function apply(ctx: Context) {
     ctx.command('chatluna.agent.list', 'List sub-agent tasks', {
         authority: 1
@@ -22,12 +29,10 @@ export function apply(ctx: Context) {
 
             const resolved = options.all
                 ? undefined
-                : await ctx.chatluna.conversation.resolveConversation(session, {
-                      permission: 'manage',
-                      mode: 'target',
-                      allPresetLanes: true,
-                      useRoutePresetLane: true
-                  })
+                : await ctx.chatluna.conversation.resolveConversation(
+                      session,
+                      TARGET_RESOLVE
+                  )
             const id = resolved?.conversation?.id
             if (!options.all && !id) return 'No active conversation.'
 
@@ -64,12 +69,7 @@ export function apply(ctx: Context) {
             if (!service) return 'ChatLuna agent service is not ready.'
 
             const resolved = await ctx.chatluna.conversation
-                .resolveConversation(session, {
-                    permission: 'manage',
-                    mode: 'target',
-                    allPresetLanes: true,
-                    useRoutePresetLane: true
-                })
+                .resolveConversation(session, TARGET_RESOLVE)
                 .catch(() => undefined)
             const conversationId = resolved?.conversation?.id
 
@@ -82,25 +82,11 @@ export function apply(ctx: Context) {
                 return `已停止 ${count} 个 Sub Agent 任务。`
             }
 
-            const runs = service.subAgent.getRuns()
             const task = id?.trim()
                 ? await findTask(ctx, session, id, conversationId)
-                : service.subAgent
-                      .getTasks()
-                      .map((task) => ({ task, run: latest(runs, task.id) }))
-                      .filter((item) => {
-                          return (
-                              matchTaskScope(
-                                  item.task,
-                                  session,
-                                  conversationId
-                              ) &&
-                              item.task.activeRunId &&
-                              item.run?.state === 'running'
-                          )
-                      })
-                      .sort((a, b) => b.run!.startedAt - a.run!.startedAt)[0]
-                      ?.task
+                : service.subAgent.getLatestRunningTask((t) =>
+                      matchTaskScope(t, session, conversationId)
+                  )
             if (typeof task === 'string') return task
             if (!task) return 'No running sub-agent task.'
 
@@ -122,12 +108,7 @@ export function apply(ctx: Context) {
 
         const resolved = await ctx.chatluna.conversation.resolveConversation(
             session,
-            {
-                permission: 'manage',
-                mode: 'target',
-                allPresetLanes: true,
-                useRoutePresetLane: true
-            }
+            TARGET_RESOLVE
         )
         const conversationId = resolved.conversation?.id
         if (!conversationId) return 'No active conversation.'
@@ -151,12 +132,7 @@ export function apply(ctx: Context) {
 
         const resolved = await ctx.chatluna.conversation.resolveConversation(
             session,
-            {
-                permission: 'manage',
-                mode: 'target',
-                allPresetLanes: true,
-                useRoutePresetLane: true
-            }
+            TARGET_RESOLVE
         )
         const conversationId = resolved.conversation?.id
         if (!conversationId) return 'No active conversation.'
@@ -177,12 +153,7 @@ export function apply(ctx: Context) {
 
         const resolved = await ctx.chatluna.conversation.resolveConversation(
             session,
-            {
-                permission: 'manage',
-                mode: 'target',
-                allPresetLanes: true,
-                useRoutePresetLane: true
-            }
+            TARGET_RESOLVE
         )
         const conversationId = resolved.conversation?.id
         if (!conversationId) return 'No active conversation.'

--- a/packages/extension-agent/src/commands/task.ts
+++ b/packages/extension-agent/src/commands/task.ts
@@ -78,7 +78,7 @@ export function apply(ctx: Context) {
                 const count =
                     await service.subAgent.abortByParentConversation(
                         conversationId
-                )
+                    )
                 return `已停止 ${count} 个 Sub Agent 任务。`
             }
 

--- a/packages/extension-agent/src/commands/task.ts
+++ b/packages/extension-agent/src/commands/task.ts
@@ -82,31 +82,15 @@ export function apply(ctx: Context) {
                 return `已停止 ${count} 个 Sub Agent 任务。`
             }
 
-            const conversationIds = conversationId
-                ? [conversationId]
-                : (
-                      await ctx.chatluna.conversation.listConversationEntries(
-                          session,
-                          {
-                              allPresetLanes: true,
-                              useRoutePresetLane: true
-                          }
-                      )
-                  ).map((item) => item.conversation.id)
-
-            if (conversationIds.length < 1) return 'No active conversation.'
-
             const runs = service.subAgent.getRuns()
             const task = id?.trim()
-                ? await findTask(ctx, session, id, conversationIds)
+                ? await findTask(ctx, session, id, conversationId)
                 : service.subAgent
                       .getTasks()
                       .filter((task) => {
                           const run = latest(runs, task.id)
                           return (
-                              conversationIds.includes(
-                                  task.parentConversationId
-                              ) &&
+                              matchTaskScope(task, session, conversationId) &&
                               task.activeRunId &&
                               run?.state === 'running'
                           )
@@ -146,7 +130,7 @@ export function apply(ctx: Context) {
         const conversationId = resolved.conversation?.id
         if (!conversationId) return 'No active conversation.'
 
-        const task = await findTask(ctx, session, id, [conversationId])
+        const task = await findTask(ctx, session, id, conversationId)
         if (typeof task === 'string') return task
 
         const run = latest(service.subAgent.getRuns(), task.id)
@@ -175,7 +159,7 @@ export function apply(ctx: Context) {
         const conversationId = resolved.conversation?.id
         if (!conversationId) return 'No active conversation.'
 
-        const task = await findTask(ctx, session, id, [conversationId])
+        const task = await findTask(ctx, session, id, conversationId)
         if (typeof task === 'string') return task
 
         return (await service.subAgent.resumeTask(task.id))
@@ -201,7 +185,7 @@ export function apply(ctx: Context) {
         const conversationId = resolved.conversation?.id
         if (!conversationId) return 'No active conversation.'
 
-        const task = await findTask(ctx, session, id, [conversationId])
+        const task = await findTask(ctx, session, id, conversationId)
         if (typeof task === 'string') return task
 
         const run = latest(service.subAgent.getRuns(), task.id)
@@ -229,18 +213,15 @@ async function findTask(
     ctx: Context,
     session: Session,
     id: string | undefined,
-    conversationIds: string[]
+    conversationId?: string
 ) {
     if (!id?.trim()) return 'Task id is required.'
 
     const service = ctx.chatluna_agent
     const all = await checkAdmin(session)
-    if (!all && conversationIds.length < 1) return 'No active conversation.'
     const tasks = service.subAgent
         .getTasks()
-        .filter((task) =>
-            all ? true : conversationIds.includes(task.parentConversationId)
-        )
+        .filter((task) => all || matchTaskScope(task, session, conversationId))
     const matches = tasks.filter((task) => task.id.startsWith(id.trim()))
     if (matches.length < 1) return `Task '${id}' was not found.`
     if (matches.length > 1) {
@@ -251,6 +232,31 @@ async function findTask(
     }
 
     return matches[0]
+}
+
+function matchTaskScope(
+    task: AgentTaskSession,
+    session: Session,
+    conversationId?: string
+) {
+    if (conversationId && task.parentConversationId === conversationId) {
+        return true
+    }
+
+    const routing = task.routing
+    if (!routing) return false
+    if (routing.platform !== session.platform) return false
+    if (routing.selfId !== session.selfId) return false
+
+    if (session.isDirect) {
+        return routing.isDirect === true && routing.userId === session.userId
+    }
+
+    return (
+        routing.isDirect !== true &&
+        routing.guildId === session.guildId &&
+        routing.channelId === session.channelId
+    )
 }
 
 function latest(runs: AgentTaskRun[], taskId: string) {

--- a/packages/extension-agent/src/service/index.ts
+++ b/packages/extension-agent/src/service/index.ts
@@ -590,6 +590,26 @@ export class ChatLunaAgentService extends Service {
         await this.refreshConsoleData()
     }
 
+    async stopSubAgentTask(id?: string) {
+        const runs = this.subAgent.getRuns()
+        const task = id?.trim()
+            ? this.subAgent.getTask(id.trim())
+            : this.subAgent
+                  .getTasks()
+                  .filter((item) => {
+                      const run = runs
+                          .filter((run) => run.taskId === item.id)
+                          .sort((a, b) => b.startedAt - a.startedAt)[0]
+                      return item.activeRunId && run?.state === 'running'
+                  })
+                  .sort((a, b) => b.startedAt - a.startedAt)[0]
+
+        if (!task) return 0
+        const count = await this.subAgent.stopTaskTree(task.id)
+        if (count > 0) await this.refreshConsoleData()
+        return count
+    }
+
     async getToolAvailability() {
         return this.permission.getToolAvailability()
     }

--- a/packages/extension-agent/src/service/index.ts
+++ b/packages/extension-agent/src/service/index.ts
@@ -591,21 +591,12 @@ export class ChatLunaAgentService extends Service {
     }
 
     async stopSubAgentTask(id?: string) {
-        const runs = this.subAgent.getRuns()
         const task = id?.trim()
             ? this.subAgent.getTask(id.trim())
-            : this.subAgent
-                  .getTasks()
-                  .filter((item) => {
-                      const run = runs.find((run) => run.taskId === item.id)
-                      return item.activeRunId && run?.state === 'running'
-                  })
-                  .sort((a, b) => b.startedAt - a.startedAt)[0]
+            : this.subAgent.getLatestRunningTask()
 
         if (!task) return 0
-        const count = await this.subAgent.stopTaskTree(task.id)
-        if (count > 0) await this.refreshConsoleData()
-        return count
+        return await this.subAgent.stopTaskTree(task.id)
     }
 
     async getToolAvailability() {

--- a/packages/extension-agent/src/service/index.ts
+++ b/packages/extension-agent/src/service/index.ts
@@ -597,9 +597,7 @@ export class ChatLunaAgentService extends Service {
             : this.subAgent
                   .getTasks()
                   .filter((item) => {
-                      const run = runs
-                          .filter((run) => run.taskId === item.id)
-                          .sort((a, b) => b.startedAt - a.startedAt)[0]
+                      const run = runs.find((run) => run.taskId === item.id)
                       return item.activeRunId && run?.state === 'running'
                   })
                   .sort((a, b) => b.startedAt - a.startedAt)[0]

--- a/packages/extension-agent/src/service/sub_agent.ts
+++ b/packages/extension-agent/src/service/sub_agent.ts
@@ -114,6 +114,18 @@ export class ChatLunaAgentSubAgentService {
         return this._task.getTask(id)
     }
 
+    getLatestRunningTask(filter?: (t: AgentTaskSession) => boolean) {
+        const runs = this.getRuns()
+        return this.getTasks()
+            .filter(
+                (t) =>
+                    t.activeRunId &&
+                    runs.find((r) => r.taskId === t.id)?.state === 'running' &&
+                    (filter?.(t) ?? true)
+            )
+            .sort((a, b) => b.startedAt - a.startedAt)[0]
+    }
+
     async stopTask(id: string) {
         const result = await this._task.stopTask(id)
         if (result) this.ctx.chatluna_agent?.refreshConsoleData()

--- a/packages/extension-agent/src/service/sub_agent.ts
+++ b/packages/extension-agent/src/service/sub_agent.ts
@@ -115,15 +115,15 @@ export class ChatLunaAgentSubAgentService {
     }
 
     getLatestRunningTask(filter?: (t: AgentTaskSession) => boolean) {
-        const runs = this.getRuns()
-        return this.getTasks()
-            .filter(
-                (t) =>
-                    t.activeRunId &&
-                    runs.find((r) => r.taskId === t.id)?.state === 'running' &&
-                    (filter?.(t) ?? true)
+        const tasks = this.getTasks()
+        for (const run of this.getRuns()) {
+            if (run.state !== 'running') continue
+
+            const task = tasks.find(
+                (t) => t.id === run.taskId && t.activeRunId === run.runId
             )
-            .sort((a, b) => b.startedAt - a.startedAt)[0]
+            if (task && (filter?.(task) ?? true)) return task
+        }
     }
 
     async stopTask(id: string) {

--- a/packages/extension-agent/src/service/sub_agent.ts
+++ b/packages/extension-agent/src/service/sub_agent.ts
@@ -120,6 +120,34 @@ export class ChatLunaAgentSubAgentService {
         return result
     }
 
+    async stopTaskTree(id: string) {
+        const task = this._task.getTask(id)
+        if (!task) return 0
+
+        const list = this._task.getTasks()
+        const pending = [task]
+        const seen = new Set<string>()
+        let count = 0
+
+        for (const item of pending) {
+            if (seen.has(item.id)) continue
+            seen.add(item.id)
+            pending.push(
+                ...list.filter(
+                    (child) => child.parentConversationId === item.conversationId
+                )
+            )
+
+            if (await this._task.stopTask(item.id)) {
+                this.detachAttachedTask(item.id)
+                count += 1
+            }
+        }
+
+        if (count > 0) this.ctx.chatluna_agent?.refreshConsoleData()
+        return count
+    }
+
     async pauseTask(id: string) {
         const result = await this._task.pauseTask(id)
         if (result) this.ctx.chatluna_agent?.refreshConsoleData()

--- a/packages/extension-agent/src/service/sub_agent.ts
+++ b/packages/extension-agent/src/service/sub_agent.ts
@@ -135,7 +135,8 @@ export class ChatLunaAgentSubAgentService {
             seen.add(item.id)
             pending.push(
                 ...list.filter(
-                    (child) => child.parentConversationId === item.conversationId
+                    (child) =>
+                        child.parentConversationId === item.conversationId
                 )
             )
 

--- a/packages/extension-agent/src/service/sub_agent.ts
+++ b/packages/extension-agent/src/service/sub_agent.ts
@@ -129,7 +129,8 @@ export class ChatLunaAgentSubAgentService {
         const seen = new Set<string>()
         let count = 0
 
-        for (const item of pending) {
+        while (pending.length > 0) {
+            const item = pending.shift()!
             if (seen.has(item.id)) continue
             seen.add(item.id)
             pending.push(

--- a/packages/extension-agent/src/types.ts
+++ b/packages/extension-agent/src/types.ts
@@ -187,6 +187,7 @@ declare module '@koishijs/plugin-console' {
         ) => Promise<SkillExportResult | undefined>
         'chatluna-agent/getSubAgents': () => Promise<SubAgentInfo[]>
         'chatluna-agent/getSubAgentRuns': () => Promise<SubAgentRunInfo[]>
+        'chatluna-agent/stopSubAgentTask': (id?: string) => Promise<number>
         'chatluna-agent/addSubAgent': (
             input: ManualSubAgentInput
         ) => Promise<SubAgentInfo>

--- a/packages/extension-agent/src/webui/index.ts
+++ b/packages/extension-agent/src/webui/index.ts
@@ -326,6 +326,10 @@ function registerSubAgentListeners(ctx: Context, agent: AgentRef) {
         agent().subAgent.getRuns()
     )
 
+    ctx.console.addListener('chatluna-agent/stopSubAgentTask', async (id) =>
+        agent().stopSubAgentTask(id)
+    )
+
     ctx.console.addListener(
         'chatluna-agent/saveSubAgentConfig',
         ok((cfg) => agent().saveSubAgentConfig(cfg))


### PR DESCRIPTION
## Summary

- add stop controls to the Sub Agent run list and run detail dialog
- support stopping the latest running sub-agent task when no task id is provided
- stop a task tree recursively, including child sub-agent tasks
- allow foreground sub-agent runs to be stopped and report a clear tool result to the parent agent
- fix conversation resolution for agent task commands across preset lanes

## Verification

- `yarn tsc --noEmit -p packages/core/tsconfig.json`
- `yarn tsc --noEmit -p packages/extension-agent/tsconfig.json`
- `yarn fast-build core`
- `yarn fast-build extension-agent`
