### PR TITLE
fix(agent): preserve sub-agent file metadata

### DIFF
--- a/packages/extension-agent/client/components/sub-agent/sub-agent-page.vue
+++ b/packages/extension-agent/client/components/sub-agent/sub-agent-page.vue
@@ -866,9 +866,9 @@ async function savePreview() {
         }
 
         if (item.scope === 'data') {
-            await send('chatluna-agent/addSubAgent', input)
-        } else {
             await send('chatluna-agent/saveSubAgentContent', item.id, input)
+        } else {
+            await send('chatluna-agent/addSubAgent', input)
         }
         ElMessage.success('保存内容成功。')
         showPreview.value = false

--- a/packages/extension-agent/src/sub-agent/scan.ts
+++ b/packages/extension-agent/src/sub-agent/scan.ts
@@ -146,6 +146,9 @@ async function scanTarget(target: ScanTarget, cfg: AgentConfig['subAgent']) {
                 ? createSubAgentItemConfig({
                       ...base,
                       ...saved,
+                      name: base.name,
+                      description: base.description,
+                      format: base.format,
                       permissions: {
                           skills:
                               saved.permissions?.skills ??


### PR DESCRIPTION
This pr fixes sub-agent file metadata handling.

Fixes #936

## Bug Fixes
- Preserve scanned file sub-agent name, description, and format metadata.
- Save data-scoped preview edits through content updates instead of re-adding the sub-agent.

## Validation
- yarn lint-fix