### PR TITLE
fix(adapter): support thinking mode toggles

### DIFF
--- a/packages/adapter-deepseek/src/client.ts
+++ b/packages/adapter-deepseek/src/client.ts
@@ -56,7 +56,7 @@ export class DeepseekClient extends PlatformModelAndEmbeddingsClient<ClientConfi
 
                 if (!model.startsWith('deepseek-v4-')) continue
                 if (model.endsWith('-thinking')) continue
-                if (model.endsWith('-instance')) continue
+                if (model.endsWith('-instant')) continue
 
                 models.push(
                     `${model}-high-thinking`,
@@ -129,7 +129,7 @@ export class DeepseekClient extends PlatformModelAndEmbeddingsClient<ClientConfi
                     model.includes('reasoner') ||
                     model.includes('thinking') ||
                     (model.startsWith('deepseek-v4-') &&
-                        !model.endsWith('-instance'))
+                        !model.endsWith('-instant'))
             })
         }
 

--- a/packages/adapter-deepseek/src/requester.ts
+++ b/packages/adapter-deepseek/src/requester.ts
@@ -45,9 +45,9 @@ export class DeepseekRequester
         params: ModelRequestParams
     ): AsyncGenerator<ChatGenerationChunk> {
         const rawModel = params.model
-        const disabled = rawModel.endsWith('-instance')
+        const disabled = rawModel.endsWith('-instant')
         const parsedModel = parseOpenAIModelNameWithReasoningEffort(
-            disabled ? rawModel.slice(0, -'-instance'.length) : rawModel
+            disabled ? rawModel.slice(0, -'-instant'.length) : rawModel
         )
         const model = parsedModel.model
         const requestContext = createRequestContext(

--- a/packages/adapter-doubao/src/client.ts
+++ b/packages/adapter-doubao/src/client.ts
@@ -108,6 +108,7 @@ export class DouBaoClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
                 for (const variant of expandReasoningEffortModelVariants(
                     model,
                     [
+                        'non-thinking',
                         'minimal-thinking',
                         'low-thinking',
                         'medium-thinking',

--- a/packages/adapter-doubao/src/requester.ts
+++ b/packages/adapter-doubao/src/requester.ts
@@ -66,7 +66,7 @@ export class DoubaoRequester
         }
 
         const baseRequest = (await buildChatCompletionParams(
-            { ...params, model },
+            params,
             this._plugin,
             false,
             [
@@ -85,6 +85,10 @@ export class DoubaoRequester
             baseRequest.thinking = {
                 type: enabledThinking ? 'enabled' : 'disabled'
             }
+        }
+
+        if (parsedModel.reasoningEffort === 'none') {
+            delete baseRequest.reasoning_effort
         }
 
         // Make the request using the shared post method


### PR DESCRIPTION
This pr fixes thinking mode toggles for DeepSeek and Doubao adapters.

Fixes #938

## Bug Fixes
- Use the DeepSeek instant suffix consistently when disabling thinking variants.
- Add the Doubao non-thinking model variant.
- Omit reasoning_effort from Doubao requests when non-thinking mode is selected.

## Validation
- yarn lint-fix