### PR TITLE
feat(agent): add prompt-only sub-agent tasks

### DIFF
--- a/packages/core/src/llm-core/agent/sub-agent.ts
+++ b/packages/core/src/llm-core/agent/sub-agent.ts
@@ -14,6 +14,7 @@ export type {
     AgentTaskSessionSnapshot,
     AgentTaskFinishedPayload,
     AgentTaskInput,
+    AgentTaskCreateContext,
     AgentTaskQueryContext,
     AgentTaskResolveContext,
     CreateTaskToolOptions,

--- a/packages/core/src/llm-core/agent/sub-agent/executor.ts
+++ b/packages/core/src/llm-core/agent/sub-agent/executor.ts
@@ -373,7 +373,8 @@ export function createTaskSession(
     parentConversationId: string,
     session: Session,
     parent?: SubagentContext,
-    maxDepth = 1
+    maxDepth = 1,
+    promptContent?: string
 ): AgentTaskSession {
     const id = randomUUID()
     const depth = (parent?.depth ?? 0) + 1
@@ -392,6 +393,7 @@ export function createTaskSession(
         depth,
         maxDepth: limit,
         parentAgent: parent?.agentName ?? 'main',
+        promptContent,
         messages: [],
         startedAt: now,
         updatedAt: now

--- a/packages/core/src/llm-core/agent/sub-agent/runtime.ts
+++ b/packages/core/src/llm-core/agent/sub-agent/runtime.ts
@@ -313,7 +313,7 @@ export function createTaskTool(
                         : undefined
 
             if (!target) {
-                if (agentName && !task?.promptContent) {
+                if (agentName && (!task?.promptContent || name)) {
                     return `Agent '${agentName}' is not available.`
                 }
                 if (task?.promptContent) {
@@ -321,6 +321,9 @@ export function createTaskTool(
                 }
                 if (!options.create) {
                     return 'agent is required when starting a new task.'
+                }
+                if (raw) {
+                    return 'Failed to create a prompt-only sub-agent.'
                 }
                 return 'Task prompt is empty.'
             }

--- a/packages/core/src/llm-core/agent/sub-agent/runtime.ts
+++ b/packages/core/src/llm-core/agent/sub-agent/runtime.ts
@@ -287,19 +287,49 @@ export function createTaskTool(
             if (!session || !conversationId)
                 return 'Task invocation is missing session context.'
 
-            const agentName = input.agent?.trim() ?? task?.agentName
-            if (!agentName) return 'agent is required when starting a new task.'
-
-            const target = await options.get(agentName, {
+            const raw = input.prompt?.trim() ?? ''
+            const name = input.agent?.trim()
+            const agentName = name ?? task?.agentName
+            const ctx = {
                 session,
                 source,
                 conversationId,
                 parent,
                 runConfig
-            })
-            if (!target) return `Agent '${agentName}' is not available.`
+            }
+            let promptContent: string | undefined
+            const target =
+                task?.promptContent && !name
+                    ? await options.create?.({
+                          ...ctx,
+                          id: task.agentId,
+                          name: task.agentName,
+                          prompt: task.promptContent
+                      })
+                    : agentName
+                      ? await options.get(agentName, ctx)
+                      : options.create && raw
+                        ? await options.create({ ...ctx, prompt: raw })
+                        : undefined
+
+            if (!target) {
+                if (agentName && !task?.promptContent) {
+                    return `Agent '${agentName}' is not available.`
+                }
+                if (task?.promptContent) {
+                    return `Task '${task.id}' prompt-only sub-agent is not available.`
+                }
+                if (!options.create) {
+                    return 'agent is required when starting a new task.'
+                }
+                return 'Task prompt is empty.'
+            }
+
+            if (!task && !name) {
+                promptContent = raw
+            }
             if (task && target.agent.id !== task.agentId)
-                return `Task '${task.id}' belongs to '${task.agentName}', not '${agentName}'.`
+                return `Task '${task.id}' belongs to '${task.agentName}', not '${target.agent.name}'.`
 
             const next =
                 task ??
@@ -308,13 +338,13 @@ export function createTaskTool(
                     conversationId,
                     session,
                     parent,
-                    options.maxDepth
+                    options.maxDepth,
+                    promptContent
                 )
             if (!task) tasks.set(next.id, next)
             if (next.activeRunId)
                 return `Task '${next.id}' is already running; result will arrive automatically. Use action=message to guide it.`
 
-            const raw = input.prompt?.trim() ?? ''
             const parts: string[] = []
             if (input.goal?.trim()) parts.push(`Goal:\n${input.goal.trim()}`)
             if (raw) parts.push(`Task:\n${raw}`)

--- a/packages/core/src/llm-core/agent/sub-agent/runtime.ts
+++ b/packages/core/src/llm-core/agent/sub-agent/runtime.ts
@@ -297,20 +297,21 @@ export function createTaskTool(
                 parent,
                 runConfig
             }
+            let target
             let promptContent: string | undefined
-            const target =
-                task?.promptContent && !name
-                    ? await options.create?.({
-                          ...ctx,
-                          id: task.agentId,
-                          name: task.agentName,
-                          prompt: task.promptContent
-                      })
-                    : agentName
-                      ? await options.get(agentName, ctx)
-                      : options.create && raw
-                        ? await options.create({ ...ctx, prompt: raw })
-                        : undefined
+
+            if (task?.promptContent && !name) {
+                target = await options.create?.({
+                    ...ctx,
+                    id: task.agentId,
+                    name: task.agentName,
+                    prompt: task.promptContent
+                })
+            } else if (agentName) {
+                target = await options.get(agentName, ctx)
+            } else if (options.create && raw) {
+                target = await options.create({ ...ctx, prompt: raw })
+            }
 
             if (!target) {
                 if (agentName && (!task?.promptContent || name)) {

--- a/packages/core/src/llm-core/agent/sub-agent/tool.ts
+++ b/packages/core/src/llm-core/agent/sub-agent/tool.ts
@@ -11,7 +11,7 @@ import type { ChatLunaToolRunnable } from '../../platform/types'
 
 export function buildTaskToolDescription() {
     return [
-        'Delegate focused work to a specialist agent (exact name required).',
+        'Delegate focused work to a specialist agent, or omit agent to create a prompt-only one-shot sub-agent.',
         'Set background=true for long tasks; results are delivered to you automatically - never poll status.',
         'Actions: run (new task, or resume with id), status, list, list_all, message (guide a running background task), stop (abort a running background task).'
     ].join('\n')
@@ -44,7 +44,7 @@ export function renderAvailableAgents(
     }
     lines.push(
         '',
-        'Use exact names. Include goal, context, and expected result in the prompt.',
+        'Use exact names, or omit agent for a prompt-only one-shot sub-agent. Include goal, context, and expected result in the prompt.',
         '</available_sub_agents>'
     )
     return new SystemMessage(lines.join('\n'))
@@ -67,7 +67,7 @@ class AgentTaskTool extends StructuredTool {
                 .string()
                 .optional()
                 .describe(
-                    'Exact agent name. Required for new tasks; optional when resuming by id.'
+                    'Exact agent name. Optional for new prompt-only one-shot tasks and when resuming by id.'
                 ),
             id: z
                 .string()

--- a/packages/core/src/llm-core/agent/sub-agent/types.ts
+++ b/packages/core/src/llm-core/agent/sub-agent/types.ts
@@ -27,6 +27,7 @@ export interface AgentTaskSession {
     maxDepth: number
     parentAgent: string
     activeRunId?: string
+    promptContent?: string
     messages: BaseMessage[]
     startedAt: number
     updatedAt: number
@@ -118,11 +119,20 @@ export interface AgentTaskResolveContext extends AgentTaskQueryContext {
     runConfig?: ChatLunaToolRunnable
 }
 
+export interface AgentTaskCreateContext extends AgentTaskResolveContext {
+    prompt: string
+    id?: string
+    name?: string
+}
+
 export interface CreateTaskToolOptions {
     list: (ctx: AgentTaskQueryContext) => Awaitable<AgentTaskDescriptor[]>
     get: (
         name: string,
         ctx: AgentTaskResolveContext
+    ) => Awaitable<AgentTaskTarget | undefined>
+    create?: (
+        ctx: AgentTaskCreateContext
     ) => Awaitable<AgentTaskTarget | undefined>
     refresh?: () => Awaitable<void>
     maxDepth?: number

--- a/packages/extension-agent/src/service/sub_agent.ts
+++ b/packages/extension-agent/src/service/sub_agent.ts
@@ -307,6 +307,23 @@ export class ChatLunaAgentSubAgentService {
     }
 
     private _createTaskRuntime() {
+        const buildTarget = async (
+            info: SubAgentInfo,
+            ctx: AgentTaskResolveContext
+        ) => ({
+            agent: await createSubAgent({
+                ctx: this.ctx,
+                permission: this.permission,
+                info,
+                model: ctx.runConfig?.configurable?.model
+            }),
+            toolMask: await this.permission.createSubAgentToolMask(
+                info,
+                ctx.session,
+                ctx.source ?? 'chatluna'
+            )
+        })
+
         return createTaskTool({
             list: ({ session, source }) =>
                 this.listRunnableAgents(session, source).map((item) => ({
@@ -325,19 +342,20 @@ export class ChatLunaAgentSubAgentService {
                     return undefined
                 }
 
-                return {
-                    agent: await createSubAgent({
-                        ctx: this.ctx,
-                        permission: this.permission,
-                        info,
-                        model: ctx.runConfig?.configurable?.model
+                return await buildTarget(info, ctx)
+            },
+            create: async (ctx) => {
+                return await buildTarget(
+                    createManualAgent(this.ctx, {
+                        id: ctx.id,
+                        name: ctx.name ?? 'one-shot',
+                        description: 'Prompt-only one-shot sub-agent',
+                        promptContent: ctx.prompt,
+                        permissions: this.config.subAgent.defaults,
+                        allowKoishiMessageTransform: false
                     }),
-                    toolMask: await this.permission.createSubAgentToolMask(
-                        info,
-                        ctx.session,
-                        ctx.source ?? 'chatluna'
-                    )
-                }
+                    ctx
+                )
             },
             refresh: async () => {
                 await this.ctx.chatluna_agent?.refreshConsoleData()
@@ -365,13 +383,10 @@ export class ChatLunaAgentSubAgentService {
         this._toolDispose?.()
         this._toolDispose = undefined
 
-        if (this.listRunnableAgents().length < 1) return
-
         this._toolDispose = this.ctx.chatluna.platform.registerTool('task', {
             description: this.buildToolDescription(),
-            selector: () => this.listRunnableAgents().length > 0,
-            authorization: (session) =>
-                this.listRunnableAgents(session, 'chatluna').length > 0,
+            selector: () => true,
+            authorization: () => true,
             createTool: () => this._task.createTool(),
             meta: {
                 source: 'extension',
@@ -415,8 +430,6 @@ export class ChatLunaAgentSubAgentService {
                 }
 
                 const agents = this.listRunnableAgents(session, source)
-                if (agents.length < 1) return next()
-
                 const status = this.ctx.chatluna_agent?.computer.getStatus()
                 const remote =
                     status != null && status.defaultProvider !== 'local'

--- a/packages/extension-agent/src/service/sub_agent.ts
+++ b/packages/extension-agent/src/service/sub_agent.ts
@@ -345,17 +345,26 @@ export class ChatLunaAgentSubAgentService {
                 return await buildTarget(info, ctx)
             },
             create: async (ctx) => {
-                return await buildTarget(
-                    createManualAgent(this.ctx, {
-                        id: ctx.id,
-                        name: ctx.name ?? 'one-shot',
-                        description: 'Prompt-only one-shot sub-agent',
-                        promptContent: ctx.prompt,
-                        permissions: this.config.subAgent.defaults,
-                        allowKoishiMessageTransform: false
-                    }),
-                    ctx
-                )
+                const info = createManualAgent(this.ctx, {
+                    id: ctx.id,
+                    name: ctx.name ?? 'one-shot',
+                    description: 'Prompt-only one-shot sub-agent',
+                    promptContent: ctx.prompt,
+                    permissions: this.config.subAgent.defaults,
+                    allowKoishiMessageTransform: false
+                })
+
+                if (
+                    !this.permission.canUseSubAgent(
+                        info,
+                        ctx.session,
+                        ctx.source
+                    )
+                ) {
+                    return undefined
+                }
+
+                return await buildTarget(info, ctx)
             },
             refresh: async () => {
                 await this.ctx.chatluna_agent?.refreshConsoleData()


### PR DESCRIPTION
This pr adds prompt-only one-shot sub-agent task support.

Close #946

## New Features
- Allow task tool calls to omit agent and create a prompt-only one-shot sub-agent.
- Preserve prompt content on task sessions for resuming one-shot tasks.
- Keep the task tool available even when no configured sub-agent exists.

## Validation
- yarn lint-fix