### PR TITLE
fix(core): preserve forward message ids

### DIFF
--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -165,7 +165,14 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                         transformedMessage.additional_kwargs.forwardMessageIds =
                             state.ids
                     }
-                    addMessageContent(transformedMessage, '[聊天记录]')
+                    addMessageContent(
+                        transformedMessage,
+                        state.ids.length > 0
+                            ? state.ids
+                                  .map((id) => `<forward id="${id}"/>`)
+                                  .join('')
+                            : '<forward/>'
+                    )
                 }
             }
 

--- a/packages/core/src/services/message_transform.ts
+++ b/packages/core/src/services/message_transform.ts
@@ -125,6 +125,7 @@ export class MessageTransformer {
                     const last = acc[acc.length - 1]
                     if (
                         isMessageContentText(item) &&
+                        last != null &&
                         isMessageContentText(last)
                     ) {
                         acc[acc.length - 1] = {

--- a/packages/core/src/services/message_transform.ts
+++ b/packages/core/src/services/message_transform.ts
@@ -5,11 +5,9 @@ import {
     ChatLunaError,
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
-import {
-    isMessageContentImageUrl,
-    isMessageContentText
-} from 'koishi-plugin-chatluna/utils/string'
-import { MessageContent } from '@langchain/core/messages'
+import { isMessageContentText } from 'koishi-plugin-chatluna/utils/string'
+import { MessageContentComplex } from '@langchain/core/messages'
+import { isMessageContentComplex } from '../utils/langchain'
 
 export class MessageTransformer {
     private _beforeTransformFunctions: BeforeTransformFunctionWithPriority[] =
@@ -75,27 +73,6 @@ export class MessageTransformer {
                 }
             )
 
-            const extractText = (content: MessageContent) => {
-                if (typeof content === 'string') return content
-                return Array.isArray(content)
-                    ? content
-                          .filter((item) => isMessageContentText(item))
-                          .map((item) => item.text)
-                          .join('')
-                    : ''
-            }
-
-            const extractImages = (content: MessageContent) =>
-                Array.isArray(content)
-                    ? content.filter((item) => isMessageContentImageUrl(item))
-                    : []
-
-            const quoteText = extractText(quoteMessage.content)
-            const quoteImages = extractImages(quoteMessage.content)
-            const hasImages =
-                extractImages(message.content).length > 0 ||
-                quoteImages.length > 0
-
             // 构建引用消息的完整格式：时间 + 发言人 + 内容
             const quoteUsername =
                 session.quote.user?.name || session.quote.user?.id || 'Unknown'
@@ -115,31 +92,44 @@ export class MessageTransformer {
                 ? `${quoteTimestamp} ${quoteUsername}`
                 : quoteUsername
 
-            if (hasImages) {
-                if (typeof message.content === 'string') {
-                    message.content =
-                        message.content.trim().length > 0
-                            ? [{ type: 'text', text: message.content }]
-                            : []
-                }
+            const messageContent = [
+                `The Referenced message is ${quoteHeader} ${quoteSaid} said`,
+                ...(Array.isArray(quoteMessage.content)
+                    ? quoteMessage.content
+                    : [quoteMessage.content]),
+                `\n\n User's current message`,
+                ...message.content
+            ]
 
-                if (quoteText && quoteText !== '[image]') {
-                    const currentText = extractText(message.content)
-                    const quotedContent = `Referenced message: [${quoteHeader} ${quoteSaid}："${quoteText}"]\n\nUser's message: ${currentText}`
-
-                    message.content = message.content.filter(
-                        (item) => item.type !== 'text'
-                    )
-                    message.content.unshift({
-                        type: 'text',
-                        text: quotedContent
+            if (
+                typeof message.content === 'string' &&
+                typeof quoteMessage.content === 'string'
+            ) {
+                message.content = messageContent
+                    .filter((content) => isMessageContentText(content))
+                    .map((content) => content.text)
+                    .join()
+            } else {
+                message.content = messageContent
+                    .map((content) => {
+                        if (isMessageContentComplex(content)) return content
+                        return { type: 'text', text: content }
                     })
-                }
-
-                message.content = [...quoteImages, ...message.content]
-            } else if (quoteText && quoteText !== '[image]') {
-                const currentText = extractText(message.content)
-                message.content = `Referenced message: [${quoteHeader} ${quoteSaid}："${quoteText}"]\n\nUser's message: ${currentText}`
+                    .reduce((acc, item) => {
+                        const last = acc[acc.length - 1]
+                        if (
+                            isMessageContentText(item) &&
+                            isMessageContentText(last)
+                        ) {
+                            acc[acc.length - 1] = {
+                                type: 'text',
+                                text: last.text + item.text
+                            }
+                        } else {
+                            acc.push(item)
+                        }
+                        return acc
+                    }, [] as MessageContentComplex[])
             }
         }
 

--- a/packages/core/src/services/message_transform.ts
+++ b/packages/core/src/services/message_transform.ts
@@ -5,9 +5,8 @@ import {
     ChatLunaError,
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
-import { isMessageContentText } from 'koishi-plugin-chatluna/utils/string'
 import { MessageContentComplex } from '@langchain/core/messages'
-import { isMessageContentComplex } from '../utils/langchain'
+import { isMessageContentComplex, isMessageContentText } from '../utils/langchain'
 
 export class MessageTransformer {
     private _beforeTransformFunctions: BeforeTransformFunctionWithPriority[] =
@@ -92,45 +91,51 @@ export class MessageTransformer {
                 ? `${quoteTimestamp} ${quoteUsername}`
                 : quoteUsername
 
+            if (
+                typeof message.content === 'string' &&
+                typeof quoteMessage.content === 'string'
+            ) {
+                message.content = [
+                    `The Referenced message is ${quoteHeader} ${quoteSaid} said\n`,
+                    quoteMessage.content,
+                    `\n\n User's current message\n`,
+                    message.content
+                ].join('')
+
+                return message
+            }
+
             const messageContent = [
                 `The Referenced message is ${quoteHeader} ${quoteSaid} said`,
                 ...(Array.isArray(quoteMessage.content)
                     ? quoteMessage.content
                     : [quoteMessage.content]),
                 `\n\n User's current message`,
-                ...message.content
+                ...(Array.isArray(message.content)
+                    ? message.content
+                    : [message.content])
             ]
 
-            if (
-                typeof message.content === 'string' &&
-                typeof quoteMessage.content === 'string'
-            ) {
-                message.content = messageContent
-                    .filter((content) => isMessageContentText(content))
-                    .map((content) => content.text)
-                    .join()
-            } else {
-                message.content = messageContent
-                    .map((content) => {
-                        if (isMessageContentComplex(content)) return content
-                        return { type: 'text', text: content }
-                    })
-                    .reduce((acc, item) => {
-                        const last = acc[acc.length - 1]
-                        if (
-                            isMessageContentText(item) &&
-                            isMessageContentText(last)
-                        ) {
-                            acc[acc.length - 1] = {
-                                type: 'text',
-                                text: last.text + item.text
-                            }
-                        } else {
-                            acc.push(item)
+            message.content = messageContent
+                .map((content) => {
+                    if (isMessageContentComplex(content)) return content
+                    return { type: 'text', text: content }
+                })
+                .reduce((acc, item) => {
+                    const last = acc[acc.length - 1]
+                    if (
+                        isMessageContentText(item) &&
+                        isMessageContentText(last)
+                    ) {
+                        acc[acc.length - 1] = {
+                            type: 'text',
+                            text: last.text + item.text
                         }
-                        return acc
-                    }, [] as MessageContentComplex[])
-            }
+                    } else {
+                        acc.push(item)
+                    }
+                    return acc
+                }, [] as MessageContentComplex[])
         }
 
         return message

--- a/packages/core/src/services/message_transform.ts
+++ b/packages/core/src/services/message_transform.ts
@@ -6,7 +6,10 @@ import {
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
 import { MessageContentComplex } from '@langchain/core/messages'
-import { isMessageContentComplex, isMessageContentText } from '../utils/langchain'
+import {
+    isMessageContentComplex,
+    isMessageContentText
+} from '../utils/langchain'
 
 export class MessageTransformer {
     private _beforeTransformFunctions: BeforeTransformFunctionWithPriority[] =

--- a/packages/core/src/utils/koishi.ts
+++ b/packages/core/src/utils/koishi.ts
@@ -214,8 +214,6 @@ export function transformMessageContentToElements(content: MessageContent) {
 export function pickForwardMessageId(element: h): string | null {
     const attrs = (element.attrs ?? {}) as Record<string, unknown>
 
-    // Only use the common message id field used across other message APIs.
-    // Keep both snake_case and camelCase for adapter compatibility.
     for (const key of ['message_id', 'messageId']) {
         const normalizedId = normalizeForwardMessageId(attrs[key])
         if (normalizedId) return normalizedId

--- a/packages/core/src/utils/langchain.ts
+++ b/packages/core/src/utils/langchain.ts
@@ -35,37 +35,32 @@ type MessageContentUrlPart =
     | MessageContentVideo
 
 export function isMessageContentImageUrl(
-    message: string | MessageContentComplex
+    message: MessageContentComplex
 ): message is MessageContentImageUrl {
-    if (typeof message === 'string') return false
     return message.type === 'image_url' && message['image_url'] != null
 }
 
 export function isMessageContentText(
-    message: string | MessageContentComplex
+    message: MessageContentComplex
 ): message is MessageContentText {
-    if (typeof message === 'string') return false
     return message.type === 'text' && message.text != null
 }
 
 export function isMessageContentFileUrl(
-    message: string | MessageContentComplex
+    message: MessageContentComplex
 ): message is MessageContentFileUrl {
-    if (typeof message === 'string') return false
     return message.type === 'file_url' && message['file_url'] != null
 }
 
 export function isMessageContentAudio(
-    message: string | MessageContentComplex
+    message: MessageContentComplex
 ): message is MessageContentAudio {
-    if (typeof message === 'string') return false
     return message.type === 'audio_url' && message['audio_url'] != null
 }
 
 export function isMessageContentVideo(
-    message: string | MessageContentComplex
+    message: MessageContentComplex
 ): message is MessageContentVideo {
-    if (typeof message === 'string') return false
     return message.type === 'video_url' && message['video_url'] != null
 }
 

--- a/packages/core/src/utils/langchain.ts
+++ b/packages/core/src/utils/langchain.ts
@@ -35,32 +35,37 @@ type MessageContentUrlPart =
     | MessageContentVideo
 
 export function isMessageContentImageUrl(
-    message: MessageContentComplex
+    message: string | MessageContentComplex
 ): message is MessageContentImageUrl {
+    if (typeof message === 'string') return false
     return message.type === 'image_url' && message['image_url'] != null
 }
 
 export function isMessageContentText(
-    message: MessageContentComplex
+    message: string | MessageContentComplex
 ): message is MessageContentText {
+    if (typeof message === 'string') return false
     return message.type === 'text' && message.text != null
 }
 
 export function isMessageContentFileUrl(
-    message: MessageContentComplex
+    message: string | MessageContentComplex
 ): message is MessageContentFileUrl {
+    if (typeof message === 'string') return false
     return message.type === 'file_url' && message['file_url'] != null
 }
 
 export function isMessageContentAudio(
-    message: MessageContentComplex
+    message: string | MessageContentComplex
 ): message is MessageContentAudio {
+    if (typeof message === 'string') return false
     return message.type === 'audio_url' && message['audio_url'] != null
 }
 
 export function isMessageContentVideo(
-    message: MessageContentComplex
+    message: string | MessageContentComplex
 ): message is MessageContentVideo {
+    if (typeof message === 'string') return false
     return message.type === 'video_url' && message['video_url'] != null
 }
 


### PR DESCRIPTION
This pr preserves forward message IDs through chat message transformation.

Close #949

## Bug Fixes
- Render forward message placeholders with collected forward IDs.
- Keep quoted multimodal message content when building referenced-message context.
- Allow LangChain content type guards to safely receive string content.

## Validation
- yarn lint-fix