### PR TITLE
feat(ollama): modernize adapter capabilities

### DIFF
--- a/packages/adapter-ollama/src/client.ts
+++ b/packages/adapter-ollama/src/client.ts
@@ -19,6 +19,7 @@ import { OllamaRequester } from './requester'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 
 import type { ModelUsageReporter } from 'koishi-plugin-chatluna/llm-core/platform/usage'
+import type { OllamaShowResponse } from './types'
 
 export class OllamaClient extends PlatformModelAndEmbeddingsClient<ClientConfig> {
     platform = 'ollama'
@@ -45,9 +46,16 @@ export class OllamaClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
 
             const models = await Promise.all(
                 rawModels.map(async (model) => {
-                    const show = await this._requester.getModelDetails(
-                        model.name
-                    )
+                    let show: OllamaShowResponse
+                    try {
+                        show = await this._requester.getModelDetails(model.name)
+                    } catch (e) {
+                        logger.warn(
+                            `Failed to get model details for ${model.name}`,
+                            e
+                        )
+                        show = { details: model.details }
+                    }
                     const caps = (show.capabilities ?? []).map((cap) =>
                         cap.toLowerCase()
                     )

--- a/packages/adapter-ollama/src/client.ts
+++ b/packages/adapter-ollama/src/client.ts
@@ -43,30 +43,123 @@ export class OllamaClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
         try {
             const rawModels = await this._requester.getModels()
 
-            return rawModels.map((model) => {
-                return {
-                    name: model,
-                    type:
-                        model.includes('embed') ||
-                        model.includes('all-minilm') ||
-                        model.includes('bge') ||
-                        model.includes('paraphrase-multilingual')
+            const models = await Promise.all(
+                rawModels.map(async (model) => {
+                    const show = await this._requester.getModelDetails(
+                        model.name
+                    )
+                    const caps = (show.capabilities ?? []).map((cap) =>
+                        cap.toLowerCase()
+                    )
+                    const families = [
+                        show.details?.family,
+                        ...(show.details?.families ?? [])
+                    ]
+                        .filter((family): family is string => family != null)
+                        .map((family) => family.toLowerCase())
+                    const name = model.name.toLowerCase()
+                    const type =
+                        caps.includes('embedding') ||
+                        caps.includes('embeddings') ||
+                        name.includes('embed') ||
+                        name.includes('all-minilm') ||
+                        name.includes('bge') ||
+                        name.includes('paraphrase-multilingual') ||
+                        families.some(
+                            (family) =>
+                                family.includes('embed') ||
+                                family.includes('all-minilm') ||
+                                family.includes('bge')
+                        )
                             ? ModelType.embeddings
-                            : ModelType.llm,
-                    capabilities: [
-                        this._config.supportImageModels.includes(model)
-                            ? ModelCapabilities.ImageInput
-                            : undefined
-                    ].filter(Boolean),
-                    maxTokens: ((model: string) => {
-                        if (model.startsWith('llama3')) {
-                            return 32000
-                        }
+                            : ModelType.llm
 
-                        return 128000
-                    })(model)
+                    let maxTokens = 0
+                    const modelInfo = show.model_info ?? {}
+                    for (const key of Object.keys(modelInfo)) {
+                        const value = modelInfo[key]
+                        if (
+                            key.endsWith('.context_length') &&
+                            typeof value === 'number'
+                        ) {
+                            maxTokens = value
+                            break
+                        }
+                    }
+
+                    if (maxTokens < 1 && show.parameters != null) {
+                        const match = show.parameters.match(/^num_ctx\s+(\d+)/m)
+                        if (match != null) {
+                            maxTokens = Number(match[1])
+                        }
+                    }
+
+                    if (maxTokens < 1) {
+                        maxTokens = model.name.startsWith('llama3')
+                            ? 32000
+                            : 128000
+                    }
+
+                    return {
+                        name: model.name,
+                        type,
+                        capabilities:
+                            type === ModelType.llm
+                                ? [
+                                      caps.includes('vision') ||
+                                      this._config.supportImageModels.includes(
+                                          model.name
+                                      )
+                                          ? ModelCapabilities.ImageInput
+                                          : undefined,
+                                      caps.includes('tools') ||
+                                      caps.includes('tool') ||
+                                      caps.includes('tool_call') ||
+                                      caps.includes('tool-calling') ||
+                                      caps.includes('function_call') ||
+                                      caps.includes('function_calling') ||
+                                      caps.includes('function-calling')
+                                          ? ModelCapabilities.ToolCall
+                                          : undefined,
+                                      caps.includes('thinking') ||
+                                      caps.includes('think')
+                                          ? ModelCapabilities.Thinking
+                                          : undefined
+                                  ].filter(Boolean)
+                                : [],
+                        maxTokens
+                    } as ModelInfo
+                })
+            )
+
+            const result = models.flatMap((model) => {
+                if (
+                    model.type !== ModelType.llm ||
+                    model.name.includes('thinking') ||
+                    !model.capabilities.includes(ModelCapabilities.Thinking)
+                ) {
+                    return [model]
                 }
+
+                return [
+                    model,
+                    ...[
+                        'non-thinking',
+                        'low-thinking',
+                        'medium-thinking',
+                        'high-thinking',
+                        'max-thinking',
+                        'thinking'
+                    ].map((suffix) => ({
+                        ...model,
+                        name: `${model.name}-${suffix}`
+                    }))
+                ]
             })
+
+            this._requester.setModels(result)
+
+            return result
         } catch (e) {
             throw new ChatLunaError(ChatLunaErrorCode.MODEL_INIT_ERROR, e)
         }
@@ -101,7 +194,10 @@ export class OllamaClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
                 timeout: this._config.timeout,
                 temperature: this._config.temperature,
                 maxRetries: this._config.maxRetries,
-                llmType: 'ollama'
+                llmType: 'ollama',
+                isThinkModel: info.capabilities.includes(
+                    ModelCapabilities.Thinking
+                )
             })
         }
 

--- a/packages/adapter-ollama/src/requester.ts
+++ b/packages/adapter-ollama/src/requester.ts
@@ -1,4 +1,4 @@
-import { AIMessageChunk } from '@langchain/core/messages'
+import { AIMessageChunk, type UsageMetadata } from '@langchain/core/messages'
 import { ChatGenerationChunk } from '@langchain/core/outputs'
 import {
     EmbeddingsRequester,
@@ -15,22 +15,93 @@ import {
     ChatLunaError,
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
-import { checkResponse, sse } from 'koishi-plugin-chatluna/utils/sse'
-import { readableStreamToAsyncIterable } from 'koishi-plugin-chatluna/utils/stream'
+import { rawSeeAsIterable } from 'koishi-plugin-chatluna/utils/sse'
 import { Context } from 'koishi'
 import {
     OllamaDeltaResponse,
     OllamaEmbedResponse,
-    OllamaRequest
+    OllamaListResponse,
+    OllamaModelSummary,
+    OllamaRequest,
+    OllamaShowResponse
 } from './types'
-import { langchainMessageToOllamaMessage } from './utils'
+import {
+    formatToolsToOllamaTools,
+    langchainMessageToOllamaMessage
+} from './utils'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { Config, logger as pluginLogger } from '.'
+import {
+    ModelCapabilities,
+    ModelInfo
+} from 'koishi-plugin-chatluna/llm-core/platform/types'
+
+function ollamaUsageToUsageMetadata(
+    chunk: OllamaDeltaResponse
+): UsageMetadata | undefined {
+    if (chunk.prompt_eval_count == null && chunk.eval_count == null) {
+        return undefined
+    }
+
+    const inputTokens = chunk.prompt_eval_count ?? 0
+    const outputTokens = chunk.eval_count ?? 0
+
+    return {
+        input_tokens: inputTokens,
+        output_tokens: outputTokens,
+        total_tokens: inputTokens + outputTokens
+    }
+}
+
+function ollamaChunkToGeneration(chunk: OllamaDeltaResponse) {
+    const content = chunk.message?.content ?? ''
+    const thinking = chunk.message?.thinking
+    const toolCallChunks =
+        chunk.message?.tool_calls?.map((call, index) => ({
+            name: call.function.name,
+            args: JSON.stringify(call.function.arguments),
+            id: call.id ?? `call_${call.function.index ?? index}`,
+            index: call.function.index ?? index
+        })) ?? []
+    const usageMetadata = ollamaUsageToUsageMetadata(chunk)
+
+    if (
+        content.length < 1 &&
+        thinking == null &&
+        toolCallChunks.length < 1 &&
+        usageMetadata == null
+    ) {
+        return undefined
+    }
+
+    return new ChatGenerationChunk({
+        generationInfo:
+            usageMetadata == null
+                ? undefined
+                : {
+                      usage_metadata: usageMetadata
+                  },
+        message: new AIMessageChunk({
+            content,
+            tool_call_chunks: toolCallChunks,
+            usage_metadata: usageMetadata,
+            additional_kwargs:
+                thinking == null
+                    ? {}
+                    : {
+                          reasoning_content: thinking
+                      }
+        }),
+        text: content
+    })
+}
 
 export class OllamaRequester
     extends ModelRequester<ClientConfig>
     implements EmbeddingsRequester
 {
+    private _models: Record<string, ModelInfo> = {}
+
     constructor(
         ctx: Context,
         _configPool: ClientConfigPool<ClientConfig>,
@@ -39,30 +110,74 @@ export class OllamaRequester
         super(ctx, _configPool, undefined, _plugin)
     }
 
+    setModels(models: ModelInfo[]) {
+        this._models = {}
+        for (const model of models) {
+            this._models[model.name] = model
+        }
+    }
+
     async *completionStreamInternal(
         params: ModelRequestParams
     ): AsyncGenerator<ChatGenerationChunk> {
         try {
+            const rawModel = params.model ?? ''
+            let model = rawModel
+            let think: OllamaRequest['think']
+            const effort = model.match(/-(low|medium|high|max)-thinking$/)
+
+            if (effort?.[1] != null) {
+                think = effort[1] as OllamaRequest['think']
+                model = model.slice(0, -`-${effort[1]}-thinking`.length)
+            } else if (model.endsWith('-non-thinking')) {
+                think = false
+                model = model.slice(0, -'-non-thinking'.length)
+            } else if (model.endsWith('-thinking')) {
+                think = true
+                model = model.slice(0, -'-thinking'.length)
+            }
+
+            const info = (this._models[rawModel] ?? this._models[model])!
+
+            if (
+                think == null &&
+                info.capabilities.includes(ModelCapabilities.Thinking)
+            ) {
+                think = model.toLowerCase().includes('gpt-oss')
+                    ? 'medium'
+                    : true
+            }
+
             const response = await this.post(
                 'api/chat',
                 {
-                    model: params.model,
+                    model,
                     messages: await langchainMessageToOllamaMessage(
                         params.input,
                         this._plugin,
-                        this._plugin.config.supportImageModels.includes(
-                            params.model
-                        )
+                        info.capabilities.includes(
+                            ModelCapabilities.ImageInput
+                        ) ||
+                            this._plugin.config.supportImageModels.includes(
+                                model
+                            ) ||
+                            this._plugin.config.supportImageModels.includes(
+                                rawModel
+                            )
                     ),
+                    tools:
+                        params.tools != null &&
+                        info.capabilities.includes(ModelCapabilities.ToolCall)
+                            ? formatToolsToOllamaTools(params.tools)
+                            : undefined,
+                    think,
                     keep_alive: this._plugin.config.keepAlive ? -1 : undefined,
                     options: {
                         temperature: params.temperature,
                         // top_k: params.n,
                         top_p: params.topP,
-                        stop:
-                            typeof params.stop === 'string'
-                                ? params.stop
-                                : params.stop?.[0]
+                        stop: params.stop,
+                        num_predict: params.maxTokens
                     },
                     stream: true
                 } satisfies OllamaRequest,
@@ -71,59 +186,34 @@ export class OllamaRequester
                 }
             )
 
-            const stream = new TransformStream<string, OllamaDeltaResponse>()
-
-            const iterable = readableStreamToAsyncIterable<OllamaDeltaResponse>(
-                stream.readable
-            )
-
-            const writable = stream.writable.getWriter()
-
             let buffer = ''
 
-            await checkResponse(response)
+            for await (const rawData of rawSeeAsIterable(response, 0)) {
+                buffer += rawData
 
-            sse(
-                response,
-                async (rawData) => {
-                    buffer += rawData
+                const parts = buffer.split('\n')
+                buffer = parts.pop() ?? ''
 
-                    const parts = buffer.split('\n')
+                for (const part of parts) {
+                    if (part.trim().length < 1) continue
 
-                    buffer = parts.pop() ?? ''
+                    const chunk = JSON.parse(part) as OllamaDeltaResponse
+                    const generation = ollamaChunkToGeneration(chunk)
 
-                    for (const part of parts) {
-                        try {
-                            writable.write(JSON.parse(part))
-                        } catch (error) {
-                            console.warn('invalid json: ', part)
-                        }
+                    if (generation != null) {
+                        yield generation
                     }
-                },
-                0
-            )
 
-            for await (const chunk of iterable) {
-                try {
-                    const content = chunk.message.content
+                    if (chunk.done) return
+                }
+            }
 
-                    const generationChunk = new ChatGenerationChunk({
-                        message: new AIMessageChunk(content),
-                        text: content
-                    })
-                    yield generationChunk
+            if (buffer.trim().length > 0) {
+                const chunk = JSON.parse(buffer) as OllamaDeltaResponse
+                const generation = ollamaChunkToGeneration(chunk)
 
-                    if (chunk.done) {
-                        return
-                    }
-                } catch (e) {
-                    throw new ChatLunaError(
-                        ChatLunaErrorCode.API_REQUEST_FAILED,
-                        new Error(
-                            'error when calling ollama completion, Result: ' +
-                                chunk
-                        )
-                    )
+                if (generation != null) {
+                    yield generation
                 }
             }
         } catch (e) {
@@ -173,21 +263,37 @@ export class OllamaRequester
         }
     }
 
-    async getModels(): Promise<string[]> {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let data: any
+    async getModels(): Promise<OllamaModelSummary[]> {
+        let data: OllamaListResponse | string
         try {
             const response = await this.get('api/tags')
             data = await response.text()
-            data = JSON.parse(data as string)
+            data = JSON.parse(data as string) as OllamaListResponse
 
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            return (<Record<string, any>[]>data.models).map(
-                (model) => model.name
-            )
+            return data.models
         } catch (e) {
             const error = new Error(
                 'error when listing ollama models, Result: ' +
+                    JSON.stringify(data)
+            )
+
+            error.stack = e.stack
+            error.cause = e.cause
+
+            throw error
+        }
+    }
+
+    async getModelDetails(model: string): Promise<OllamaShowResponse> {
+        let data: unknown
+        try {
+            const response = await this.post('api/show', { model })
+            data = await response.text()
+
+            return JSON.parse(data as string) as OllamaShowResponse
+        } catch (e) {
+            const error = new Error(
+                'error when showing ollama model, Result: ' +
                     JSON.stringify(data)
             )
 

--- a/packages/adapter-ollama/src/requester.ts
+++ b/packages/adapter-ollama/src/requester.ts
@@ -1,4 +1,3 @@
-import { AIMessageChunk, type UsageMetadata } from '@langchain/core/messages'
 import { ChatGenerationChunk } from '@langchain/core/outputs'
 import {
     EmbeddingsRequester,
@@ -15,7 +14,10 @@ import {
     ChatLunaError,
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
-import { rawSeeAsIterable } from 'koishi-plugin-chatluna/utils/sse'
+import {
+    checkResponse,
+    rawSeeAsIterable
+} from 'koishi-plugin-chatluna/utils/sse'
 import { Context } from 'koishi'
 import {
     OllamaDeltaResponse,
@@ -27,74 +29,16 @@ import {
 } from './types'
 import {
     formatToolsToOllamaTools,
-    langchainMessageToOllamaMessage
+    langchainMessageToOllamaMessage,
+    ollamaChunkToGeneration
 } from './utils'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { Config, logger as pluginLogger } from '.'
 import {
     ModelCapabilities,
-    ModelInfo
+    ModelInfo,
+    ModelType
 } from 'koishi-plugin-chatluna/llm-core/platform/types'
-
-function ollamaUsageToUsageMetadata(
-    chunk: OllamaDeltaResponse
-): UsageMetadata | undefined {
-    if (chunk.prompt_eval_count == null && chunk.eval_count == null) {
-        return undefined
-    }
-
-    const inputTokens = chunk.prompt_eval_count ?? 0
-    const outputTokens = chunk.eval_count ?? 0
-
-    return {
-        input_tokens: inputTokens,
-        output_tokens: outputTokens,
-        total_tokens: inputTokens + outputTokens
-    }
-}
-
-function ollamaChunkToGeneration(chunk: OllamaDeltaResponse) {
-    const content = chunk.message?.content ?? ''
-    const thinking = chunk.message?.thinking
-    const toolCallChunks =
-        chunk.message?.tool_calls?.map((call, index) => ({
-            name: call.function.name,
-            args: JSON.stringify(call.function.arguments),
-            id: call.id ?? `call_${call.function.index ?? index}`,
-            index: call.function.index ?? index
-        })) ?? []
-    const usageMetadata = ollamaUsageToUsageMetadata(chunk)
-
-    if (
-        content.length < 1 &&
-        thinking == null &&
-        toolCallChunks.length < 1 &&
-        usageMetadata == null
-    ) {
-        return undefined
-    }
-
-    return new ChatGenerationChunk({
-        generationInfo:
-            usageMetadata == null
-                ? undefined
-                : {
-                      usage_metadata: usageMetadata
-                  },
-        message: new AIMessageChunk({
-            content,
-            tool_call_chunks: toolCallChunks,
-            usage_metadata: usageMetadata,
-            additional_kwargs:
-                thinking == null
-                    ? {}
-                    : {
-                          reasoning_content: thinking
-                      }
-        }),
-        text: content
-    })
-}
 
 export class OllamaRequester
     extends ModelRequester<ClientConfig>
@@ -137,7 +81,13 @@ export class OllamaRequester
                 model = model.slice(0, -'-thinking'.length)
             }
 
-            const info = (this._models[rawModel] ?? this._models[model])!
+            const info = this._models[rawModel] ??
+                this._models[model] ?? {
+                    name: model,
+                    type: ModelType.llm,
+                    capabilities: [],
+                    maxTokens: 128000
+                }
 
             if (
                 think == null &&
@@ -186,6 +136,8 @@ export class OllamaRequester
                 }
             )
 
+            await checkResponse(response)
+
             let buffer = ''
 
             for await (const rawData of rawSeeAsIterable(response, 0)) {
@@ -197,7 +149,14 @@ export class OllamaRequester
                 for (const part of parts) {
                     if (part.trim().length < 1) continue
 
-                    const chunk = JSON.parse(part) as OllamaDeltaResponse
+                    let chunk: OllamaDeltaResponse
+                    try {
+                        chunk = JSON.parse(part) as OllamaDeltaResponse
+                    } catch (e) {
+                        this.logger.warn('invalid json: ', part, e)
+                        continue
+                    }
+
                     const generation = ollamaChunkToGeneration(chunk)
 
                     if (generation != null) {
@@ -209,11 +168,15 @@ export class OllamaRequester
             }
 
             if (buffer.trim().length > 0) {
-                const chunk = JSON.parse(buffer) as OllamaDeltaResponse
-                const generation = ollamaChunkToGeneration(chunk)
+                try {
+                    const chunk = JSON.parse(buffer) as OllamaDeltaResponse
+                    const generation = ollamaChunkToGeneration(chunk)
 
-                if (generation != null) {
-                    yield generation
+                    if (generation != null) {
+                        yield generation
+                    }
+                } catch (e) {
+                    this.logger.warn('invalid json in buffer: ', buffer, e)
                 }
             }
         } catch (e) {

--- a/packages/adapter-ollama/src/types.ts
+++ b/packages/adapter-ollama/src/types.ts
@@ -47,7 +47,7 @@ export interface OllamaTool {
 export interface OllamaToolCall {
     type?: 'function'
     id?: string
-    function: {
+    function?: {
         index?: number
         name: string
         arguments: Record<string, unknown>

--- a/packages/adapter-ollama/src/types.ts
+++ b/packages/adapter-ollama/src/types.ts
@@ -1,34 +1,107 @@
+export type OllamaRole = 'system' | 'user' | 'assistant' | 'tool'
+
+export type OllamaThink = boolean | 'low' | 'medium' | 'high' | 'max'
+
 export interface OllamaRequest {
     model: string
     options: {
-        temperature: number
+        temperature?: number
         top_k?: number
-        top_p: number
-        stop: string
+        top_p?: number
+        stop?: string | string[]
+        num_predict?: number
     }
-    keep_alive?: number
+    keep_alive?: number | string
     messages: OllamaMessage[]
+    tools?: OllamaTool[]
+    think?: OllamaThink
     stream: boolean
 }
 
-export interface OllamaDeltaResponse {
+export interface OllamaDeltaResponse extends OllamaUsage {
     model: string
-    message: OllamaMessage
+    created_at?: string
+    message?: OllamaMessage
     done: boolean
+    done_reason?: string
 }
 
 export interface OllamaMessage {
-    role: string
+    role: OllamaRole
     content: string
+    thinking?: string
     images?: string[]
+    tool_calls?: OllamaToolCall[]
+    tool_name?: string
+}
+
+export interface OllamaTool {
+    type: 'function'
+    function: {
+        name: string
+        description?: string
+        parameters: Record<string, unknown>
+    }
+}
+
+export interface OllamaToolCall {
+    type?: 'function'
+    id?: string
+    function: {
+        index?: number
+        name: string
+        arguments: Record<string, unknown>
+    }
+}
+
+export interface OllamaUsage {
+    total_duration?: number
+    load_duration?: number
+    prompt_eval_count?: number
+    prompt_eval_duration?: number
+    eval_count?: number
+    eval_duration?: number
+}
+
+export interface OllamaListResponse {
+    models: OllamaModelSummary[]
+}
+
+export interface OllamaModelSummary {
+    name: string
+    model: string
+    modified_at?: string
+    size?: number
+    digest?: string
+    details?: OllamaModelDetails
+}
+
+export interface OllamaShowResponse {
+    parameters?: string
+    license?: string
+    modified_at?: string
+    details?: OllamaModelDetails
+    template?: string
+    capabilities?: string[]
+    model_info?: Record<string, unknown>
+}
+
+export interface OllamaModelDetails {
+    parent_model?: string
+    format?: string
+    family?: string
+    families?: string[]
+    parameter_size?: string
+    quantization_level?: string
 }
 
 export interface OllamaEmbedRequest {
     model: string
     input: string | string[]
+    keep_alive?: number | string
 }
 
-export interface OllamaEmbedResponse {
+export interface OllamaEmbedResponse extends OllamaUsage {
     model: string
     embeddings: number[][]
 }

--- a/packages/adapter-ollama/src/utils.ts
+++ b/packages/adapter-ollama/src/utils.ts
@@ -1,11 +1,18 @@
 import {
     AIMessage,
+    AIMessageChunk,
     BaseMessage,
     MessageContentImageUrl,
-    MessageType
+    MessageType,
+    UsageMetadata
 } from '@langchain/core/messages'
 import { StructuredTool } from '@langchain/core/tools'
-import { OllamaMessage, OllamaRole, OllamaTool } from './types'
+import {
+    OllamaDeltaResponse,
+    OllamaMessage,
+    OllamaRole,
+    OllamaTool
+} from './types'
 import {
     getMessageContent,
     isMessageContentImageUrl
@@ -16,6 +23,7 @@ import {
     formatToolsToOpenAITools
 } from '@chatluna/v1-shared-adapter'
 import { logger } from '.'
+import { ChatGenerationChunk } from '@langchain/core/outputs'
 
 export function formatToolsToOllamaTools(
     tools: StructuredTool[]
@@ -159,4 +167,67 @@ export function messageTypeToOllamaRole(type: MessageType): OllamaRole {
         default:
             throw new Error(`Unknown message type: ${type}`)
     }
+}
+
+export function ollamaUsageToUsageMetadata(
+    chunk: OllamaDeltaResponse
+): UsageMetadata | undefined {
+    if (chunk.prompt_eval_count == null && chunk.eval_count == null) {
+        return undefined
+    }
+
+    const inputTokens = chunk.prompt_eval_count ?? 0
+    const outputTokens = chunk.eval_count ?? 0
+
+    return {
+        input_tokens: inputTokens,
+        output_tokens: outputTokens,
+        total_tokens: inputTokens + outputTokens
+    }
+}
+
+export function ollamaChunkToGeneration(chunk: OllamaDeltaResponse) {
+    const content = chunk.message?.content ?? ''
+    const thinking = chunk.message?.thinking
+    const toolCallChunks =
+        chunk.message?.tool_calls?.map((call, index) => ({
+            name: call.function?.name,
+            args:
+                call.function?.arguments != null
+                    ? JSON.stringify(call.function.arguments)
+                    : '{}',
+            id: call.id ?? `call_${call.function?.index ?? index}`,
+            index: call.function?.index ?? index
+        })) ?? []
+    const usageMetadata = ollamaUsageToUsageMetadata(chunk)
+
+    if (
+        content.length < 1 &&
+        thinking == null &&
+        toolCallChunks.length < 1 &&
+        usageMetadata == null
+    ) {
+        return undefined
+    }
+
+    return new ChatGenerationChunk({
+        generationInfo:
+            usageMetadata == null
+                ? undefined
+                : {
+                      usage_metadata: usageMetadata
+                  },
+        message: new AIMessageChunk({
+            content,
+            tool_call_chunks: toolCallChunks,
+            usage_metadata: usageMetadata,
+            additional_kwargs:
+                thinking == null
+                    ? {}
+                    : {
+                          reasoning_content: thinking
+                      }
+        }),
+        text: content
+    })
 }

--- a/packages/adapter-ollama/src/utils.ts
+++ b/packages/adapter-ollama/src/utils.ts
@@ -61,7 +61,7 @@ export async function langchainMessageToOllamaMessage(
                 ? undefined
                 : await Promise.all(
                       rawMessage.content
-                          .filter((part) => isMessageContentImageUrl(part))
+                          .filter(isMessageContentImageUrl)
                           .map((part) =>
                               processOllamaImageContent(plugin, part)
                           )

--- a/packages/adapter-ollama/src/utils.ts
+++ b/packages/adapter-ollama/src/utils.ts
@@ -4,6 +4,7 @@ import {
     BaseMessage,
     MessageContentImageUrl,
     MessageType,
+    ToolMessage,
     UsageMetadata
 } from '@langchain/core/messages'
 import { StructuredTool } from '@langchain/core/tools'
@@ -48,6 +49,7 @@ export async function langchainMessageToOllamaMessage(
     supportImage: boolean
 ): Promise<OllamaMessage[]> {
     const result: OllamaMessage[] = []
+    const toolNames = new Map<string, string>()
 
     for (const rawMessage of messages) {
         if (rawMessage.additional_kwargs.images != null) {
@@ -95,40 +97,29 @@ export async function langchainMessageToOllamaMessage(
             }
 
             if (Array.isArray(toolCalls) && toolCalls.length > 0) {
-                msg.tool_calls = toolCalls.map((toolCall, index) => ({
-                    type: 'function',
-                    function: {
-                        index,
-                        name: toolCall.name,
-                        arguments: toolCall.args
+                msg.tool_calls = toolCalls.map((toolCall, index) => {
+                    if (toolCall.id != null) {
+                        toolNames.set(toolCall.id, toolCall.name)
                     }
-                }))
+
+                    return {
+                        type: 'function',
+                        function: {
+                            index,
+                            name: toolCall.name,
+                            arguments: toolCall.args
+                        }
+                    }
+                })
             }
         }
 
         if (msg.role === 'tool') {
-            msg.tool_name = rawMessage.name
+            const id = (rawMessage as ToolMessage).tool_call_id
+            msg.tool_name = rawMessage.name ?? toolNames.get(id)
         }
 
         result.push(msg)
-    }
-
-    for (let i = 0; i < result.length; i++) {
-        if (result[i].role !== 'assistant') continue
-
-        const calls = result[i].tool_calls
-        if (calls == null) continue
-
-        for (
-            let j = i + 1;
-            j < result.length && result[j].role === 'tool';
-            j++
-        ) {
-            const call = calls[j - i - 1]
-            if (result[j].tool_name == null && call != null) {
-                result[j].tool_name = call.function.name
-            }
-        }
     }
 
     return result

--- a/packages/adapter-ollama/src/utils.ts
+++ b/packages/adapter-ollama/src/utils.ts
@@ -1,16 +1,38 @@
 import {
+    AIMessage,
     BaseMessage,
     MessageContentImageUrl,
     MessageType
 } from '@langchain/core/messages'
-import { OllamaMessage } from './types'
+import { StructuredTool } from '@langchain/core/tools'
+import { OllamaMessage, OllamaRole, OllamaTool } from './types'
 import {
     getMessageContent,
     isMessageContentImageUrl
 } from 'koishi-plugin-chatluna/utils/string'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
-import { fetchImageUrl } from '@chatluna/v1-shared-adapter'
+import {
+    fetchImageUrl,
+    formatToolsToOpenAITools
+} from '@chatluna/v1-shared-adapter'
 import { logger } from '.'
+
+export function formatToolsToOllamaTools(
+    tools: StructuredTool[]
+): OllamaTool[] | undefined {
+    if (tools.length < 1) {
+        return undefined
+    }
+
+    return formatToolsToOpenAITools(tools, false).map((tool) => ({
+        type: 'function',
+        function: {
+            name: tool.function.name,
+            description: tool.function.description,
+            parameters: tool.function.parameters as Record<string, unknown>
+        }
+    }))
+}
 
 export async function langchainMessageToOllamaMessage(
     messages: BaseMessage[],
@@ -19,85 +41,86 @@ export async function langchainMessageToOllamaMessage(
 ): Promise<OllamaMessage[]> {
     const result: OllamaMessage[] = []
 
-    const mappedMessage = await Promise.all(
-        messages.map(async (rawMessage) => {
-            if (rawMessage.additional_kwargs.images != null) {
-                logger.warn(
-                    'Deprecated: `additional_kwargs.images` is no longer supported. Use `image_url` content parts instead.'
-                )
+    for (const rawMessage of messages) {
+        if (rawMessage.additional_kwargs.images != null) {
+            logger.warn(
+                'Deprecated: `additional_kwargs.images` is no longer supported. Use `image_url` content parts instead.'
+            )
+        }
+
+        const images: string[] | undefined = supportImage
+            ? typeof rawMessage.content === 'string'
+                ? undefined
+                : await Promise.all(
+                      rawMessage.content
+                          .filter((part) => isMessageContentImageUrl(part))
+                          .map((part) =>
+                              processOllamaImageContent(plugin, part)
+                          )
+                  )
+            : undefined
+
+        const msg: OllamaMessage = {
+            role: messageTypeToOllamaRole(rawMessage.getType()),
+            content: getMessageContent(rawMessage.content),
+            images: images?.filter((image): image is string => image != null)
+        }
+
+        if (msg.images == null) {
+            delete msg.images
+        } else if (msg.images.length === 0) {
+            delete msg.images
+        } else {
+            msg.images = msg.images.map((image) =>
+                image.replace(/^data:image\/\w+;base64,/, '')
+            )
+        }
+
+        if (rawMessage.getType() === 'ai') {
+            const toolCalls = (rawMessage as AIMessage).tool_calls
+            const thinking = rawMessage.additional_kwargs.reasoning_content as
+                | string
+                | undefined
+
+            if (thinking != null) {
+                msg.thinking = thinking
             }
 
-            const images: string[] | undefined = supportImage
-                ? typeof rawMessage.content === 'string'
-                    ? undefined
-                    : await Promise.all(
-                          rawMessage.content
-                              .filter((part) => isMessageContentImageUrl(part))
-                              .map((part) =>
-                                  processOllamaImageContent(plugin, part)
-                              )
-                      )
-                : undefined
-
-            const result = {
-                role: messageTypeToOllamaRole(rawMessage.getType()),
-                content: getMessageContent(rawMessage.content),
-                images: images?.filter(
-                    (image): image is string => image != null
-                )
+            if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+                msg.tool_calls = toolCalls.map((toolCall, index) => ({
+                    type: 'function',
+                    function: {
+                        index,
+                        name: toolCall.name,
+                        arguments: toolCall.args
+                    }
+                }))
             }
-
-            if (result.images == null) {
-                delete result.images
-            } else if (result.images.length === 0) {
-                delete result.images
-            } else {
-                result.images = result.images.map((image) =>
-                    // replace base64 headers
-                    image.replace(/^data:image\/\w+;base64,/, '')
-                )
-            }
-            return result
-        })
-    )
-
-    for (let i = 0; i < mappedMessage.length; i++) {
-        const message = {
-            ...mappedMessage[i]
         }
 
-        if (message.role !== 'system') {
-            result.push(message)
-            continue
+        if (msg.role === 'tool') {
+            msg.tool_name = rawMessage.name
         }
 
-        /*   if (removeSystemMessage) {
-            continue
-        } */
-
-        result.push({
-            role: 'user',
-            content: message.content
-        })
-
-        if (mappedMessage?.[i + 1]?.role === 'assistant') {
-            continue
-        }
-
-        if (mappedMessage?.[i + 1]?.role === 'user') {
-            result.push({
-                role: 'assistant',
-                content: 'Okay, what do I need to do?'
-            })
-        }
+        result.push(msg)
     }
 
-    if (result[result.length - 1].role === 'model') {
-        result.push({
-            role: 'user',
-            content:
-                'Continue what I said to you last message. Follow these instructions.'
-        })
+    for (let i = 0; i < result.length; i++) {
+        if (result[i].role !== 'assistant') continue
+
+        const calls = result[i].tool_calls
+        if (calls == null) continue
+
+        for (
+            let j = i + 1;
+            j < result.length && result[j].role === 'tool';
+            j++
+        ) {
+            const call = calls[j - i - 1]
+            if (result[j].tool_name == null && call != null) {
+                result[j].tool_name = call.function.name
+            }
+        }
     }
 
     return result
@@ -122,7 +145,7 @@ async function processOllamaImageContent(
     return url
 }
 
-export function messageTypeToOllamaRole(type: MessageType): string {
+export function messageTypeToOllamaRole(type: MessageType): OllamaRole {
     switch (type) {
         case 'system':
             return 'system'
@@ -131,7 +154,8 @@ export function messageTypeToOllamaRole(type: MessageType): string {
         case 'human':
             return 'user'
         case 'function':
-            return 'function'
+        case 'tool':
+            return 'tool'
         default:
             throw new Error(`Unknown message type: ${type}`)
     }


### PR DESCRIPTION
This pr modernizes the Ollama adapter capability handling.

Close #550

## New Features
- Discover Ollama model details and capabilities through api/show.
- Support Ollama tool calls, thinking variants, and usage metadata in streaming responses.
- Add typed Ollama request, response, model, tool, and usage shapes.

## Validation
- yarn lint-fix