### PR TITLE
fix(core): 修复 CJS 产物 langchain 引用解析失败

### DIFF
--- a/packages/core/src/services/message_transform.ts
+++ b/packages/core/src/services/message_transform.ts
@@ -9,7 +9,7 @@ import { MessageContentComplex } from '@langchain/core/messages'
 import {
     isMessageContentComplex,
     isMessageContentText
-} from '../utils/langchain'
+} from 'koishi-plugin-chatluna/utils/langchain'
 
 export class MessageTransformer {
     private _beforeTransformFunctions: BeforeTransformFunctionWithPriority[] =


### PR DESCRIPTION
### 修复内容

- 将 `message_transform.ts` 中的 `../utils/langchain` 相对导入改为 `koishi-plugin-chatluna/utils/langchain` 包名导入。
- 避免 CJS 产物生成 `require("../utils/langchain")`，该路径无法被 Node.js 解析到实际存在的 `langchain.cjs`。

### 原因

发布包中存在的是：

```text
lib/utils/langchain.cjs
lib/utils/langchain.mjs
lib/utils/langchain.d.ts
```

但 CommonJS 的无扩展名相对 `require()` 不会自动尝试 `.cjs`，因此 `require("../utils/langchain")` 会导致 Koishi 加载时报 `Cannot find module '../utils/langchain'`。

使用 `koishi-plugin-chatluna/utils/langchain` 后会走 package exports，在 CJS 下解析到对应的 `.cjs` 产物。

Fixes #955

### 验证

- `corepack yarn fast-build shared-prompt-renderer`
- `corepack yarn fast-build core`
- `node -e "require('./packages/core/lib/services/chat.cjs'); console.log('chat.cjs require ok')"`