### PR TITLE
fix(agent): improve shell environment handling

### DIFF
--- a/packages/extension-agent/src/computer/backends/local/sandbox.ts
+++ b/packages/extension-agent/src/computer/backends/local/sandbox.ts
@@ -132,7 +132,7 @@ export function wrapCommandWithSandbox(
                 '--proc',
                 '/proc',
                 shell,
-                ...getPosixShellArgs('true')
+                ...getPosixShellArgs(shell, 'true')
             ],
             { encoding: 'utf8' }
         )
@@ -173,7 +173,7 @@ export function wrapCommandWithSandbox(
         '--die-with-parent',
         ...(cfg.networkPolicy === 'block' ? ['--unshare-net'] : []),
         quote(shell),
-        ...getPosixShellArgs(command).map((arg) => quote(arg))
+        ...getPosixShellArgs(shell, command).map((arg) => quote(arg))
     ].filter((arg): arg is string => arg != null)
 
     return args.join(' ')

--- a/packages/extension-agent/src/computer/backends/local/sandbox.ts
+++ b/packages/extension-agent/src/computer/backends/local/sandbox.ts
@@ -4,6 +4,7 @@ import { spawnSync } from 'node:child_process'
 import path from 'path'
 import which from 'which'
 import { LocalBackendConfig } from '../../../types'
+import { getPosixShell, getPosixShellArgs } from './shell'
 
 const PROTECTED_NAMES = ['.git', '.chatluna', '.agents', '.codex', '.claude']
 const BWRAP_PROBE_CACHE = new Set<string>()
@@ -116,6 +117,7 @@ export function wrapCommandWithSandbox(
     }
 
     if (!BWRAP_PROBE_CACHE.has(bwrap)) {
+        const shell = getPosixShell()
         const result = spawnSync(
             bwrap,
             [
@@ -129,9 +131,8 @@ export function wrapCommandWithSandbox(
                 '/dev',
                 '--proc',
                 '/proc',
-                'sh',
-                '-lc',
-                'true'
+                shell,
+                ...getPosixShellArgs('true')
             ],
             { encoding: 'utf8' }
         )
@@ -149,6 +150,7 @@ export function wrapCommandWithSandbox(
         }
     }
 
+    const shell = getPosixShell()
     const args = [
         quote(bwrap),
         '--ro-bind / /',
@@ -170,8 +172,8 @@ export function wrapCommandWithSandbox(
         '--proc /proc',
         '--die-with-parent',
         ...(cfg.networkPolicy === 'block' ? ['--unshare-net'] : []),
-        'sh -lc',
-        quote(command)
+        quote(shell),
+        ...getPosixShellArgs(command).map((arg) => quote(arg))
     ].filter((arg): arg is string => arg != null)
 
     return args.join(' ')

--- a/packages/extension-agent/src/computer/backends/local/shell.ts
+++ b/packages/extension-agent/src/computer/backends/local/shell.ts
@@ -36,6 +36,38 @@ export function findPowerShell(): string | undefined {
     )
 }
 
+export function getPosixShell() {
+    return (
+        process.env['SHELL'] ||
+        which.sync('zsh', { nothrow: true }) ||
+        which.sync('bash', { nothrow: true }) ||
+        which.sync('sh', { nothrow: true }) ||
+        'sh'
+    )
+}
+
+export function getPosixShellArgs(command?: string) {
+    const shell = path.basename(getPosixShell()).replace(/\.exe$/i, '')
+
+    if (command == null) {
+        if (shell.includes('fish')) {
+            return ['--interactive']
+        }
+
+        return ['-i']
+    }
+
+    if (shell.includes('fish')) {
+        return ['--interactive', '--command', command]
+    }
+
+    if (shell.includes('bash') || shell.includes('zsh')) {
+        return ['-ic', command]
+    }
+
+    return ['-c', command]
+}
+
 function resolvePowerShellCommand(command: string): ResolvedShellCommand {
     return {
         file: findPowerShell() ?? 'powershell.exe',
@@ -64,9 +96,10 @@ export async function resolveInteractiveShellCommand(
     cfg: LocalBackendConfig
 ): Promise<ResolvedShellCommand> {
     if (process.platform !== 'win32') {
+        const shell = getPosixShell()
         return {
-            file: process.env['SHELL'] || 'bash',
-            args: ['-i']
+            file: shell,
+            args: getPosixShellArgs()
         }
     }
 
@@ -103,9 +136,10 @@ export async function resolveShellCommand(
     cfg: LocalBackendConfig
 ): Promise<ResolvedShellCommand> {
     if (process.platform !== 'win32') {
+        const shell = getPosixShell()
         return {
-            file: process.env['SHELL'] || 'bash',
-            args: ['-lc', command]
+            file: shell,
+            args: getPosixShellArgs(command)
         }
     }
 

--- a/packages/extension-agent/src/computer/backends/local/shell.ts
+++ b/packages/extension-agent/src/computer/backends/local/shell.ts
@@ -46,22 +46,22 @@ export function getPosixShell() {
     )
 }
 
-export function getPosixShellArgs(command?: string) {
-    const shell = path.basename(getPosixShell()).replace(/\.exe$/i, '')
+export function getPosixShellArgs(shell: string, command?: string) {
+    const name = path.basename(shell).replace(/\.exe$/i, '')
 
     if (command == null) {
-        if (shell.includes('fish')) {
+        if (name.includes('fish')) {
             return ['--interactive']
         }
 
         return ['-i']
     }
 
-    if (shell.includes('fish')) {
+    if (name.includes('fish')) {
         return ['--interactive', '--command', command]
     }
 
-    if (shell.includes('bash') || shell.includes('zsh')) {
+    if (name.includes('bash') || name.includes('zsh')) {
         return ['-ic', command]
     }
 
@@ -99,7 +99,7 @@ export async function resolveInteractiveShellCommand(
         const shell = getPosixShell()
         return {
             file: shell,
-            args: getPosixShellArgs()
+            args: getPosixShellArgs(shell)
         }
     }
 
@@ -139,7 +139,7 @@ export async function resolveShellCommand(
         const shell = getPosixShell()
         return {
             file: shell,
-            args: getPosixShellArgs(command)
+            args: getPosixShellArgs(shell, command)
         }
     }
 

--- a/packages/extension-agent/src/computer/backends/open_terminal.ts
+++ b/packages/extension-agent/src/computer/backends/open_terminal.ts
@@ -7,7 +7,7 @@ import { Readable } from 'node:stream'
 import { Context } from 'koishi'
 import type {} from '@koishijs/plugin-proxy-agent'
 import mimeTypes from 'mime-types'
-import { buildHashCommand, quoteShell, readHashCommandOutput } from './types'
+import { buildHashCommand, readHashCommandOutput } from './types'
 import { ComputerCapability, OpenTerminalBackendConfig } from '../../types'
 import {
     ComputerSessionApi,
@@ -679,6 +679,7 @@ exit
         if (this.options.userId) {
             headers['X-User-Id'] = this.options.userId
         }
+        headers['X-Session-Id'] = this.sessionId
 
         this._headers = headers
         return headers
@@ -745,6 +746,18 @@ async function openOpenTerminal(
         rows?: number
     }
 ) {
+    await ctx.http.post(
+        options.url('/files/cwd'),
+        { path: options.cwd },
+        {
+            proxyAgent: '',
+            headers: {
+                ...options.headers,
+                'content-type': 'application/json'
+            }
+        }
+    )
+
     const result = readOpenTerminalData<OpenTerminalTerminalData>(
         await ctx.http.post(options.url('/api/terminals'), undefined, {
             proxyAgent: '',
@@ -806,7 +819,6 @@ async function openOpenTerminal(
                         })
                     )
                 }
-                ws.send(Buffer.from(`cd ${quoteShell(options.cwd)}\n`, 'utf8'))
                 resolve()
             })
 

--- a/packages/extension-agent/src/computer/tools/publish_file.ts
+++ b/packages/extension-agent/src/computer/tools/publish_file.ts
@@ -38,7 +38,12 @@ Usage:
                 computer,
                 `Published files:\n${files
                     .map((file) => `- ${file.name}: ${file.url}`)
-                    .join('\n')}`
+                    .join('\n')}` +
+                    '\n\nImportant:\n' +
+                    '- If you are a sub-agent or delegated worker, pass these links to the main agent exactly as returned ' +
+                    'and remind the main agent to send the files to the user.\n' +
+                    '- If you are the main agent, use the links, file formats, and current environment ' +
+                    'to send or present the files to the user.'
             )
         } catch (err) {
             return this.formatResult(


### PR DESCRIPTION
This pr improves local and remote shell environment handling for agent computer backends.

Fixes #958

## Bug Fixes
- Resolve POSIX shell commands through the active user shell with interactive arguments.
- Use the resolved shell inside sandbox probes and wrapped sandbox commands.
- Pass OpenTerminal cwd and session headers directly instead of sending a shell cd command.

## Validation
- yarn lint-fix