### PR TITLE
fix(adapter): avoid usage metadata merge warnings

### DIFF
--- a/packages/adapter-claude/src/requester.ts
+++ b/packages/adapter-claude/src/requester.ts
@@ -16,7 +16,10 @@ import {
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
 import { deepAssign } from 'koishi-plugin-chatluna/utils/object'
-import { createUsageMetadata } from '@chatluna/v1-shared-adapter'
+import {
+    createUsageMetadata,
+    ReasoningState
+} from '@chatluna/v1-shared-adapter'
 import { Config, logger } from '.'
 import {
     ClaudeDeltaResponse,
@@ -140,12 +143,7 @@ export class ClaudeRequester extends ModelRequester<ClientConfig> {
         })
 
         const iterator = sseIterable(response)
-        const reasoningState = {
-            content: '',
-            startedAt: Date.now(),
-            endedAt: undefined as number | undefined,
-            blocks: [] as ClaudeReasoningBlockParam[]
-        }
+        const reasoningState = new ReasoningState<ClaudeReasoningBlockParam>()
 
         for await (const event of iterator) {
             if (event.event === 'ping') continue
@@ -207,7 +205,7 @@ export class ClaudeRequester extends ModelRequester<ClientConfig> {
             ) {
                 const content = parsedRawChunk.content_block.thinking ?? ''
 
-                reasoningState.content += content
+                reasoningState.append(content)
                 reasoningState.blocks[parsedRawChunk.index] = {
                     type: 'thinking',
                     thinking: content,
@@ -231,7 +229,7 @@ export class ClaudeRequester extends ModelRequester<ClientConfig> {
                 parsedRawChunk.type === 'content_block_delta' &&
                 parsedRawChunk.delta.type === 'thinking_delta'
             ) {
-                reasoningState.content += parsedRawChunk.delta.thinking
+                reasoningState.append(parsedRawChunk.delta.thinking)
 
                 const block = reasoningState.blocks[parsedRawChunk.index]
                 if (block?.type === 'thinking') {
@@ -263,9 +261,7 @@ export class ClaudeRequester extends ModelRequester<ClientConfig> {
                 (parsedChunk instanceof AIMessageChunk &&
                     (parsedChunk.tool_call_chunks?.length ?? 0) > 0)
 
-            if (reasoningState.endedAt == null && hasMessageChunk) {
-                reasoningState.endedAt = Date.now()
-            }
+            if (hasMessageChunk) reasoningState.end()
 
             if (!hasMessageChunk) {
                 continue
@@ -285,9 +281,7 @@ export class ClaudeRequester extends ModelRequester<ClientConfig> {
         )
 
         if (reasoningState.content.length > 0 || reasoningBlocks.length > 0) {
-            const reasoningTime =
-                (reasoningState.endedAt ?? Date.now()) -
-                reasoningState.startedAt
+            const reasoningTime = reasoningState.time
             const reasoningSignature =
                 reasoningBlocks.length === 1 &&
                 reasoningBlocks[0].type === 'thinking'
@@ -313,9 +307,7 @@ export class ClaudeRequester extends ModelRequester<ClientConfig> {
                 text: ''
             })
 
-            logger.debug(
-                `reasoning content: ${reasoningState.content}. Use time: ${(reasoningTime ?? 0) / 1000}s`
-            )
+            logger.debug(reasoningState.format, ...reasoningState.params)
         }
     }
 

--- a/packages/adapter-claude/src/requester.ts
+++ b/packages/adapter-claude/src/requester.ts
@@ -185,9 +185,6 @@ export class ClaudeRequester extends ModelRequester<ClientConfig> {
                 })
 
                 yield new ChatGenerationChunk({
-                    generationInfo: {
-                        usage_metadata: usageMetadata
-                    },
                     message: new AIMessageChunk({
                         content: '',
                         usage_metadata: usageMetadata

--- a/packages/adapter-claude/src/requester.ts
+++ b/packages/adapter-claude/src/requester.ts
@@ -100,7 +100,7 @@ export class ClaudeRequester extends ModelRequester<ClientConfig> {
         const betas = new Set<string>()
         const rawBetas = request.anthropicBeta ?? request['anthropic-beta']
 
-        if (typeof rawBetas === 'string' && rawBetas.length > 0) {
+        if (typeof rawBetas === 'string') {
             for (const beta of rawBetas.split(',')) {
                 const trimmed = beta.trim()
                 if (trimmed.length > 0) {
@@ -109,7 +109,7 @@ export class ClaudeRequester extends ModelRequester<ClientConfig> {
             }
         } else if (Array.isArray(rawBetas)) {
             for (const beta of rawBetas) {
-                const trimmed = typeof beta === 'string' ? beta.trim() : ''
+                const trimmed = beta.trim()
                 if (trimmed.length > 0) {
                     betas.add(trimmed)
                 }
@@ -199,54 +199,48 @@ export class ClaudeRequester extends ModelRequester<ClientConfig> {
                 continue
             }
 
-            if (
-                parsedRawChunk.type === 'content_block_start' &&
-                parsedRawChunk.content_block.type === 'thinking'
-            ) {
-                const content = parsedRawChunk.content_block.thinking ?? ''
+            if (parsedRawChunk.type === 'content_block_start') {
+                const block = parsedRawChunk.content_block
+                if (block.type === 'thinking') {
+                    const content = block.thinking ?? ''
 
-                reasoningState.append(content)
-                reasoningState.blocks[parsedRawChunk.index] = {
-                    type: 'thinking',
-                    thinking: content,
-                    signature: parsedRawChunk.content_block.signature ?? ''
+                    reasoningState.append(content)
+                    reasoningState.blocks[parsedRawChunk.index] = {
+                        type: 'thinking',
+                        thinking: content,
+                        signature: block.signature ?? ''
+                    }
+                    continue
                 }
-                continue
+
+                if (block.type === 'redacted_thinking') {
+                    reasoningState.blocks[parsedRawChunk.index] = {
+                        type: 'redacted_thinking',
+                        data: block.data ?? ''
+                    }
+                    continue
+                }
             }
 
-            if (
-                parsedRawChunk.type === 'content_block_start' &&
-                parsedRawChunk.content_block.type === 'redacted_thinking'
-            ) {
-                reasoningState.blocks[parsedRawChunk.index] = {
-                    type: 'redacted_thinking',
-                    data: parsedRawChunk.content_block.data ?? ''
-                }
-                continue
-            }
+            if (parsedRawChunk.type === 'content_block_delta') {
+                const delta = parsedRawChunk.delta
+                if (delta.type === 'thinking_delta') {
+                    reasoningState.append(delta.thinking)
 
-            if (
-                parsedRawChunk.type === 'content_block_delta' &&
-                parsedRawChunk.delta.type === 'thinking_delta'
-            ) {
-                reasoningState.append(parsedRawChunk.delta.thinking)
-
-                const block = reasoningState.blocks[parsedRawChunk.index]
-                if (block?.type === 'thinking') {
-                    block.thinking += parsedRawChunk.delta.thinking
+                    const block = reasoningState.blocks[parsedRawChunk.index]
+                    if (block?.type === 'thinking') {
+                        block.thinking += delta.thinking
+                    }
+                    continue
                 }
-                continue
-            }
 
-            if (
-                parsedRawChunk.type === 'content_block_delta' &&
-                parsedRawChunk.delta.type === 'signature_delta'
-            ) {
-                const block = reasoningState.blocks[parsedRawChunk.index]
-                if (block?.type === 'thinking') {
-                    block.signature = parsedRawChunk.delta.signature
+                if (delta.type === 'signature_delta') {
+                    const block = reasoningState.blocks[parsedRawChunk.index]
+                    if (block?.type === 'thinking') {
+                        block.signature = delta.signature
+                    }
+                    continue
                 }
-                continue
             }
 
             const parsedChunk = convertDeltaToMessageChunk(parsedRawChunk)

--- a/packages/adapter-claude/src/utils.ts
+++ b/packages/adapter-claude/src/utils.ts
@@ -37,16 +37,6 @@ type ClaudeInlineDataContent = MessageContentComplex & {
     }
 }
 
-function isClaudeInlineDataContent(
-    message: MessageContentComplex
-): message is ClaudeInlineDataContent {
-    return (
-        message != null &&
-        typeof message === 'object' &&
-        'inline_data' in message
-    )
-}
-
 export async function langchainMessageToClaudeMessage(
     messages: BaseMessage[],
     plugin: ChatLunaPlugin,
@@ -119,7 +109,7 @@ export async function langchainMessageToClaudeMessage(
 
                 if (Array.isArray(content)) {
                     blocks.push(...content)
-                } else if ((content?.length ?? 0) > 0) {
+                } else if (content) {
                     blocks.push({
                         type: 'text',
                         text: content
@@ -177,13 +167,7 @@ export async function langchainMessageToClaudeMessage(
             content: msg.content
         })
 
-        const next = mappedMessages[i + 1]?.role
-
-        if (next === 'assistant') {
-            continue
-        }
-
-        if (next === 'user') {
+        if (mappedMessages[i + 1]?.role === 'user') {
             result.push({
                 role: 'assistant',
                 content: 'Okay, what do I need to do?'
@@ -332,41 +316,42 @@ async function processMessageContent(
     plugin: ChatLunaPlugin,
     content: MessageContentComplex[]
 ) {
-    const mappedContent = await Promise.all(
-        content.map(async (message) => {
-            if (message.type === 'text') {
-                return {
-                    type: 'text',
-                    text: message.text as string
-                } as const
-            }
+    const mappedContent: (ClaudeInputContentBlockParam | null | undefined)[] =
+        await Promise.all(
+            content.map(async (message) => {
+                if (message.type === 'text') {
+                    return {
+                        type: 'text',
+                        text: message.text as string
+                    } as const
+                }
 
-            if (isMessageContentImageUrl(message)) {
-                return await processImageContent(plugin, message)
-            }
+                if (isMessageContentImageUrl(message)) {
+                    return await processImageContent(plugin, message)
+                }
 
-            if (isClaudeInlineDataContent(message)) {
-                return processInlineDataContent(message)
-            }
+                if (
+                    message != null &&
+                    typeof message === 'object' &&
+                    'inline_data' in message
+                ) {
+                    return processInlineDataContent(
+                        message as ClaudeInlineDataContent
+                    )
+                }
 
-            if (message.type === 'file_url') {
-                return await processFileContent(
-                    plugin,
-                    message as MessageContentFile
-                )
-            }
-        })
+                if (message.type === 'file_url') {
+                    return await processFileContent(
+                        plugin,
+                        message as MessageContentFile
+                    )
+                }
+            })
+        )
+
+    return mappedContent.filter(
+        (message): message is ClaudeInputContentBlockParam => message != null
     )
-
-    const result: ClaudeInputContentBlockParam[] = []
-
-    for (const message of mappedContent) {
-        if (message != null) {
-            result.push(message)
-        }
-    }
-
-    return result
 }
 
 export function messageTypeToClaudeRole(
@@ -389,10 +374,6 @@ export function messageTypeToClaudeRole(
 export function formatToolsToClaudeTools(
     tools: StructuredTool[]
 ): ClaudeTool[] {
-    if (tools.length < 1) {
-        return []
-    }
-
     return tools.map(formatToolToClaudeTool)
 }
 
@@ -413,80 +394,74 @@ export function formatToolToClaudeTool(tool: StructuredTool): ClaudeTool {
 }
 
 export function convertDeltaToMessageChunk(delta: ClaudeDeltaResponse) {
-    if (delta.type === 'message_start') {
-        return new AIMessageChunk({
-            content: '',
-            id: delta.message.id
-        })
-    }
-
-    if (delta.type === 'content_block_start') {
-        if (delta.content_block.type === 'tool_use') {
+    switch (delta.type) {
+        case 'message_start':
             return new AIMessageChunk({
                 content: '',
-                tool_call_chunks: [
-                    {
-                        id: delta.content_block.id,
-                        index: delta.index,
-                        name: delta.content_block.name,
-                        args: ''
-                    }
-                ],
-                additional_kwargs: {}
+                id: delta.message.id
             })
-        }
-
-        if (delta.content_block.type === 'text') {
-            const content = delta.content_block.text
-            if (content !== undefined) {
+        case 'content_block_start': {
+            const block = delta.content_block
+            if (block.type === 'tool_use') {
                 return new AIMessageChunk({
-                    content,
+                    content: '',
+                    tool_call_chunks: [
+                        {
+                            id: block.id,
+                            index: delta.index,
+                            name: block.name,
+                            args: ''
+                        }
+                    ],
                     additional_kwargs: {}
                 })
             }
+
+            if (block.type === 'text' && block.text !== undefined) {
+                return new AIMessageChunk({
+                    content: block.text,
+                    additional_kwargs: {}
+                })
+            }
+
+            return
         }
-
-        return
-    }
-
-    if (delta.type !== 'content_block_delta') {
-        return
-    }
-
-    if (delta.delta.type === 'text_delta') {
-        return new AIMessageChunk({
-            content: delta.delta.text
-        })
-    }
-
-    if (delta.delta.type === 'input_json_delta') {
-        return new AIMessageChunk({
-            content: '',
-            tool_call_chunks: [
-                {
-                    index: delta.index,
-                    args: delta.delta.partial_json
-                }
-            ],
-            additional_kwargs: {}
-        })
-    }
-
-    if (delta.delta.type === 'thinking_delta') {
-        return new AIMessageChunk({
-            content: '',
-            additional_kwargs: {
-                reasoning_content: delta.delta.thinking
+        case 'content_block_delta': {
+            const chunk = delta.delta
+            switch (chunk.type) {
+                case 'text_delta':
+                    return new AIMessageChunk({
+                        content: chunk.text
+                    })
+                case 'input_json_delta':
+                    return new AIMessageChunk({
+                        content: '',
+                        tool_call_chunks: [
+                            {
+                                index: delta.index,
+                                args: chunk.partial_json
+                            }
+                        ],
+                        additional_kwargs: {}
+                    })
+                case 'thinking_delta':
+                    return new AIMessageChunk({
+                        content: '',
+                        additional_kwargs: {
+                            reasoning_content: chunk.thinking
+                        }
+                    })
+                case 'signature_delta':
+                    return new AIMessageChunk({
+                        content: '',
+                        additional_kwargs: {
+                            reasoning_signature: chunk.signature
+                        }
+                    })
+                default:
             }
-        })
-    }
-
-    if (delta.delta.type === 'signature_delta') {
-        return new AIMessageChunk({
-            content: '',
-            additional_kwargs: {
-                reasoning_signature: delta.delta.signature
-            }
-        })
+            break
+        }
+        default:
     }
 }

--- a/packages/adapter-dify/src/requester.ts
+++ b/packages/adapter-dify/src/requester.ts
@@ -209,7 +209,7 @@ export class DifyRequester extends ModelRequester<DifyClientConfig> {
             const content = data.answer
 
             if (content != null) {
-                const messageChunk = new AIMessageChunk(content)
+                const messageChunk = new AIMessageChunk({ content })
                 const generationChunk = new ChatGenerationChunk({
                     message: messageChunk,
                     text: content
@@ -314,7 +314,7 @@ export class DifyRequester extends ModelRequester<DifyClientConfig> {
             const content = data.answer
 
             if (content != null) {
-                const messageChunk = new AIMessageChunk(content)
+                const messageChunk = new AIMessageChunk({ content })
                 const generationChunk = new ChatGenerationChunk({
                     message: messageChunk,
                     text: content

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -53,7 +53,10 @@ import type {} from 'koishi-plugin-chatluna-storage-service'
 import { ToolCallChunk } from '@langchain/core/messages/tool'
 import { RunnableConfig } from '@langchain/core/runnables'
 import { trackLogToLocal } from 'koishi-plugin-chatluna/utils/logger'
-import { createUsageMetadata } from '@chatluna/v1-shared-adapter'
+import {
+    createUsageMetadata,
+    ReasoningState
+} from '@chatluna/v1-shared-adapter'
 
 export class GeminiRequester
     extends ModelRequester<ClientConfig, Config>
@@ -83,6 +86,7 @@ export class GeminiRequester
             const generation = await this.completion(params)
 
             yield new ChatGenerationChunk({
+                generationInfo: generation.generationInfo,
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 message: generation.message as any as BaseMessageChunk,
                 text: generation.text
@@ -321,11 +325,18 @@ export class GeminiRequester
 
         let result: ChatGenerationChunk
 
-        let reasoningContent = ''
+        const reasoningState = new ReasoningState()
         for await (const chunk of this._processChunks(iterable)) {
             if (chunk.type === 'reasoning') {
-                reasoningContent = chunk.content
+                reasoningState.set(chunk.content)
             } else {
+                if (
+                    reasoningState.endedAt == null &&
+                    reasoningState.content.length > 0
+                ) {
+                    reasoningState.end()
+                }
+
                 result =
                     result != null
                         ? result.concat(chunk.generation)
@@ -341,7 +352,7 @@ export class GeminiRequester
         }
 
         const finalChunk = this._handleFinalContent(
-            reasoningContent,
+            reasoningState,
             groundingContent.value
         )
 
@@ -362,17 +373,24 @@ export class GeminiRequester
             currentGroundingIndex
         )
 
-        let reasoningContent = ''
+        const reasoningState = new ReasoningState()
         for await (const chunk of this._processChunks(iterable)) {
             if (chunk.type === 'reasoning') {
-                reasoningContent = chunk.content
+                reasoningState.set(chunk.content)
             } else {
+                if (
+                    reasoningState.endedAt == null &&
+                    reasoningState.content.length > 0
+                ) {
+                    reasoningState.end()
+                }
+
                 yield chunk.generation
             }
         }
 
         const finalContent = this._handleFinalContent(
-            reasoningContent,
+            reasoningState,
             groundingContent.value
         )
 
@@ -677,11 +695,11 @@ export class GeminiRequester
     }
 
     private _handleFinalContent(
-        reasoningContent: string,
+        reasoningState: ReasoningState,
         groundingContent: string
     ) {
-        if (reasoningContent.length > 0) {
-            logger.debug(`reasoning content: ${reasoningContent}`)
+        if (reasoningState.content.length > 0) {
+            logger.debug(reasoningState.format, ...reasoningState.params)
         }
 
         if (groundingContent.length > 0) {

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -83,7 +83,6 @@ export class GeminiRequester
             const generation = await this.completion(params)
 
             yield new ChatGenerationChunk({
-                generationInfo: generation.generationInfo,
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 message: generation.message as any as BaseMessageChunk,
                 text: generation.text
@@ -117,7 +116,8 @@ export class GeminiRequester
                 await trackLogToLocal(
                     'Request',
                     JSON.stringify(chatGenerationParams),
-                    logger
+                    logger,
+                    'warn'
                 )
             }
             if (e instanceof ChatLunaError) {
@@ -164,7 +164,8 @@ export class GeminiRequester
                 await trackLogToLocal(
                     'Request',
                     JSON.stringify(chatGenerationParams),
-                    logger
+                    logger,
+                    'warn'
                 )
             }
             if (e instanceof ChatLunaError) {
@@ -524,9 +525,6 @@ export class GeminiRequester
                 yield {
                     type: 'generation',
                     generation: new ChatGenerationChunk({
-                        generationInfo: {
-                            usage_metadata: usageMetadata
-                        },
                         message: new AIMessageChunk({
                             content: '',
                             usage_metadata: usageMetadata

--- a/packages/adapter-ollama/src/utils.ts
+++ b/packages/adapter-ollama/src/utils.ts
@@ -202,12 +202,6 @@ export function ollamaChunkToGeneration(chunk: OllamaDeltaResponse) {
     }
 
     return new ChatGenerationChunk({
-        generationInfo:
-            usageMetadata == null
-                ? undefined
-                : {
-                      usage_metadata: usageMetadata
-                  },
         message: new AIMessageChunk({
             content,
             tool_call_chunks: toolCallChunks,

--- a/packages/adapter-openai-like/src/requester.ts
+++ b/packages/adapter-openai-like/src/requester.ts
@@ -102,7 +102,6 @@ export class OpenAIRequester
         const generation = await this.completion(params)
 
         yield new ChatGenerationChunk({
-            generationInfo: generation.generationInfo,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             message: generation.message as any as BaseMessageChunk,
             text: generation.text

--- a/packages/core/src/chains/chain.ts
+++ b/packages/core/src/chains/chain.ts
@@ -288,7 +288,7 @@ export class ChatChain {
 
             if (shouldLogTime) {
                 logger.debug(
-                    `middleware %c executed in %s`,
+                    `[Middleware] %c completed in %c`,
                     middleware.name,
                     formatDuration(executionTime)
                 )

--- a/packages/core/src/llm-core/chain/prompt.ts
+++ b/packages/core/src/llm-core/chain/prompt.ts
@@ -212,12 +212,23 @@ export class ChatLunaChatPrompt
 
         // Debug logging
         if (logger?.level === Logger.DEBUG) {
-            logger?.debug(
-                `[Agent ${runtime.configurable?.subagentContext?.agentName || 'main'}] ` +
-                    (runtime.usedTokens > runtime.sendTokenLimit
-                        ? `Used tokens: ${runtime.usedTokens} exceed limit: ${runtime.sendTokenLimit}`
-                        : `Used tokens: ${runtime.usedTokens}, token limit: ${runtime.sendTokenLimit}`)
-            )
+            const name =
+                runtime.configurable?.subagentContext?.agentName || 'main'
+            if (runtime.usedTokens > runtime.sendTokenLimit) {
+                logger?.debug(
+                    '[Agent %s] Used tokens: %c exceed limit: %c',
+                    name,
+                    runtime.usedTokens,
+                    runtime.sendTokenLimit
+                )
+            } else {
+                logger?.debug(
+                    '[Agent %s] Used tokens: %c, token limit: %c',
+                    name,
+                    runtime.usedTokens,
+                    runtime.sendTokenLimit
+                )
+            }
 
             const mapMessages = runtime.result.map((msg) => {
                 const original = msg?.toDict?.()

--- a/packages/core/src/llm-core/platform/metrics.ts
+++ b/packages/core/src/llm-core/platform/metrics.ts
@@ -26,13 +26,6 @@ export function attachInvocationMetrics(
         ...chunk.generationInfo,
         [chatlunaMetricsKey]: metrics
     }
-    const message = chunk.message as AIMessageChunk | undefined
-    if (message != null) {
-        message.response_metadata = {
-            ...message.response_metadata,
-            [chatlunaMetricsKey]: metrics
-        }
-    }
 }
 
 export function readInvocationMetrics(
@@ -57,7 +50,9 @@ export function createModelUsageTiming(
 ): ModelUsageTiming {
     const totalMs = Math.max(Date.now() - start, MIN_LATENCY_MS)
     const outputTokens =
-        usage?.output_tokens + (usage?.output_token_details?.reasoning ?? 0)
+        usage == null
+            ? undefined
+            : usage.output_tokens + (usage.output_token_details?.reasoning ?? 0)
     if (firstAt == null) {
         return {
             totalMs,

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -428,7 +428,7 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
             return
         }
 
-        logger.debug(formatUsageMetadata(latestTokenUsage))
+        logger.debug(...formatUsageMetadata(latestTokenUsage))
     }
 
     private async _reportStreamUsage(
@@ -554,7 +554,7 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                 total_tokens: completionTokens + promptTokens
             }
         } else if (options.stream !== true) {
-            logger.debug(formatUsageMetadata(usageMetadata))
+            logger.debug(...formatUsageMetadata(usageMetadata))
         }
 
         if (response.message.getType() === 'ai') {
@@ -1353,31 +1353,36 @@ function usageContextFromOptions(options: ChatLunaModelCallOptions) {
         : undefined
 }
 
-function formatUsageMetadata(usage: UsageMetadata) {
-    const result = [
-        `Token usage from API: input=${usage.input_tokens}`,
-        `output=${usage.output_tokens}`,
-        `total=${usage.total_tokens}`
+function formatUsageMetadata(usage: UsageMetadata): [string, ...unknown[]] {
+    const result = ['Token usage from API: input=%c', 'output=%c', 'total=%c']
+    const params: unknown[] = [
+        usage.input_tokens,
+        usage.output_tokens,
+        usage.total_tokens
     ]
-    const input = [
-        ...(usage.input_token_details?.audio != null
-            ? [`audio=${usage.input_token_details.audio}`]
-            : []),
-        ...(usage.input_token_details?.cache_read != null
-            ? [`cache_read=${usage.input_token_details.cache_read}`]
-            : []),
-        ...(usage.input_token_details?.cache_creation != null
-            ? [`cache_creation=${usage.input_token_details.cache_creation}`]
-            : [])
-    ]
-    const output = [
-        ...(usage.output_token_details?.audio != null
-            ? [`audio=${usage.output_token_details.audio}`]
-            : []),
-        ...(usage.output_token_details?.reasoning != null
-            ? [`reasoning=${usage.output_token_details.reasoning}`]
-            : [])
-    ]
+    const input: string[] = []
+    const output: string[] = []
+
+    if (usage.input_token_details?.audio != null) {
+        input.push('audio=%c')
+        params.push(usage.input_token_details.audio)
+    }
+    if (usage.input_token_details?.cache_read != null) {
+        input.push('cache_read=%c')
+        params.push(usage.input_token_details.cache_read)
+    }
+    if (usage.input_token_details?.cache_creation != null) {
+        input.push('cache_creation=%c')
+        params.push(usage.input_token_details.cache_creation)
+    }
+    if (usage.output_token_details?.audio != null) {
+        output.push('audio=%c')
+        params.push(usage.output_token_details.audio)
+    }
+    if (usage.output_token_details?.reasoning != null) {
+        output.push('reasoning=%c')
+        params.push(usage.output_token_details.reasoning)
+    }
 
     if (input.length > 0) {
         result.push(`| input(${input.join(', ')})`)
@@ -1387,5 +1392,5 @@ function formatUsageMetadata(usage: UsageMetadata) {
         result.push(`| output(${output.join(', ')})`)
     }
 
-    return result.join(' ')
+    return [result.join(' '), ...params]
 }

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -562,11 +562,6 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                 usageMetadata
         }
 
-        response.generationInfo = {
-            ...response.generationInfo,
-            usage_metadata: usageMetadata
-        }
-
         await this._reportUsage(
             usageMetadata,
             estimated,
@@ -574,9 +569,14 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
             metrics.timing
         )
 
+        const llmOutput = {
+            ...response.generationInfo,
+            usage_metadata: usageMetadata
+        }
+
         return {
             generations: [response],
-            llmOutput: response.generationInfo
+            llmOutput
         }
     }
 

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -1367,6 +1367,10 @@ function formatUsageMetadata(usage: UsageMetadata): [string, ...unknown[]] {
         input.push('audio=%c')
         params.push(usage.input_token_details.audio)
     }
+    if (usage.input_token_details?.image != null) {
+        input.push('image=%c')
+        params.push(usage.input_token_details.image)
+    }
     if (usage.input_token_details?.cache_read != null) {
         input.push('cache_read=%c')
         params.push(usage.input_token_details.cache_read)
@@ -1378,6 +1382,10 @@ function formatUsageMetadata(usage: UsageMetadata): [string, ...unknown[]] {
     if (usage.output_token_details?.audio != null) {
         output.push('audio=%c')
         params.push(usage.output_token_details.audio)
+    }
+    if (usage.output_token_details?.image != null) {
+        output.push('image=%c')
+        params.push(usage.output_token_details.image)
     }
     if (usage.output_token_details?.reasoning != null) {
         output.push('reasoning=%c')

--- a/packages/core/src/middlewares/chat/message_delay.ts
+++ b/packages/core/src/middlewares/chat/message_delay.ts
@@ -106,7 +106,10 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 }
                 queue.turns.push(turn)
                 logger.debug(
-                    `Creating new turn for ${conversationId}, messageId: ${messageId}, user: ${userName}, queue: ${queue.turns.length}`
+                    'Creating new turn for %c, user: %c, queue: %c',
+                    conversationId,
+                    userName,
+                    queue.turns.length
                 )
             }
 

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -53,7 +53,9 @@ export async function trackLogToLocal(
         await fs.promises.writeFile(logFile, output)
 
         logger[level](
-            `[${tag}] A local log file has been created at ${logFile}`
+            '[%s] A local log file has been created at %s',
+            tag,
+            logFile
         )
 
         // Clean up old log files (older than 7 days)

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -33,7 +33,8 @@ export function clearLogger() {
 export async function trackLogToLocal(
     tag: string,
     output: string,
-    logger: Logger
+    logger: Logger,
+    level: 'debug' | 'warn' = 'debug'
 ) {
     const currentTime = new Date()
         .toISOString()
@@ -50,7 +51,10 @@ export async function trackLogToLocal(
 
     const writeAndCleanup = async () => {
         await fs.promises.writeFile(logFile, output)
-        logger.info(`[${tag}] A local log file has been created at ${logFile}`)
+
+        logger[level](
+            `[${tag}] A local log file has been created at ${logFile}`
+        )
 
         // Clean up old log files (older than 7 days)
         const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -118,6 +118,12 @@ export async function buildChatCompletionParams(
 ) {
     const parsedModel = parseOpenAIModelNameWithReasoningEffort(params.model)
     const normalizedModel = parsedModel.model
+    const lowerModel = normalizedModel.toLowerCase()
+    const isOpenAIReasoningModel =
+        lowerModel.startsWith('o1') ||
+        lowerModel.startsWith('o3') ||
+        lowerModel.startsWith('o4') ||
+        lowerModel.startsWith('gpt-5')
 
     const base = {
         model: normalizedModel,
@@ -138,13 +144,6 @@ export async function buildChatCompletionParams(
         max_tokens: normalizedModel.includes('vision')
             ? undefined
             : params.maxTokens,
-        temperature: params.temperature === 0 ? undefined : params.temperature,
-        presence_penalty:
-            params.presencePenalty === 0 ? undefined : params.presencePenalty,
-        frequency_penalty:
-            params.frequencyPenalty === 0 ? undefined : params.frequencyPenalty,
-        n: params.n,
-        top_p: params.topP,
         prompt_cache_key: params.id,
         prompt_cache_retention: undefined,
         prediction: undefined,
@@ -159,20 +158,23 @@ export async function buildChatCompletionParams(
         }
     }
 
-    const lowerModel = normalizedModel.toLowerCase()
-    const isOpenAIReasoningModel =
-        lowerModel.startsWith('o1') ||
-        lowerModel.startsWith('o3') ||
-        lowerModel.startsWith('o4') ||
-        lowerModel.startsWith('gpt-5')
-
-    if (isOpenAIReasoningModel) {
-        delete base.temperature
-        delete base.presence_penalty
-        delete base.frequency_penalty
-        delete base.n
-        delete base.top_p
+    if (!isOpenAIReasoningModel) {
+        Object.assign(base, {
+            temperature:
+                params.temperature === 0 ? undefined : params.temperature,
+            presence_penalty:
+                params.presencePenalty === 0
+                    ? undefined
+                    : params.presencePenalty,
+            frequency_penalty:
+                params.frequencyPenalty === 0
+                    ? undefined
+                    : params.frequencyPenalty,
+            n: params.n,
+            top_p: params.topP
+        })
     }
+
     return deepAssign({}, base, params.overrideRequestParams ?? {})
 }
 
@@ -287,11 +289,8 @@ export async function* processStreamResponse<
 
                 reasoningState.end()
 
-                defaultRole = (
-                    (choice.message.role?.length ?? 0) > 0
-                        ? choice.message.role
-                        : defaultRole
-                ) as ChatCompletionResponseMessageRoleEnum
+                defaultRole = (choice.message.role ||
+                    defaultRole) as ChatCompletionResponseMessageRoleEnum
 
                 yield new ChatGenerationChunk({
                     message: messageChunk,
@@ -337,16 +336,10 @@ export async function* processStreamResponse<
                     (messageChunk.tool_call_chunks?.length ?? 0) > 0) ||
                 messageChunk.additional_kwargs.function_call != null
 
-            if (!hasMessageChunk) {
-                defaultRole = (
-                    (delta.role?.length ?? 0) > 0 ? delta.role : defaultRole
-                ) as ChatCompletionResponseMessageRoleEnum
-                continue
-            }
+            defaultRole = (delta.role ||
+                defaultRole) as ChatCompletionResponseMessageRoleEnum
 
-            defaultRole = (
-                (delta.role?.length ?? 0) > 0 ? delta.role : defaultRole
-            ) as ChatCompletionResponseMessageRoleEnum
+            if (!hasMessageChunk) continue
 
             yield new ChatGenerationChunk({
                 message: messageChunk,
@@ -937,7 +930,6 @@ export async function createEmbeddings<
     embeddingUrl: string = 'embeddings'
 ): Promise<EmbeddingsResult> {
     const { modelRequester } = requestContext
-    let data: CreateEmbeddingResponse | string
 
     try {
         const response = await modelRequester.post(embeddingUrl, {
@@ -945,8 +937,7 @@ export async function createEmbeddings<
             model: params.model
         })
 
-        data = await response.text()
-        data = JSON.parse(data as string) as CreateEmbeddingResponse
+        const data = (await response.json()) as CreateEmbeddingResponse
 
         if (data.data && data.data.length > 0) {
             return data.usage
@@ -1060,49 +1051,34 @@ export async function getModels<
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const rawModels = data.data.map((model: any) => model.id) as string[]
 
-        const expanded: string[] = []
         const seen = new Set<string>()
 
-        const isOpenAIReasoningModel = (model: string) => {
+        for (const model of rawModels) {
+            seen.add(model)
+
             const lower = model.toLowerCase()
-            return (
+            const isReasoning =
                 lower.startsWith('gpt-5') ||
                 lower.startsWith('o1') ||
                 lower.startsWith('o3') ||
                 lower.startsWith('o4')
-            )
-        }
+            if (!isReasoning) continue
 
-        const hasThinkingTag = (model: string) => {
-            const lower = model.toLowerCase()
-            return (
+            const hasThinking =
                 lower.includes('thinking') ||
                 ['minimal', 'low', 'medium', 'high', 'xhigh'].some((level) =>
                     lower.includes(level)
                 )
-            )
-        }
-
-        const push = (model: string) => {
-            if (seen.has(model)) return
-            seen.add(model)
-            expanded.push(model)
-        }
-
-        for (const model of rawModels) {
-            push(model)
-
-            if (!isOpenAIReasoningModel(model)) continue
-            if (hasThinkingTag(model)) continue
+            if (hasThinking) continue
 
             // OpenAI-style "thinking" via model suffixes. These are virtual
             // variants that map to request params (e.g. reasoning_effort).
             for (const variant of expandReasoningEffortModelVariants(model)) {
-                push(variant)
+                seen.add(variant)
             }
         }
 
-        return expanded
+        return Array.from(seen)
     } catch (e) {
         if (e instanceof ChatLunaError) {
             throw e

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -37,6 +37,7 @@ import {
     langchainMessageToResponseInput,
     openAIResponseUsageToUsageMetadata,
     openAIUsageToUsageMetadata,
+    ReasoningState,
     responseOutputImageItems,
     responseOutputText,
     responseOutputToolCalls
@@ -234,12 +235,7 @@ export async function* processStreamResponse<
 ) {
     let defaultRole: ChatCompletionResponseMessageRoleEnum = 'assistant'
     let errorCount = 0
-    const reasoningState = {
-        content: '',
-        seen: false,
-        startedAt: Date.now(),
-        endedAt: undefined as number | undefined
-    }
+    const reasoningState = new ReasoningState()
 
     for await (const event of iterator) {
         const chunk = event.data
@@ -289,9 +285,7 @@ export async function* processStreamResponse<
 
                 reasoningState.content = ''
 
-                if (reasoningState.endedAt == null) {
-                    reasoningState.endedAt = Date.now()
-                }
+                reasoningState.end()
 
                 defaultRole = (
                     (choice.message.role?.length ?? 0) > 0
@@ -311,9 +305,7 @@ export async function* processStreamResponse<
                 (delta.tool_calls?.length ?? 0) > 0 ||
                 delta.function_call != null
 
-            if (reasoningState.endedAt == null && hasResult) {
-                reasoningState.endedAt = Date.now()
-            }
+            if (hasResult) reasoningState.end()
 
             // DeepSeek-V4 thinking mode may emit reasoning_content === "".
             // Track field presence so we can echo it back verbatim later.
@@ -324,7 +316,7 @@ export async function* processStreamResponse<
                     !hasResult &&
                     typeof delta.reasoning_content === 'string'
                 ) {
-                    reasoningState.content += delta.reasoning_content
+                    reasoningState.append(delta.reasoning_content)
                 }
             }
 
@@ -387,8 +379,7 @@ export async function* processStreamResponse<
     }
 
     if (reasoningState.seen || reasoningState.content.length > 0) {
-        const reasoningTime =
-            (reasoningState.endedAt ?? Date.now()) - reasoningState.startedAt
+        const reasoningTime = reasoningState.time
 
         yield new ChatGenerationChunk({
             message: new AIMessageChunk({
@@ -406,7 +397,8 @@ export async function* processStreamResponse<
         })
 
         requestContext.modelRequester.logger.debug(
-            `Reasoning Content: ${reasoningState.content}. Thought for: ${(reasoningTime ?? 0) / 1000}s`
+            reasoningState.format,
+            ...reasoningState.params
         )
     }
 }

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -264,9 +264,6 @@ export async function* processStreamResponse<
             if (data.usage) {
                 const usageMetadata = openAIUsageToUsageMetadata(data.usage)
                 yield new ChatGenerationChunk({
-                    generationInfo: {
-                        usage_metadata: usageMetadata
-                    },
                     message: new AIMessageChunk({
                         content: '',
                         usage_metadata: usageMetadata
@@ -474,13 +471,7 @@ export async function processResponse<
 
         return new ChatGenerationChunk({
             message: messageChunk,
-            text: getMessageContent(messageChunk.content),
-            generationInfo:
-                usageMetadata == null
-                    ? undefined
-                    : {
-                          usage_metadata: usageMetadata
-                      }
+            text: getMessageContent(messageChunk.content)
         })
     } catch (e) {
         if (e instanceof ChatLunaError) {
@@ -551,12 +542,6 @@ export async function responseToChatGeneration(
     })
 
     return new ChatGenerationChunk({
-        generationInfo:
-            usageMetadata == null
-                ? undefined
-                : {
-                      usage_metadata: usageMetadata
-                  },
         message,
         text
     })
@@ -639,7 +624,7 @@ export async function* processResponseApiStream<
 
             if (data.type === 'response.output_text.delta' && data.delta) {
                 yield new ChatGenerationChunk({
-                    message: new AIMessageChunk(data.delta),
+                    message: new AIMessageChunk({ content: data.delta }),
                     text: data.delta
                 })
                 continue
@@ -726,9 +711,6 @@ export async function* processResponseApiStream<
 
                 if (usageMetadata) {
                     yield new ChatGenerationChunk({
-                        generationInfo: {
-                            usage_metadata: usageMetadata
-                        },
                         message: new AIMessageChunk({
                             content: '',
                             usage_metadata: usageMetadata
@@ -802,7 +784,8 @@ export async function* completionStream<
             await trackLogToLocal(
                 'Request',
                 JSON.stringify(chatCompletionParams),
-                requestContext.ctx.logger('')
+                requestContext.ctx.logger(''),
+                'warn'
             )
         }
         if (e instanceof ChatLunaError) {
@@ -853,7 +836,8 @@ export async function completion<
             await trackLogToLocal(
                 'Request',
                 JSON.stringify(chatCompletionParams),
-                requestContext.ctx.logger('')
+                requestContext.ctx.logger(''),
+                'warn'
             )
         }
         if (e instanceof ChatLunaError) {
@@ -898,7 +882,8 @@ export async function* responseApiCompletionStream<
             await trackLogToLocal(
                 'Request',
                 JSON.stringify(request),
-                requestContext.ctx.logger('')
+                requestContext.ctx.logger(''),
+                'warn'
             )
         }
         if (e instanceof ChatLunaError) throw e
@@ -942,7 +927,8 @@ export async function responseApiCompletion<
             await trackLogToLocal(
                 'Request',
                 JSON.stringify(request),
-                requestContext.ctx.logger('')
+                requestContext.ctx.logger(''),
+                'warn'
             )
         }
         if (e instanceof ChatLunaError) throw e

--- a/packages/shared-adapter/src/types.ts
+++ b/packages/shared-adapter/src/types.ts
@@ -302,35 +302,10 @@ export interface ChatCompletionRequestMessageToolCall {
     }
 }
 
-/**
- *
- * @export
- * @interface CreateEmbeddingResponse
- */
 export interface CreateEmbeddingResponse {
-    /**
-     *
-     * @type {string}
-     * @memberof CreateEmbeddingResponse
-     */
     object: string
-    /**
-     *
-     * @type {string}
-     * @memberof CreateEmbeddingResponse
-     */
     model: string
-    /**
-     *
-     * @type {Array<CreateEmbeddingResponseDataInner>}
-     * @memberof CreateEmbeddingResponse
-     */
     data: CreateEmbeddingResponseDataInner[]
-    /**
-     *
-     * @type {CreateEmbeddingResponseUsage}
-     * @memberof CreateEmbeddingResponse
-     */
     usage: CreateEmbeddingResponseUsage
 }
 
@@ -339,48 +314,14 @@ export interface CreateEmbeddingRequest {
     input: string | string[]
 }
 
-/**
- *
- * @export
- * @interface CreateEmbeddingResponseDataInner
- */
 export interface CreateEmbeddingResponseDataInner {
-    /**
-     *
-     * @type {number}
-     * @memberof CreateEmbeddingResponseDataInner
-     */
     index: number
-    /**
-     *
-     * @type {string}
-     * @memberof CreateEmbeddingResponseDataInner
-     */
     object: string
-    /**
-     *
-     * @type {Array<number>}
-     * @memberof CreateEmbeddingResponseDataInner
-     */
     embedding: number[]
 }
-/**
- *
- * @export
- * @interface CreateEmbeddingResponseUsage
- */
+
 export interface CreateEmbeddingResponseUsage {
-    /**
-     *
-     * @type {number}
-     * @memberof CreateEmbeddingResponseUsage
-     */
     prompt_tokens: number
-    /**
-     *
-     * @type {number}
-     * @memberof CreateEmbeddingResponseUsage
-     */
     total_tokens: number
 }
 

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -40,7 +40,6 @@ import {
     isChatLunaUserMessage,
     isMessageContentAudio
 } from 'koishi-plugin-chatluna/utils/langchain'
-import { ToolCallChunk } from '@langchain/core/messages/tool'
 import { isZodSchemaV3 } from '@langchain/core/utils/types'
 import {
     DEFAULT_AUDIO_MAX_BASE64_BYTES,
@@ -97,30 +96,29 @@ export function createUsageMetadata(data: {
     cacheCreationTokens?: number
     reasoningTokens?: number
 }): UsageMetadata {
-    const inputTokenDetails = {
-        ...(data.inputAudioTokens != null
-            ? { audio: data.inputAudioTokens }
-            : {}),
-        ...(data.inputImageTokens != null
-            ? { image: data.inputImageTokens }
-            : {}),
-        ...(data.cacheReadTokens != null
-            ? { cache_read: data.cacheReadTokens }
-            : {}),
-        ...(data.cacheCreationTokens != null
-            ? { cache_creation: data.cacheCreationTokens }
-            : {})
+    const inputTokenDetails: UsageMetadata['input_token_details'] = {}
+    const outputTokenDetails: UsageMetadata['output_token_details'] = {}
+
+    if (data.inputAudioTokens != null) {
+        inputTokenDetails.audio = data.inputAudioTokens
     }
-    const outputTokenDetails = {
-        ...(data.outputAudioTokens != null
-            ? { audio: data.outputAudioTokens }
-            : {}),
-        ...(data.outputImageTokens != null
-            ? { image: data.outputImageTokens }
-            : {}),
-        ...(data.reasoningTokens != null
-            ? { reasoning: data.reasoningTokens }
-            : {})
+    if (data.inputImageTokens != null) {
+        inputTokenDetails.image = data.inputImageTokens
+    }
+    if (data.cacheReadTokens != null) {
+        inputTokenDetails.cache_read = data.cacheReadTokens
+    }
+    if (data.cacheCreationTokens != null) {
+        inputTokenDetails.cache_creation = data.cacheCreationTokens
+    }
+    if (data.outputAudioTokens != null) {
+        outputTokenDetails.audio = data.outputAudioTokens
+    }
+    if (data.outputImageTokens != null) {
+        outputTokenDetails.image = data.outputImageTokens
+    }
+    if (data.reasoningTokens != null) {
+        outputTokenDetails.reasoning = data.reasoningTokens
     }
 
     return {
@@ -336,15 +334,14 @@ export function responseOutputToolCalls(response: ResponseObject) {
 }
 
 export function responseOutputImageItems(response: ResponseObject) {
-    return (response.output ?? [])
-        .filter((item) => item.type === 'image_generation_call' && item.result)
-        .map(
-            (item) =>
-                item as Extract<
-                    ResponseOutputItem,
-                    { type: 'image_generation_call' }
-                >
-        )
+    return (response.output ?? []).filter(
+        (
+            item
+        ): item is Extract<
+            ResponseOutputItem,
+            { type: 'image_generation_call' }
+        > => item.type === 'image_generation_call' && !!item.result
+    )
 }
 
 export async function langchainMessageToOpenAIMessage(
@@ -662,28 +659,12 @@ type MessageContentFileLike = MessageContentComplex &
     )
 
 function getFileLikeUrlInfo(content: MessageContentFileLike) {
-    switch (content.type) {
-        case 'file_url': {
-            const raw = content.file_url
-            return {
-                url: typeof raw === 'string' ? raw : raw.url,
-                mimeType: typeof raw === 'string' ? undefined : raw.mimeType
-            }
-        }
-        case 'audio_url': {
-            const raw = content.audio_url
-            return {
-                url: typeof raw === 'string' ? raw : raw.url,
-                mimeType: typeof raw === 'string' ? undefined : raw.mimeType
-            }
-        }
-        case 'video_url': {
-            const raw = content.video_url
-            return {
-                url: typeof raw === 'string' ? raw : raw.url,
-                mimeType: typeof raw === 'string' ? undefined : raw.mimeType
-            }
-        }
+    const raw = content[content.type] as
+        | string
+        | { url: string; mimeType?: string }
+    return {
+        url: typeof raw === 'string' ? raw : raw.url,
+        mimeType: typeof raw === 'string' ? undefined : raw.mimeType
     }
 }
 
@@ -894,10 +875,7 @@ export function convertMessageToMessageChunk(
 ) {
     const content = message.content ?? ''
     const reasoningContent = message.reasoning_content
-
-    const role = (
-        (message.role?.length ?? 0) > 0 ? message.role : 'assistant'
-    ).toLowerCase()
+    const role = (message.role || 'assistant').toLowerCase()
 
     const additionalKwargs: {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/naming-convention
@@ -912,45 +890,35 @@ export function convertMessageToMessageChunk(
         additionalKwargs.reasoning_content = reasoningContent
     }
 
-    if (role === 'user') {
-        return new HumanMessageChunk({ content })
-    } else if (role === 'assistant') {
-        const toolCallChunks: ToolCallChunk[] = []
-        if (Array.isArray(message.tool_calls)) {
-            for (const rawToolCall of message.tool_calls) {
-                let name = rawToolCall.function?.name
-
-                if (name != null && name.length < 1) {
-                    name = undefined
-                }
-                toolCallChunks.push({
-                    name,
-                    args: rawToolCall.function?.arguments,
-                    id: rawToolCall.id
-                })
-            }
-        }
-        return new AIMessageChunk({
-            content,
-            tool_call_chunks: toolCallChunks,
-            additional_kwargs: additionalKwargs
-        })
-    } else if (role === 'system') {
-        return new SystemMessageChunk({ content })
-    } else if (role === 'function') {
-        return new FunctionMessageChunk({
-            content,
-            additional_kwargs: additionalKwargs,
-            name: message.name
-        })
-    } else if (role === 'tool') {
-        return new ToolMessageChunk({
-            content,
-            additional_kwargs: additionalKwargs,
-            tool_call_id: message.tool_call_id
-        })
-    } else {
-        return new ChatMessageChunk({ content, role })
+    switch (role) {
+        case 'user':
+            return new HumanMessageChunk({ content })
+        case 'assistant':
+            return new AIMessageChunk({
+                content,
+                tool_call_chunks: (message.tool_calls ?? []).map((call) => ({
+                    name: call.function?.name || undefined,
+                    args: call.function?.arguments,
+                    id: call.id
+                })),
+                additional_kwargs: additionalKwargs
+            })
+        case 'system':
+            return new SystemMessageChunk({ content })
+        case 'function':
+            return new FunctionMessageChunk({
+                content,
+                additional_kwargs: additionalKwargs,
+                name: message.name
+            })
+        case 'tool':
+            return new ToolMessageChunk({
+                content,
+                additional_kwargs: additionalKwargs,
+                tool_call_id: message.tool_call_id
+            })
+        default:
+            return new ChatMessageChunk({ content, role })
     }
 }
 
@@ -959,23 +927,17 @@ export function convertDeltaToMessageChunk(
     delta: Record<string, any>,
     defaultRole?: ChatCompletionResponseMessageRoleEnum
 ) {
-    const role = (
-        (delta.role?.length ?? 0) > 0 ? delta.role : defaultRole
-    ).toLowerCase()
+    const role = (delta.role || defaultRole).toLowerCase()
     const content = delta.content ?? ''
     const reasoningContent = delta.reasoning_content as string | undefined
 
-    let additionalKwargs: {
+    const additionalKwargs: {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/naming-convention
         function_call?: any
         reasoning_content?: string
-    }
+    } = {}
     if (delta.function_call) {
-        additionalKwargs = {
-            function_call: delta.function_call
-        }
-    } else {
-        additionalKwargs = {}
+        additionalKwargs.function_call = delta.function_call
     }
 
     // Preserve empty reasoning_content for DeepSeek-V4 thinking mode.
@@ -983,47 +945,40 @@ export function convertDeltaToMessageChunk(
         additionalKwargs.reasoning_content = reasoningContent
     }
 
-    if (role === 'user') {
-        return new HumanMessageChunk({ content })
-    } else if (role === 'assistant') {
-        const toolCallChunks = []
-        if (Array.isArray(delta.tool_calls)) {
-            for (const rawToolCall of delta.tool_calls) {
-                const toolCall = {
-                    name: rawToolCall.function?.name,
-                    args: rawToolCall.function?.arguments,
-                    id: rawToolCall.id === '' ? undefined : rawToolCall.id,
-                    index: rawToolCall.index
-                }
+    switch (role) {
+        case 'user':
+            return new HumanMessageChunk({ content })
+        case 'assistant': {
+            const toolCallChunks = Array.isArray(delta.tool_calls)
+                ? delta.tool_calls.map((call) => ({
+                      name: call.function?.name || undefined,
+                      args: call.function?.arguments,
+                      id: call.id === '' ? undefined : call.id,
+                      index: call.index
+                  }))
+                : []
 
-                if (toolCall.name != null && toolCall.name.length < 1) {
-                    delete toolCall.name
-                }
-
-                toolCallChunks.push(toolCall)
-            }
+            return new AIMessageChunk({
+                content,
+                tool_call_chunks: toolCallChunks,
+                additional_kwargs: additionalKwargs
+            })
         }
-
-        return new AIMessageChunk({
-            content,
-            tool_call_chunks: toolCallChunks,
-            additional_kwargs: additionalKwargs
-        })
-    } else if (role === 'system') {
-        return new SystemMessageChunk({ content })
-    } else if (role === 'function') {
-        return new FunctionMessageChunk({
-            content,
-            additional_kwargs: additionalKwargs,
-            name: delta.name
-        })
-    } else if (role === 'tool') {
-        return new ToolMessageChunk({
-            content,
-            additional_kwargs: additionalKwargs,
-            tool_call_id: delta.tool_call_id
-        })
-    } else {
-        return new ChatMessageChunk({ content, role })
+        case 'system':
+            return new SystemMessageChunk({ content })
+        case 'function':
+            return new FunctionMessageChunk({
+                content,
+                additional_kwargs: additionalKwargs,
+                name: delta.name
+            })
+        case 'tool':
+            return new ToolMessageChunk({
+                content,
+                additional_kwargs: additionalKwargs,
+                tool_call_id: delta.tool_call_id
+            })
+        default:
+            return new ChatMessageChunk({ content, role })
     }
 }

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -49,6 +49,42 @@ import {
     supportImageInput
 } from './client'
 
+export class ReasoningState<T = unknown> {
+    content = ''
+    seen = false
+    startedAt = Date.now()
+    endedAt?: number
+    blocks: T[] = []
+
+    append(content: string) {
+        this.content += content
+        this.seen = true
+    }
+
+    set(content: string) {
+        this.content = content
+        this.seen = true
+    }
+
+    end() {
+        if (this.endedAt == null) {
+            this.endedAt = Date.now()
+        }
+    }
+
+    get time() {
+        return (this.endedAt ?? Date.now()) - this.startedAt
+    }
+
+    get format() {
+        return 'Thought for %c: %s'
+    }
+
+    get params() {
+        return [`${this.time / 1000}s`, this.content]
+    }
+}
+
 export function createUsageMetadata(data: {
     inputTokens: number
     outputTokens: number


### PR DESCRIPTION
This pr avoids duplicate usage metadata merge warnings across adapters.

## Bug Fixes
- Stop duplicating usage metadata into generationInfo for streaming chunks.
- Return usage metadata through llmOutput for completed chat calls.
- Construct AIMessageChunk values with object content where needed.

## Other Changes
- Log failed request dumps at warn level.

## Validation
- Verified branch diff and signed commit status.