### PR TITLE
feat(adapter): add prompt cache key toggle

### DIFF
--- a/packages/adapter-openai-like/src/index.ts
+++ b/packages/adapter-openai-like/src/index.ts
@@ -69,6 +69,7 @@ export interface Config extends ChatLunaPlugin.Config {
     frequencyPenalty: number
     nonStreaming: boolean
     responseApi: boolean
+    setCacheKey: boolean
     googleSearch: boolean
     googleSearchSupportModel: string[]
     responseBuiltinTools: ResponseBuiltinToolName[]
@@ -134,7 +135,8 @@ export const Config: Schema<Config> = Schema.intersect([
         presencePenalty: Schema.number().min(-2).max(2).step(0.1).default(0),
         frequencyPenalty: Schema.number().min(-2).max(2).step(0.1).default(0),
         nonStreaming: Schema.boolean().default(false),
-        responseApi: Schema.boolean().default(false)
+        responseApi: Schema.boolean().default(false),
+        setCacheKey: Schema.boolean().default(true)
     }),
     Schema.object({
         googleSearch: Schema.boolean().default(false),

--- a/packages/adapter-openai-like/src/locales/en-US.schema.yml
+++ b/packages/adapter-openai-like/src/locales/en-US.schema.yml
@@ -39,6 +39,7 @@ $inner:
       frequencyPenalty: 'Token frequency penalty (-2 to 2, step 0.1, reduces repetition)'
       nonStreaming: 'Force disable streaming response. When enabled, requests will always be made in non-streaming mode, even if the stream parameter is configured.'
       responseApi: 'Enable OpenAI Responses API. Disabled by default; when disabled, Chat Completions API is used.'
+      setCacheKey: 'Whether to send prompt_cache_key. When disabled, requests will not include prompt_cache_key.'
 
     - $desc: Other settings
       googleSearch: Whether to enable Google search. (Only valid for Gemini models that support Google search and use the new-api)

--- a/packages/adapter-openai-like/src/locales/zh-CN.schema.yml
+++ b/packages/adapter-openai-like/src/locales/zh-CN.schema.yml
@@ -39,6 +39,7 @@ $inner:
       frequencyPenalty: 频率惩罚系数，数值越高，越不易重复出现次数较多的 Token（范围：-2~2，步长：0.1）。
       nonStreaming: 强制不启用流式返回。开启后，将总是以非流式发起请求，即便配置了 stream 参数。
       responseApi: 是否启用 OpenAI Responses API。默认关闭，关闭时继续使用 Chat Completions API。
+      setCacheKey: 是否上传 prompt_cache_key。关闭后请求中不会包含 prompt_cache_key。
 
     - $desc: 其他设置
       googleSearch: 是否启用 Google 搜索。（只对支持 google 搜索的 gemini 模型 且为 new-api 的端点有效）

--- a/packages/adapter-openai-like/src/requester.ts
+++ b/packages/adapter-openai-like/src/requester.ts
@@ -47,6 +47,18 @@ export class OpenAIRequester
         super(ctx, _configPool, _pluginConfig, _plugin)
     }
 
+    public post(
+        url: string,
+        data: Parameters<ModelRequester['post']>[1],
+        params?: Parameters<ModelRequester['post']>[2]
+    ) {
+        if (!this._pluginConfig.setCacheKey) {
+            delete data.prompt_cache_key
+        }
+
+        return super.post(url, data, params)
+    }
+
     async completion(params: ModelRequestParams): Promise<ChatGeneration> {
         if (
             !this._pluginConfig.nonStreaming &&

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -36,15 +36,19 @@ export function trackLogToLocal(
                 `[${tag}] A local log file has been created at ${logFile}`
             )
             const cutoff = Date.now() - 604800000
-            const logs = await Promise.all(
-                (await fs.promises.readdir(dir))
-                    .filter((f) => f.endsWith('.log'))
-                    .map(async (f) => {
-                        const p = `${dir}/${f}`,
-                            s = await fs.promises.stat(p)
-                        return { p, size: s.size, time: s.mtimeMs }
-                    })
-            )
+            const logs: { p: string; size: number; time: number }[] = []
+            for (const f of await fs.promises.readdir(dir)) {
+                if (!f.endsWith('.log')) continue
+                const p = `${dir}/${f}`
+                try {
+                    const s = await fs.promises.stat(p)
+                    logs.push({ p, size: s.size, time: s.mtimeMs })
+                } catch (e) {
+                    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+                        logger.error(e)
+                    }
+                }
+            }
             logs.sort((a, b) => a.time - b.time)
             let total = logs.reduce((s, l) => s + l.size, 0),
                 deleted = 0
@@ -54,10 +58,14 @@ export function trackLogToLocal(
                     await fs.promises.unlink(l.p)
                     total -= l.size
                     deleted++
-                } catch {}
+                } catch (e) {
+                    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+                        logger.error(e)
+                    }
+                }
             }
             if (deleted)
                 logger.debug(`[${tag}] Deleted ${deleted} old log file(s).`)
-        })().catch(() => undefined)
+        })().catch((e) => logger.error(e))
     }, 0)
 }

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -1,98 +1,62 @@
-import { Context, Logger, sleep } from 'koishi'
+import { Context, Logger } from 'koishi'
 import os from 'os'
 import fs from 'fs'
 
-let loggers: Record<string, Logger> = {}
+let loggers: Record<string, Logger> = {},
+    logLevel = -1
 
-let logLevel = -1
-
-export function createLogger(ctx: Context, name: string = 'chatluna') {
-    const result = loggers[name] || ctx.logger(name)
-
-    if (logLevel >= 0) {
-        result.level = logLevel
-    }
-
-    loggers[name] = result
-
-    return result
+export function createLogger(ctx: Context, name = 'chatluna') {
+    const logger = loggers[name] || ctx.logger(name)
+    if (logLevel >= 0) logger.level = logLevel
+    return (loggers[name] = logger)
 }
 
 export function setLoggerLevel(level: number) {
     logLevel = level
-
-    for (const name in loggers) {
-        loggers[name].level = level
-    }
+    for (const n in loggers) loggers[n].level = level
 }
 
 export function clearLogger() {
     loggers = {}
 }
 
-export async function trackLogToLocal(
+export function trackLogToLocal(
     tag: string,
     output: string,
     logger: Logger,
     level: 'debug' | 'warn' = 'debug'
 ) {
-    const currentTime = new Date()
-        .toISOString()
-        .slice(0, 19)
-        .replace('T', '-')
-        .replace(/:/g, '-')
-    const tempDir = os.tmpdir()
-    const logDir = `${tempDir}/chatluna/logs`
-    const logFile = `${logDir}/chatluna-log-${currentTime}.log`
-
-    if (!fs.existsSync(logDir)) {
-        fs.mkdirSync(logDir, { recursive: true })
-    }
-
-    const writeAndCleanup = async () => {
-        await fs.promises.writeFile(logFile, output)
-
-        logger[level](
-            '[%s] A local log file has been created at %s',
-            tag,
-            logFile
-        )
-
-        // Clean up old log files (older than 7 days)
-        const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000
-        const files = await fs.promises.readdir(logDir)
-        let deletedCount = 0
-
-        for (const file of files) {
-            if (!file.startsWith('chatluna-log-') || !file.endsWith('.log')) {
-                continue
-            }
-
-            const filePath = `${logDir}/${file}`
-            let stats: fs.Stats
-            try {
-                stats = await fs.promises.stat(filePath)
-            } catch {
-                continue
-            }
-
-            if (stats.mtimeMs < sevenDaysAgo) {
-                try {
-                    await fs.promises.unlink(filePath)
-                    deletedCount += 1
-                } catch {
-                    // ignore failed deletions
-                }
-                await sleep(0)
-            }
-        }
-
-        if (deletedCount > 0) {
-            logger.debug(`[${tag}] Deleted ${deletedCount} old log file(s).`)
-        }
-    }
-
+    const dir = `${os.tmpdir()}/chatluna/logs`,
+        logFile = `${dir}/chatluna-log-${new Date().toISOString().replace(/[T:]/g, '-').slice(0, 19)}.log`
+    fs.mkdirSync(dir, { recursive: true })
     setTimeout(() => {
-        writeAndCleanup().catch(() => undefined)
+        try {
+            fs.writeFileSync(logFile, output)
+            logger[level](
+                `[${tag}] A local log file has been created at ${logFile}`
+            )
+            const cutoff = Date.now() - 604800000
+            const logs = fs
+                .readdirSync(dir)
+                .filter((f) => f.endsWith('.log'))
+                .map((f) => {
+                    const p = `${dir}/${f}`,
+                        s = fs.statSync(p)
+                    return { p, size: s.size, time: s.mtimeMs }
+                })
+                .sort((a, b) => a.time - b.time)
+            let total = logs.reduce((s, l) => s + l.size, 0),
+                deleted = 0
+            for (const l of logs) {
+                if (l.time >= cutoff && total <= 1073741824) break
+                try {
+                    fs.unlinkSync(l.p)
+                    total -= l.size
+                    deleted++
+                } catch {}
+            }
+            if (deleted)
+                logger.debug(`[${tag}] Deleted ${deleted} old log file(s).`)
+        } catch {}
     }, 0)
 }

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -27,36 +27,37 @@ export function trackLogToLocal(
     level: 'debug' | 'warn' = 'debug'
 ) {
     setTimeout(() => {
-        try {
+        ;(async () => {
             const dir = `${os.tmpdir()}/chatluna/logs`,
                 logFile = `${dir}/chatluna-log-${new Date().toISOString().replace(/[T:.]/g, '-')}-${process.hrtime.bigint()}.log`
-            fs.mkdirSync(dir, { recursive: true })
-            fs.writeFileSync(logFile, output)
+            await fs.promises.mkdir(dir, { recursive: true })
+            await fs.promises.writeFile(logFile, output)
             logger[level](
                 `[${tag}] A local log file has been created at ${logFile}`
             )
             const cutoff = Date.now() - 604800000
-            const logs = fs
-                .readdirSync(dir)
-                .filter((f) => f.endsWith('.log'))
-                .map((f) => {
-                    const p = `${dir}/${f}`,
-                        s = fs.statSync(p)
-                    return { p, size: s.size, time: s.mtimeMs }
-                })
-                .sort((a, b) => a.time - b.time)
+            const logs = await Promise.all(
+                (await fs.promises.readdir(dir))
+                    .filter((f) => f.endsWith('.log'))
+                    .map(async (f) => {
+                        const p = `${dir}/${f}`,
+                            s = await fs.promises.stat(p)
+                        return { p, size: s.size, time: s.mtimeMs }
+                    })
+            )
+            logs.sort((a, b) => a.time - b.time)
             let total = logs.reduce((s, l) => s + l.size, 0),
                 deleted = 0
             for (const l of logs) {
                 if (l.time >= cutoff && total <= 1073741824) break
                 try {
-                    fs.unlinkSync(l.p)
+                    await fs.promises.unlink(l.p)
                     total -= l.size
                     deleted++
                 } catch {}
             }
             if (deleted)
                 logger.debug(`[${tag}] Deleted ${deleted} old log file(s).`)
-        } catch {}
+        })().catch(() => undefined)
     }, 0)
 }

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -59,7 +59,10 @@ export function trackLogToLocal(
                     total -= l.size
                     deleted++
                 } catch (e) {
-                    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+                    if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+                        total -= l.size
+                        deleted++
+                    } else {
                         logger.error(e)
                     }
                 }

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -26,11 +26,11 @@ export function trackLogToLocal(
     logger: Logger,
     level: 'debug' | 'warn' = 'debug'
 ) {
-    const dir = `${os.tmpdir()}/chatluna/logs`,
-        logFile = `${dir}/chatluna-log-${new Date().toISOString().replace(/[T:]/g, '-').slice(0, 19)}.log`
-    fs.mkdirSync(dir, { recursive: true })
     setTimeout(() => {
         try {
+            const dir = `${os.tmpdir()}/chatluna/logs`,
+                logFile = `${dir}/chatluna-log-${new Date().toISOString().replace(/[T:.]/g, '-')}-${process.hrtime.bigint()}.log`
+            fs.mkdirSync(dir, { recursive: true })
             fs.writeFileSync(logFile, output)
             logger[level](
                 `[${tag}] A local log file has been created at ${logFile}`

--- a/packages/core/src/utils/string.ts
+++ b/packages/core/src/utils/string.ts
@@ -529,6 +529,7 @@ export function getSystemPromptVariables(
             platform: session.platform,
             conversationId: conversation.id
         },
+        message_id: session.messageId,
         noop: '',
         time: new Date().toLocaleTimeString(),
         weekday: getCurrentWeekday(),

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -658,8 +658,7 @@ type MessageContentFileLike = MessageContentComplex &
 
 function getFileLikeUrlInfo(content: MessageContentFileLike) {
     const raw = content[content.type] as
-        | string
-        | { url: string; mimeType?: string }
+        string | { url: string; mimeType?: string }
     return {
         url: typeof raw === 'string' ? raw : raw.url,
         mimeType: typeof raw === 'string' ? undefined : raw.mimeType

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -658,7 +658,9 @@ type MessageContentFileLike = MessageContentComplex &
 
 function getFileLikeUrlInfo(content: MessageContentFileLike) {
     const raw = content[content.type] as
-        string | { url: string; mimeType?: string }
+    const raw = content[content.type] as
+        | string
+        | { url: string; mimeType?: string }
     return {
         url: typeof raw === 'string' ? raw : raw.url,
         mimeType: typeof raw === 'string' ? undefined : raw.mimeType

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -658,9 +658,7 @@ type MessageContentFileLike = MessageContentComplex &
 
 function getFileLikeUrlInfo(content: MessageContentFileLike) {
     const raw = content[content.type] as
-    const raw = content[content.type] as
-        | string
-        | { url: string; mimeType?: string }
+        string | { url: string; mimeType?: string }
     return {
         url: typeof raw === 'string' ? raw : raw.url,
         mimeType: typeof raw === 'string' ? undefined : raw.mimeType


### PR DESCRIPTION
This pr adds a prompt cache key toggle for OpenAI-compatible adapters.

## New Features
- Add an OpenAI-like adapter setting to control whether prompt_cache_key is sent.
- Document the setting in English and Chinese schema locales.

## Other Changes
- Expose message_id in system prompt variables.

## Validation
- yarn lint-fix