### PR TITLE
feat(core): improve koishi element streaming parser

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -267,6 +267,7 @@
         "@vue/reactivity": "^3.6.0-alpha.2",
         "decimal.js": "^10.6.0",
         "he": "^1.2.0",
+        "htmlparser2": "^10.1.0",
         "https-proxy-agent": "^7.0.6",
         "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21",
         "js-yaml": "^4.1.0",

--- a/packages/core/src/render/koishi-element.ts
+++ b/packages/core/src/render/koishi-element.ts
@@ -1,8 +1,8 @@
 import { BaseMessageChunk } from '@langchain/core/messages'
 import { h, Schema } from 'koishi'
-import he from 'he'
 import { logger } from 'koishi-plugin-chatluna'
 import { transformMessageContentToElements } from 'koishi-plugin-chatluna/utils/string'
+import { parseElements } from 'koishi-plugin-chatluna/utils/koishi'
 import { Message, RenderMessage, RenderOptions } from '../types'
 import { Renderer } from './base'
 import { MessageElementSplitter } from './split'
@@ -18,7 +18,9 @@ export class KoishiElementRenderer extends Renderer {
         transformed = transformAndEscape(transformed)
 
         if (options.split && options.split !== 'none') {
-            transformed = transformed.map((element) => h('message', element))
+            transformed = transformed.map((element) =>
+                element.type === 'message' ? element : h('message', element)
+            )
         }
 
         return {
@@ -63,6 +65,7 @@ class KoishiElementStreamSession implements RenderStreamSession {
     }
 
     write(chunk: BaseMessageChunk) {
+        if (this.plan.mode === 'buffer') return null
         const text = getChunkText(chunk)
         if (!text) return null
 
@@ -76,6 +79,7 @@ class KoishiElementStreamSession implements RenderStreamSession {
     }
 
     flush() {
+        if (this.plan.mode === 'buffer') return null
         if (this.plan.mode === 'edit' && this.text.trim()) {
             return transformAndEscape([h.text(this.text)])
         }
@@ -94,23 +98,13 @@ function getChunkText(chunk: BaseMessageChunk) {
         .join('')
 }
 
-function unescape(element: h): h {
-    if (element.type === 'text') {
-        element.attrs['content'] = he.decode(element.attrs['content'])
-    }
-    if (element.children && element.children.length > 0) {
-        element.children = element.children.map(unescape)
-    }
-    return element
-}
-
 export function transformAndEscape(source: h[]) {
     return source.flatMap((element) => {
         if (element.type !== 'text') {
             return element
         }
         try {
-            return h.parse(element.attrs['content']).map(unescape)
+            return parseElements(element.attrs['content'])
         } catch (e) {
             logger.error(e)
             return [h.text(element.attrs['content'])]

--- a/packages/core/src/render/split.ts
+++ b/packages/core/src/render/split.ts
@@ -1,6 +1,7 @@
 import { BaseMessageChunk } from '@langchain/core/messages'
 import { h } from 'koishi'
 import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
+import { parseElements } from 'koishi-plugin-chatluna/utils/koishi'
 import type { RenderOptions, SplitMode } from '../types'
 import { nextTextCut, splitText as splitByMode } from './sentence'
 
@@ -114,31 +115,20 @@ export class MessageElementSplitter {
     writeText(text: string) {
         if (!text) return []
         this.buf += text
-        return this.parseMessageElements(false)
+        const result = parseElements(this.buf, true)
+        this.buf = result.rest
+        return result.elements
     }
 
     flush() {
         if (!this.buf.trim()) return []
-        return this.parseMessageElements(true)
-    }
-
-    private parseMessageElements(flush: boolean) {
         try {
-            const elements = h.parse(this.buf)
-            if (!elements.some((el) => el.type === 'message')) {
-                return flush ? this.flushText() : []
-            }
-            this.buf = ''
-            return elements
+            return parseElements(this.buf)
         } catch {
-            return flush ? this.flushText() : []
+            return [h.text(this.buf)]
+        } finally {
+            this.buf = ''
         }
-    }
-
-    private flushText() {
-        const elements = [h.text(this.buf)]
-        this.buf = ''
-        return elements
     }
 }
 

--- a/packages/core/src/render/stream.ts
+++ b/packages/core/src/render/stream.ts
@@ -103,7 +103,7 @@ export class ReplyStream {
             if (frame?.type === 'done') {
                 if (this.mode === 'edit') {
                     await this.sendMessage(frame.message, 'edit')
-                } else if (this.firstChunk) {
+                } else if (this.mode === 'buffer' || this.firstChunk) {
                     await this.sendMessage(frame.message, 'split')
                 }
             }

--- a/packages/core/src/utils/koishi.ts
+++ b/packages/core/src/utils/koishi.ts
@@ -1,6 +1,7 @@
 import { Command, ForkScope, h, Session, User } from 'koishi'
 import { PromiseLikeDisposable } from 'koishi-plugin-chatluna/utils/types'
 import { Marked, Token } from 'marked'
+import { Parser } from 'htmlparser2'
 import type { MessageContent } from '@langchain/core/messages'
 import {
     isMessageContentAudio,
@@ -26,6 +27,87 @@ const marked = new Marked({
         }
     }
 })
+
+const htmlVoidElements = new Set(
+    'area base br col embed hr img input link meta source track wbr'.split(' ')
+)
+
+export function parseElements(source: string): h[]
+export function parseElements(
+    source: string,
+    partial: true
+): { elements: h[]; rest: string }
+export function parseElements(source: string, partial = false) {
+    const elements: h[] = []
+    const stack: [h[], h[]?, number?, number?][] = [[elements]]
+    let depth = 0
+    let cut = -1
+    let count = 0
+
+    const append = (element: h) => {
+        const current = stack[stack.length - 1][0]
+        const last = current[current.length - 1]
+        if (last?.type === 'text' && element.type === 'text') {
+            last.attrs['content'] += element.attrs['content']
+        } else {
+            current.push(element)
+        }
+    }
+
+    const parser = new Parser(
+        {
+            onopentag(name, sourceAttrs) {
+                const attrs: Record<string, string | boolean> = {}
+                for (const [key, value] of Object.entries(sourceAttrs)) {
+                    if (key.startsWith('no-')) attrs[key.slice(3)] = false
+                    else attrs[key] = value || true
+                }
+
+                const element = h(name, attrs)
+                append(element)
+                if (name === 'message') depth++
+                if (!htmlVoidElements.has(name)) {
+                    const parent = stack[stack.length - 1][0]
+                    stack.push([
+                        element.children,
+                        parent,
+                        parent.length - 1,
+                        parser.startIndex
+                    ])
+                }
+            },
+            ontext(text) {
+                append(h.text(text))
+            },
+            onclosetag(name, implied) {
+                if (htmlVoidElements.has(name)) return
+                const entry = stack.pop()
+                if (entry?.[1] == null) return
+                const empty = source
+                    .slice(parser.startIndex, parser.endIndex + 1)
+                    .trimEnd()
+                    .endsWith('/>')
+                if (implied && !empty) {
+                    entry[1][entry[2]!] = h.text(
+                        source.slice(entry[3], parser.startIndex)
+                    )
+                }
+                if (name !== 'message' || depth < 1) return
+                depth--
+                if (depth === 0 && (!implied || empty)) {
+                    cut = parser.endIndex + 1
+                    count = elements.length
+                }
+            }
+        },
+        { decodeEntities: true, recognizeSelfClosing: true }
+    )
+    parser.end(source)
+
+    if (!partial) return elements
+    if (cut < 0) return { elements: [], rest: source }
+    return { elements: elements.slice(0, count), rest: source.slice(cut) }
+}
 
 export function forkScopeToDisposable(scope: ForkScope): PromiseLikeDisposable {
     return () => {

--- a/packages/core/src/utils/koishi.ts
+++ b/packages/core/src/utils/koishi.ts
@@ -31,6 +31,11 @@ const marked = new Marked({
 const htmlVoidElements = new Set(
     'area base br col embed hr img input link meta source track wbr'.split(' ')
 )
+const htmlOptionalEndElements = new Set(
+    'html head body p li dt dd rt rp optgroup option colgroup thead tbody tfoot tr td th'.split(
+        ' '
+    )
+)
 
 export function parseElements(source: string): h[]
 export function parseElements(
@@ -87,7 +92,15 @@ export function parseElements(source: string, partial = false) {
                     .slice(parser.startIndex, parser.endIndex + 1)
                     .trimEnd()
                     .endsWith('/>')
-                if (implied && !empty) {
+                const truncated =
+                    parser.startIndex >= source.length ||
+                    source.startsWith('</', parser.startIndex)
+                if (
+                    implied &&
+                    !empty &&
+                    truncated &&
+                    !htmlOptionalEndElements.has(name)
+                ) {
                     entry[1][entry[2]!] = h.text(
                         source.slice(entry[3], parser.startIndex)
                     )


### PR DESCRIPTION
This pr improves Koishi element streaming and partial message parsing.

## New Features
- Add a partial HTML element parser for streaming Koishi messages.
- Stream complete message elements as they arrive without waiting for full buffers.

## Bug Fixes
- Avoid wrapping already-wrapped message elements during split rendering.
- Keep buffered streams from emitting incomplete element chunks.

## Other Changes
- Add htmlparser2 dependency for robust element parsing.

## Validation
- yarn lint-fix