### PR TITLE
fix(core): improve conversation delete selectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ tsconfig.temp.json
 .idea
 .vscode
 .chatluna
+.opencode
 .tmp
 *.suo
 *.ntvs*

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -711,6 +711,12 @@ export async function createChatGenerationParams(
     const systemInstructionKey = pluginConfig.useCamelCaseSystemInstruction
         ? 'systemInstruction'
         : 'system_instruction'
+
+    const includeServerSideToolInvocationKey =
+        pluginConfig.useCamelCaseSystemInstruction
+            ? 'includeServerSideToolInvocations'
+            : 'include_server_side_tool_invocations'
+
     const tools =
         params.tools != null ||
         modelConfig.forceGoogleSearch ||
@@ -748,7 +754,9 @@ export async function createChatGenerationParams(
         tools,
         toolConfig:
             modelConfig.model.includes('gemini-3') && hasBuiltinTools
-                ? { includeServerSideToolInvocations: true }
+                ? {
+                      [includeServerSideToolInvocationKey]: true
+                  }
                 : undefined
     }
 }

--- a/packages/core/src/commands/conversation.ts
+++ b/packages/core/src/commands/conversation.ts
@@ -234,7 +234,7 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
             )
         })
 
-    ctx.command('chatluna.delete [conversation:string]', {
+    ctx.command('chatluna.delete [conversation:text]', {
         authority: 1
     })
         .option('preset', '-p <preset:string>')

--- a/packages/core/src/locales/en-US.yml
+++ b/packages/core/src/locales/en-US.yml
@@ -546,6 +546,7 @@ chatluna:
             rename_failed: 'Failed to rename conversation: {0}'
             delete_success: 'Deleted conversation: {0}'
             delete_success_multi: 'Deleted conversations:\n{0}'
+            delete_partial: 'Some conversations were deleted:\n{0}\nFailed to delete:\n{1}'
             delete_failed: 'Failed to delete conversation: {0}'
             use_model_success: '{1} now uses model {0}.'
             use_model_failed: 'Failed to switch model: {0}'

--- a/packages/core/src/locales/zh-CN.yml
+++ b/packages/core/src/locales/zh-CN.yml
@@ -545,6 +545,7 @@ chatluna:
             rename_failed: '重命名会话失败：{0}'
             delete_success: '已删除会话：{0}'
             delete_success_multi: '已删除会话：\n{0}'
+            delete_partial: '部分会话删除成功：\n{0}\n删除失败：\n{1}'
             delete_failed: '删除会话失败：{0}'
             use_model_success: '{1} 已切换到模型 {0}。'
             use_model_failed: '切换模型失败：{0}'

--- a/packages/core/src/middlewares/chat/rollback_chat.ts
+++ b/packages/core/src/middlewares/chat/rollback_chat.ts
@@ -14,13 +14,6 @@ import {
 
 const MAX_ROLLBACK_HOPS = 1000
 
-function getTargetConversation(context: ChainMiddlewareContext) {
-    return (
-        context.options.conversation_manage?.targetConversation ??
-        context.options.targetConversation
-    )
-}
-
 export function apply(ctx: Context, config: Config, chain: ChatChain) {
     chain
         .middleware('rollback_chat', async (session, context) => {
@@ -29,14 +22,16 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             if (command !== 'rollback') return ChainMiddlewareRunStatus.SKIPPED
 
             const rollbackRound = context.options.rollback_round ?? 1
-            const targetConversation = getTargetConversation(context)
+            const target =
+                context.options.conversation_manage?.targetConversation ??
+                context.options.targetConversation
             const resolved =
-                targetConversation == null
+                target == null
                     ? context.options.conversation
                     : await ctx.chatluna.conversation.resolveConversation(
                           session,
                           {
-                              targetConversation,
+                              targetConversation: target,
                               presetLane: context.options.presetLane,
                               allPresetLanes: context.options.allPresetLanes,
                               permission: 'manage',

--- a/packages/core/src/middlewares/chat/stop_chat.ts
+++ b/packages/core/src/middlewares/chat/stop_chat.ts
@@ -1,18 +1,7 @@
 import { Context } from 'koishi'
 import { Config } from '../../config'
-import {
-    ChainMiddlewareContext,
-    ChainMiddlewareRunStatus,
-    ChatChain
-} from '../../chains/chain'
+import { ChainMiddlewareRunStatus, ChatChain } from '../../chains/chain'
 import { checkAdmin } from 'koishi-plugin-chatluna/utils/koishi'
-
-function getTargetConversation(context: ChainMiddlewareContext) {
-    return (
-        context.options.conversation_manage?.targetConversation ??
-        context.options.targetConversation
-    )
-}
 
 export function apply(ctx: Context, config: Config, chain: ChatChain) {
     chain
@@ -21,14 +10,16 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
 
             if (command !== 'stop_chat') return ChainMiddlewareRunStatus.SKIPPED
 
-            const targetConversation = getTargetConversation(context)
+            const target =
+                context.options.conversation_manage?.targetConversation ??
+                context.options.targetConversation
             const resolved =
-                targetConversation == null
+                target == null
                     ? context.options.conversation
                     : await ctx.chatluna.conversation.resolveConversation(
                           session,
                           {
-                              targetConversation,
+                              targetConversation: target,
                               presetLane: context.options.presetLane,
                               allPresetLanes: context.options.allPresetLanes,
                               permission: 'manage',

--- a/packages/core/src/middlewares/conversation/resolve_conversation.ts
+++ b/packages/core/src/middlewares/conversation/resolve_conversation.ts
@@ -9,6 +9,7 @@ import {
     ChatLunaError,
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
+import { parseDeleteSeqs } from '../../utils/conversation'
 
 export function apply(ctx: Context, config: Config, chain: ChatChain) {
     chain
@@ -25,12 +26,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 options.targetConversation
             const batchTarget =
                 context.command === 'conversation_delete' &&
-                targetConversation != null &&
-                targetConversation.length <= 512 &&
-                targetConversation.split(',').length <= 100 &&
-                /^\d+(?:\.\.\d+)?(?:,\d+(?:\.\.\d+)?)*$/.test(
-                    targetConversation
-                )
+                parseDeleteSeqs(targetConversation) !== undefined
             const explicitConversationId =
                 options.conversation?.conversationId ??
                 options.conversation?.conversation?.id

--- a/packages/core/src/middlewares/system/conversation_manage.ts
+++ b/packages/core/src/middlewares/system/conversation_manage.ts
@@ -307,18 +307,40 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 }
 
                 const deleted: string[] = []
+                const failed: string[] = []
                 for (const item of targets) {
-                    const conversation =
-                        await ctx.chatluna.conversation.deleteConversation(
-                            session,
-                            {
-                                ...opts,
-                                conversationId: item.conversation.id
-                            }
+                    try {
+                        const conversation =
+                            await ctx.chatluna.conversation.deleteConversation(
+                                session,
+                                {
+                                    ...opts,
+                                    conversationId: item.conversation.id
+                                }
+                            )
+                        deleted.push(
+                            `${conversation.title} (${conversation.seq ?? conversation.id})`
                         )
-                    deleted.push(
-                        `${conversation.title} (${conversation.seq ?? conversation.id})`
+                    } catch {
+                        failed.push(
+                            `${item.conversation.title} (${item.displaySeq})`
+                        )
+                    }
+                }
+
+                if (deleted.length === 0) {
+                    context.message = session.text(
+                        'chatluna.conversation.messages.delete_failed',
+                        [failed.join('\n')]
                     )
+                    return ChainMiddlewareRunStatus.STOP
+                }
+                if (failed.length > 0) {
+                    context.message = session.text(
+                        'chatluna.conversation.messages.delete_partial',
+                        [deleted.join('\n'), failed.join('\n')]
+                    )
+                    return ChainMiddlewareRunStatus.STOP
                 }
 
                 context.message = session.text(

--- a/packages/core/src/middlewares/system/conversation_manage.ts
+++ b/packages/core/src/middlewares/system/conversation_manage.ts
@@ -18,6 +18,7 @@ import {
 import { Pagination } from 'koishi-plugin-chatluna/utils/pagination'
 import { checkAdmin } from 'koishi-plugin-chatluna/utils/koishi'
 import { logger } from '../..'
+import { parseDeleteSeqs } from '../../utils/conversation'
 import fs from 'fs/promises'
 
 export function apply(ctx: Context, config: Config, chain: ChatChain) {
@@ -271,13 +272,33 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
         try {
             const opts = getManageOptions(context)
             const conversationId = resolvedConversationId(context)
+            const seqs =
+                conversationId == null
+                    ? parseDeleteSeqs(
+                          context.options.conversation_manage
+                              ?.targetConversation
+                      )
+                    : undefined
 
-            if (conversationId == null) {
-                const seqs = parseDeleteSeqs(
-                    context.options.conversation_manage?.targetConversation
+            if (seqs === null) {
+                context.message = session.text(
+                    'chatluna.conversation.messages.target_not_found',
+                    [ChatLunaErrorCode.CONVERSATION_NOT_FOUND]
+                )
+                return ChainMiddlewareRunStatus.STOP
+            }
+
+            if (seqs != null) {
+                const entries =
+                    await ctx.chatluna.conversation.listConversationEntries(
+                        session,
+                        opts
+                    )
+                const targets = entries.filter((item) =>
+                    seqs.includes(item.displaySeq)
                 )
 
-                if (seqs === null) {
+                if (targets.length !== seqs.length) {
                     context.message = session.text(
                         'chatluna.conversation.messages.target_not_found',
                         [ChatLunaErrorCode.CONVERSATION_NOT_FOUND]
@@ -285,45 +306,26 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                     return ChainMiddlewareRunStatus.STOP
                 }
 
-                if (seqs != null) {
-                    const entries =
-                        await ctx.chatluna.conversation.listConversationEntries(
+                const deleted: string[] = []
+                for (const item of targets) {
+                    const conversation =
+                        await ctx.chatluna.conversation.deleteConversation(
                             session,
-                            opts
+                            {
+                                ...opts,
+                                conversationId: item.conversation.id
+                            }
                         )
-                    const targets = entries.filter((item) =>
-                        seqs.includes(item.displaySeq)
+                    deleted.push(
+                        `${conversation.title} (${conversation.seq ?? conversation.id})`
                     )
-
-                    if (targets.length !== seqs.length) {
-                        context.message = session.text(
-                            'chatluna.conversation.messages.target_not_found',
-                            [ChatLunaErrorCode.CONVERSATION_NOT_FOUND]
-                        )
-                        return ChainMiddlewareRunStatus.STOP
-                    }
-
-                    const deleted: string[] = []
-                    for (const item of targets) {
-                        const conversation =
-                            await ctx.chatluna.conversation.deleteConversation(
-                                session,
-                                {
-                                    ...opts,
-                                    conversationId: item.conversation.id
-                                }
-                            )
-                        deleted.push(
-                            `${conversation.title} (${conversation.seq ?? conversation.id})`
-                        )
-                    }
-
-                    context.message = session.text(
-                        'chatluna.conversation.messages.delete_success_multi',
-                        [deleted.join('\n')]
-                    )
-                    return ChainMiddlewareRunStatus.STOP
                 }
+
+                context.message = session.text(
+                    'chatluna.conversation.messages.delete_success_multi',
+                    [deleted.join('\n')]
+                )
+                return ChainMiddlewareRunStatus.STOP
             }
 
             const conversation =
@@ -807,42 +809,6 @@ function requireConversation(
         )
     }
     return conversation
-}
-
-function parseDeleteSeqs(input?: string) {
-    if (input == null || input.length === 0) {
-        return
-    }
-
-    const parts = input.split(',')
-    if (input.length > 512 || parts.length > 100) return null
-
-    const seqs = new Set<number>()
-    for (const part of parts) {
-        const match = /^(\d+)(?:\.\.(\d+))?$/.exec(part)
-        if (match == null) return null
-
-        const start = Number(match[1])
-        const end = Number(match[2] ?? match[1])
-        if (
-            !Number.isSafeInteger(start) ||
-            !Number.isSafeInteger(end) ||
-            start < 1 ||
-            end < 1
-        ) {
-            return null
-        }
-
-        const min = Math.min(start, end)
-        const max = Math.max(start, end)
-
-        for (let seq = min; seq <= max; seq += 1) {
-            seqs.add(seq)
-            if (seqs.size > 100) return null
-        }
-    }
-
-    return Array.from(seqs)
 }
 
 function conversationSummary(conversation: ConversationRecord) {

--- a/packages/core/src/utils/conversation.ts
+++ b/packages/core/src/utils/conversation.ts
@@ -51,3 +51,51 @@ export function pickBindingKey(
         ? resolved.bindingKey
         : conversation.bindingKey
 }
+
+export function parseDeleteSeqs(input?: string): number[] | null | undefined {
+    if (input == null || input.length === 0) {
+        return
+    }
+
+    // Only pure number/range selectors are batch targets. Titles such as
+    // "Claude Code 黑子" must stay intact and return undefined.
+    if (
+        !/^\d+(?:\.\.\d+)?(?:(?:\s*[,，;；]\s*|\s+)\d+(?:\.\.\d+)?)*$/.test(
+            input
+        )
+    ) {
+        return
+    }
+
+    if (input.length > 512) return null
+
+    const parts = input.split(/[,，;；\s]+/).filter((part) => part.length > 0)
+    if (parts.length > 100) return null
+
+    const seqs = new Set<number>()
+    for (const part of parts) {
+        const match = /^(\d+)(?:\.\.(\d+))?$/.exec(part)
+        if (match == null) return null
+
+        const start = Number(match[1])
+        const end = Number(match[2] ?? match[1])
+        if (
+            !Number.isSafeInteger(start) ||
+            !Number.isSafeInteger(end) ||
+            start < 1 ||
+            end < 1
+        ) {
+            return null
+        }
+
+        const min = Math.min(start, end)
+        const max = Math.max(start, end)
+
+        for (let seq = min; seq <= max; seq += 1) {
+            seqs.add(seq)
+            if (seqs.size > 100) return null
+        }
+    }
+
+    return Array.from(seqs)
+}

--- a/packages/core/tests/conversation-resolve.spec.ts
+++ b/packages/core/tests/conversation-resolve.spec.ts
@@ -752,6 +752,7 @@ it('chatluna.delete removes range and list selectors', async () => {
     ]
     const actions = new Map<string, (...args: any[]) => Promise<void>>()
     const deleted: string[] = []
+    const failures = new Set<string>()
     const messages: string[] = []
     const resolveTargets: (string | undefined)[] = []
     let listCalls = 0
@@ -806,6 +807,9 @@ it('chatluna.delete removes range and list selectors', async () => {
                     return entries()
                 },
                 deleteConversation: async (_session, opts) => {
+                    if (failures.has(opts.conversationId)) {
+                        throw new Error('delete failed')
+                    }
                     deleted.push(opts.conversationId)
                     return conversations.find(
                         (item) => item.id === opts.conversationId
@@ -950,6 +954,20 @@ it('chatluna.delete removes range and list selectors', async () => {
         'chatluna.conversation.messages.delete_success:Claude Code 黑子,4,conversation-space-title',
         'chatluna.conversation.messages.delete_success:1..101,5,conversation-range-title'
     ])
+
+    failures.add('conversation-second')
+    await action({ options: {}, session }, '1,2')
+    assert.equal(
+        messages.at(-1),
+        'chatluna.conversation.messages.delete_partial:First Topic (1),Second Topic (2)'
+    )
+
+    failures.add('conversation-first')
+    await action({ options: {}, session }, '1,2')
+    assert.equal(
+        messages.at(-1),
+        'chatluna.conversation.messages.delete_failed:First Topic (1)\nSecond Topic (2)'
+    )
 })
 
 it('conversation_switch preserves explicit chain conversation through middleware order', async () => {

--- a/packages/core/tests/conversation-resolve.spec.ts
+++ b/packages/core/tests/conversation-resolve.spec.ts
@@ -852,9 +852,13 @@ it('chatluna.delete removes range and list selectors', async () => {
         return msg
     }
 
-    const action = actions.get('chatluna.delete [conversation:string]')!
+    const action = actions.get('chatluna.delete [conversation:text]')!
     await action({ options: {}, session }, '1..2')
     await action({ options: {}, session }, '1,3')
+    await action({ options: {}, session }, '1，3')
+    await action({ options: {}, session }, '1; 2；3')
+    await action({ options: {}, session }, '1 2')
+    await action({ options: {}, session }, '1..2，4')
     const validCount = deleted.length
     await action({ options: {}, session }, '1,4')
     assert.equal(deleted.length, validCount)
@@ -874,11 +878,21 @@ it('chatluna.delete removes range and list selectors', async () => {
     )
     assert.equal(deleted.length, beforeInvalid)
 
+    // Title with spaces must not be treated as batch selectors.
+    conversations.push(
+        createConversation({
+            id: 'conversation-space-title',
+            title: 'Claude Code 黑子',
+            seq: 4
+        })
+    )
+    await action({ options: {}, session }, 'Claude Code 黑子')
+
     conversations.push(
         createConversation({
             id: 'conversation-range-title',
             title: '1..101',
-            seq: 4
+            seq: 5
         })
     )
     await action({ options: {}, session }, '1..101')
@@ -889,14 +903,26 @@ it('chatluna.delete removes range and list selectors', async () => {
         'conversation-first',
         'conversation-third',
         'conversation-first',
+        'conversation-third',
         'conversation-first',
         'conversation-second',
         'conversation-third',
+        'conversation-first',
+        'conversation-second',
+        'conversation-first',
+        'conversation-first',
+        'conversation-second',
+        'conversation-third',
+        'conversation-space-title',
         'conversation-range-title'
     ])
     assert.deepEqual(resolveTargets, [
         '1..2',
         '1,3',
+        '1，3',
+        '1; 2；3',
+        '1 2',
+        '1..2，4',
         '1,4',
         '1,1',
         '3..1',
@@ -904,11 +930,16 @@ it('chatluna.delete removes range and list selectors', async () => {
         '1..50,25..75',
         '1..101',
         '999999999999999999999..999999999999999999999',
+        'Claude Code 黑子',
         '1..101'
     ])
     assert.deepEqual(messages, [
         'chatluna.conversation.messages.delete_success_multi:First Topic (1)\nSecond Topic (2)',
         'chatluna.conversation.messages.delete_success_multi:First Topic (1)\nThird Topic (3)',
+        'chatluna.conversation.messages.delete_success_multi:First Topic (1)\nThird Topic (3)',
+        'chatluna.conversation.messages.delete_success_multi:First Topic (1)\nSecond Topic (2)\nThird Topic (3)',
+        'chatluna.conversation.messages.delete_success_multi:First Topic (1)\nSecond Topic (2)',
+        'chatluna.conversation.messages.target_not_found:412',
         'chatluna.conversation.messages.target_not_found:412',
         'chatluna.conversation.messages.delete_success_multi:First Topic (1)',
         'chatluna.conversation.messages.delete_success_multi:First Topic (1)\nSecond Topic (2)\nThird Topic (3)',
@@ -916,7 +947,8 @@ it('chatluna.delete removes range and list selectors', async () => {
         'chatluna.conversation.messages.target_not_found:412',
         'chatluna.conversation.messages.target_not_found:412',
         'chatluna.conversation.messages.target_not_found:412',
-        'chatluna.conversation.messages.delete_success:1..101,4,conversation-range-title'
+        'chatluna.conversation.messages.delete_success:Claude Code 黑子,4,conversation-space-title',
+        'chatluna.conversation.messages.delete_success:1..101,5,conversation-range-title'
     ])
 })
 

--- a/packages/core/tests/conversation-utils.spec.ts
+++ b/packages/core/tests/conversation-utils.spec.ts
@@ -13,10 +13,7 @@ import {
     parsePresetLaneInput
 } from '../src/utils/message_content'
 import { ChatLunaPromptRenderService } from '../src/services/prompt_renderer'
-import {
-    applyPresetLane,
-    computeBaseBindingKey
-} from '../src/types'
+import { applyPresetLane, computeBaseBindingKey } from '../src/types'
 import { usageSourceFromStack } from '../src/utils/usage_source'
 import { selectFromList } from '../src/utils/string'
 import {
@@ -24,6 +21,43 @@ import {
     type BindingSessionShape,
     FakeDatabase
 } from './helpers'
+import { parseDeleteSeqs } from '../src/utils/conversation'
+
+it('parseDeleteSeqs supports multi-separators, ranges, and safety limits', () => {
+    assert.deepEqual(parseDeleteSeqs('1,3'), [1, 3])
+    assert.deepEqual(parseDeleteSeqs('1，3'), [1, 3])
+    assert.deepEqual(parseDeleteSeqs('1; 2；3'), [1, 2, 3])
+    assert.deepEqual(parseDeleteSeqs('1 2'), [1, 2])
+    assert.deepEqual(parseDeleteSeqs('1  2   3'), [1, 2, 3])
+    assert.deepEqual(parseDeleteSeqs('1..2，4'), [1, 2, 4])
+    assert.deepEqual(parseDeleteSeqs('1..2'), [1, 2])
+    assert.deepEqual(parseDeleteSeqs('3..1'), [1, 2, 3])
+    assert.deepEqual(parseDeleteSeqs('1,1'), [1])
+    assert.deepEqual(parseDeleteSeqs('1..50,25..75'), [
+        ...Array.from({ length: 75 }, (_, i) => i + 1)
+    ])
+
+    // Titles with spaces / non-selector text stay intact (not batch).
+    assert.equal(parseDeleteSeqs('Claude Code 黑子'), undefined)
+    assert.equal(parseDeleteSeqs('hello,world'), undefined)
+    assert.equal(parseDeleteSeqs('1 and 2'), undefined)
+    assert.equal(parseDeleteSeqs(undefined), undefined)
+    assert.equal(parseDeleteSeqs(''), undefined)
+
+    // Invalid / over-limit pure selectors.
+    assert.equal(parseDeleteSeqs('1..101'), null)
+    assert.equal(
+        parseDeleteSeqs('999999999999999999999..999999999999999999999'),
+        null
+    )
+    assert.equal(parseDeleteSeqs('0'), null)
+    assert.equal(parseDeleteSeqs('1..0'), null)
+    assert.equal(parseDeleteSeqs(`1..${'9'.repeat(510)}`), null)
+    assert.equal(
+        parseDeleteSeqs(Array.from({ length: 101 }, (_, i) => i + 1).join(',')),
+        null
+    )
+})
 
 it('computeBaseBindingKey builds personal direct bindings', () => {
     const bindingKey = computeBaseBindingKey(


### PR DESCRIPTION
This pr improves conversation delete selectors and related resolve handling.

## Bug Fixes
- Parse multi-separator and range selectors for batch conversation delete.
- Keep title-like inputs from being treated as batch selectors.
- Support Gemini camel/snake includeServerSideToolInvocations key.

## Other Changes
- Ignore local .opencode workspace files.
- Move delete selector parsing into shared conversation utils with tests.

## Validation
- yarn lint-fix