### PR TITLE
fix(agent): polish agent console UI details

### DIFF
--- a/packages/extension-agent/client/components/mcp/mcp-servers-view.vue
+++ b/packages/extension-agent/client/components/mcp/mcp-servers-view.vue
@@ -63,57 +63,63 @@
                             </div>
                         </div>
 
-                        <div class="server-state" :class="stateClass(item)">
-                            <span class="state-dot" />
-                            <span>
-                                {{
-                                    stateLabel(
-                                        item.updating
-                                            ? 'reconnecting'
-                                            : item.status?.state
-                                    )
-                                }}
-                            </span>
+                        <div class="server-controls">
+                            <div class="server-state" :class="stateClass(item)">
+                                <span class="state-dot" />
+                                <span>
+                                    {{
+                                        stateLabel(
+                                            item.updating
+                                                ? 'reconnecting'
+                                                : item.status?.state
+                                        )
+                                    }}
+                                </span>
+                            </div>
+                            <el-switch
+                                :model-value="item.tools.some((t) => t.enabled)"
+                                :loading="serverToolsBusy[item.name]"
+                                :disabled="
+                                    serverToolsBusy[item.name] ||
+                                    item.updating ||
+                                    item.tools.length === 0 ||
+                                    item.tools.some((t) => t.updating)
+                                "
+                                @click.stop
+                                @change="toggleServerTools(item.name)"
+                            />
                         </div>
-                    </div>
-
-                    <div v-if="!props.hideDesc" class="server-summary">
-                        {{
-                            (item.updating && !item.status?.updating
-                                ? '正在重新连接服务器。'
-                                : item.status?.stateText) ||
-                            '尚未连接，等待首次初始化。'
-                        }}
                     </div>
 
                     <div class="server-meta">
-                        <div>
-                            <span>传输</span>
-                            <strong>{{ item.kind }}</strong>
-                        </div>
-                        <div>
-                            <span>工具</span>
-                            <strong>{{ item.tools.length }}</strong>
-                        </div>
-                        <div>
-                            <span>超时</span>
-                            <strong>{{ item.server.timeout ?? 60 }}s</strong>
-                        </div>
-                        <div v-if="item.status?.attempts">
-                            <span>重试</span>
-                            <strong>
-                                {{ item.status.attempts }}/{{
+                        <div class="meta-chips">
+                            <el-tag size="small" effect="plain" type="info">
+                                传输 {{ item.kind }}
+                            </el-tag>
+                            <el-tag size="small" effect="plain" type="success">
+                                工具 {{ item.tools.length }}
+                            </el-tag>
+                            <el-tag size="small" effect="plain" type="warning">
+                                超时 {{ item.server.timeout ?? 60 }}s
+                            </el-tag>
+                            <el-tag
+                                v-if="item.status?.attempts"
+                                size="small"
+                                effect="plain"
+                                type="danger"
+                            >
+                                重试 {{ item.status.attempts }}/{{
                                     item.status.maxAttempts ?? 5
                                 }}
-                            </strong>
+                            </el-tag>
                         </div>
-                        <div class="meta-wide">
+                        <div class="meta-endpoint">
                             <span>
                                 {{ item.kind === 'stdio' ? '命令' : '入口' }}
                             </span>
-                            <strong>
+                            <code :title="endpointLabel(item)">
                                 {{ endpointLabel(item) }}
-                            </strong>
+                            </code>
                         </div>
                     </div>
 
@@ -121,64 +127,56 @@
                         {{ item.status.error }}
                     </div>
 
-                    <div class="server-actions">
-                        <el-tooltip
-                            effect="dark"
-                            :content="
-                                item.tools.some((t) => t.enabled)
-                                    ? '禁用该服务器的所有工具'
-                                    : '启用该服务器的所有工具'
-                            "
-                            placement="top"
+                    <div class="server-footer">
+                        <el-dropdown
+                            trigger="click"
+                            @command="(cmd) => onServerMenu(cmd, item)"
                         >
-                            <span class="tooltip-trigger-wrapper">
-                                <el-button
-                                    size="small"
-                                    plain
-                                    :loading="serverToolsBusy[item.name]"
-                                    :disabled="
-                                        serverToolsBusy[item.name] ||
-                                        item.updating ||
-                                        item.tools.length === 0 ||
-                                        item.tools.some((t) => t.updating)
-                                    "
-                                    @click="toggleServerTools(item.name)"
-                                >
-                                    {{
-                                        item.tools.some((t) => t.enabled)
-                                            ? '禁用全部'
-                                            : '启用全部'
-                                    }}
-                                </el-button>
-                            </span>
-                        </el-tooltip>
-                        <el-button
-                            size="small"
-                            plain
-                            :disabled="item.updating"
-                            @click="openEdit(item.name)"
-                        >
-                            编辑
-                        </el-button>
-                        <el-button
-                            size="small"
-                            plain
-                            :loading="item.updating"
-                            :disabled="item.updating"
-                            @click="reconnect(item.name)"
-                        >
-                            {{ item.updating ? '重连中' : '重连' }}
-                        </el-button>
-                        <el-button
-                            class="danger-soft"
-                            size="small"
-                            type="danger"
-                            plain
-                            :disabled="item.updating"
-                            @click="removeServer(item.name)"
-                        >
-                            删除
-                        </el-button>
+                            <el-button
+                                class="more-btn"
+                                text
+                                :icon="More"
+                                @click.stop
+                            />
+                            <template #dropdown>
+                                <el-dropdown-menu>
+                                    <el-dropdown-item
+                                        command="toggle-tools"
+                                        :disabled="
+                                            serverToolsBusy[item.name] ||
+                                            item.updating ||
+                                            item.tools.length === 0 ||
+                                            item.tools.some((t) => t.updating)
+                                        "
+                                    >
+                                        {{
+                                            item.tools.some((t) => t.enabled)
+                                                ? '禁用全部工具'
+                                                : '启用全部工具'
+                                        }}
+                                    </el-dropdown-item>
+                                    <el-dropdown-item
+                                        command="edit"
+                                        :disabled="item.updating"
+                                    >
+                                        编辑
+                                    </el-dropdown-item>
+                                    <el-dropdown-item
+                                        command="reconnect"
+                                        :disabled="item.updating"
+                                    >
+                                        {{ item.updating ? '重连中' : '重连' }}
+                                    </el-dropdown-item>
+                                    <el-dropdown-item
+                                        command="remove"
+                                        divided
+                                        :disabled="item.updating"
+                                    >
+                                        删除
+                                    </el-dropdown-item>
+                                </el-dropdown-menu>
+                            </template>
+                        </el-dropdown>
                     </div>
                 </div>
             </div>
@@ -203,6 +201,11 @@
                     :key="item.name"
                     class="tool-card"
                     :class="{ busy: item.updating, centered: props.hideDesc }"
+                    role="button"
+                    tabindex="0"
+                    @click="openTool(item)"
+                    @keydown.enter.prevent="openTool(item)"
+                    @keydown.space.prevent="openTool(item)"
                 >
                     <div class="tool-top">
                         <div class="tool-brand">
@@ -222,7 +225,7 @@
                                     {{ item.title || item.name }}
                                 </div>
                                 <div v-if="!props.hideDesc" class="tool-name">
-                                    {{ item.name }}
+                                    {{ item.server }}
                                 </div>
                             </div>
                         </div>
@@ -231,6 +234,7 @@
                             :model-value="item.enabled"
                             :loading="item.updating"
                             :disabled="item.updating"
+                            @click.stop
                             @change="
                                 (value) => toggleTool(item, value as boolean)
                             "
@@ -239,17 +243,6 @@
 
                     <div v-if="!props.hideDesc" class="tool-description">
                         {{ item.description || '这个工具暂时没有说明。' }}
-                    </div>
-
-                    <div class="tool-actions">
-                        <el-button
-                            size="small"
-                            plain
-                            :disabled="item.updating"
-                            @click="openTool(item)"
-                        >
-                            编辑
-                        </el-button>
                     </div>
                 </div>
             </div>
@@ -574,7 +567,8 @@ import {
     RefreshRight,
     Tools,
     Menu,
-    Document
+    Document,
+    More
 } from '@element-plus/icons-vue'
 import type {
     McpConfig,
@@ -1086,6 +1080,34 @@ function openEdit(name: string) {
     showServerDialog.value = true
 }
 
+function onServerMenu(
+    command: string,
+    item: {
+        name: string
+        updating: boolean
+        tools: { enabled: boolean; updating?: boolean }[]
+    }
+) {
+    if (command === 'toggle-tools') {
+        toggleServerTools(item.name)
+        return
+    }
+
+    if (command === 'edit') {
+        openEdit(item.name)
+        return
+    }
+
+    if (command === 'reconnect') {
+        reconnect(item.name)
+        return
+    }
+
+    if (command === 'remove') {
+        removeServer(item.name)
+    }
+}
+
 function openTool(item: McpToolInfo) {
     toolForm.name = item.name
     toolForm.server = item.server
@@ -1325,15 +1347,24 @@ async function saveTool() {
 }
 
 .card-list {
-    --card-cols: 4;
+    --card-cols: 3;
     display: grid;
     grid-template-columns: repeat(var(--card-cols), minmax(0, 1fr));
     gap: 16px;
     box-sizing: border-box;
 }
 
-.card-list.compact {
+.server-grid,
+.server-grid.compact {
     --card-cols: 3;
+}
+
+.tool-grid {
+    --card-cols: 5;
+}
+
+.tool-grid.compact {
+    --card-cols: 4;
 }
 
 .server-card,
@@ -1454,6 +1485,7 @@ async function saveTool() {
 .server-state {
     display: inline-flex;
     align-items: center;
+    justify-content: flex-end;
     gap: 6px;
     flex: 0 0 auto;
     font-size: 12px;
@@ -1494,7 +1526,6 @@ async function saveTool() {
     background: var(--el-color-danger);
 }
 
-.server-summary,
 .tool-description {
     font-size: 12px;
     line-height: 1.6;
@@ -1502,65 +1533,119 @@ async function saveTool() {
     word-break: break-word;
     overflow-wrap: anywhere;
     display: -webkit-box;
-    -webkit-line-clamp: 3;
+    -webkit-line-clamp: 4;
     -webkit-box-orient: vertical;
     overflow: hidden;
 }
 
-.card-list.compact .server-summary,
-.card-list.compact .tool-description {
-    -webkit-line-clamp: 2;
+.tool-grid.compact .tool-description {
+    -webkit-line-clamp: 3;
 }
 
 .server-meta {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 10px 12px;
-}
-
-.server-meta > div {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
     min-width: 0;
 }
 
-.server-meta .meta-wide {
-    grid-column: 1 / -1;
+.meta-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    min-width: 0;
 }
 
-.server-meta span,
-.server-meta strong {
-    display: block;
+.meta-chips :deep(.el-tag) {
+    border-radius: 6px;
+}
+
+.meta-endpoint {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+}
+
+.meta-endpoint span {
     font-size: 11px;
-    line-height: 1.45;
-}
-
-.server-meta span {
+    line-height: 1.4;
     color: var(--k-text-light);
 }
 
-.server-meta strong {
-    margin-top: 2px;
+.meta-endpoint code {
+    display: block;
+    min-width: 0;
     color: var(--k-text-dark);
-    font-weight: 500;
-    overflow-wrap: anywhere;
+    font-family:
+        ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+        'Courier New', monospace;
+    font-size: 11px;
+    line-height: 1.5;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.server-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    flex: 0 0 auto;
+}
+
+.server-footer {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: auto;
+}
+
+.more-btn {
+    --el-button-text-color: var(--k-text-light);
+    --el-button-hover-text-color: var(--k-text-dark);
+    padding: 4px;
+    min-height: 28px;
+    min-width: 28px;
+}
+
+.more-btn :deep(.el-icon) {
+    transform: rotate(90deg);
+}
+
+.tool-card {
+    cursor: pointer;
 }
 
 @media (max-width: 1680px) {
-    .card-list {
+    .server-grid,
+    .server-grid.compact {
         --card-cols: 3;
     }
 
-    .card-list.compact {
-        --card-cols: 2;
+    .tool-grid {
+        --card-cols: 5;
+    }
+
+    .tool-grid.compact {
+        --card-cols: 4;
     }
 }
 
 @media (max-width: 1320px) {
-    .card-list {
+    .server-grid {
         --card-cols: 2;
     }
 
-    .card-list.compact {
-        --card-cols: 1;
+    .server-grid.compact {
+        --card-cols: 2;
+    }
+
+    .tool-grid {
+        --card-cols: 3;
+    }
+
+    .tool-grid.compact {
+        --card-cols: 2;
     }
 }
 
@@ -1574,39 +1659,6 @@ async function saveTool() {
     line-height: 1.45;
     word-break: break-word;
     overflow-wrap: anywhere;
-}
-
-.server-actions,
-.tool-actions {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(88px, 1fr));
-    gap: 8px;
-    margin-top: auto;
-}
-
-.server-actions :deep(.el-button),
-.tool-actions :deep(.el-button) {
-    width: 100%;
-    min-width: 0;
-    margin: 0;
-}
-
-.server-actions :deep(.danger-soft.el-button) {
-    --el-button-bg-color: color-mix(
-        in srgb,
-        var(--el-color-danger),
-        transparent 92%
-    );
-    --el-button-border-color: color-mix(
-        in srgb,
-        var(--el-color-danger),
-        transparent 68%
-    );
-    --el-button-text-color: color-mix(
-        in srgb,
-        var(--el-color-danger),
-        var(--k-text-dark) 22%
-    );
 }
 
 .empty-state {
@@ -1791,7 +1843,9 @@ async function saveTool() {
 
 @media (max-width: 768px) {
     .card-list,
-    .card-list.compact {
+    .card-list.compact,
+    .tool-grid,
+    .tool-grid.compact {
         --card-cols: 1;
         grid-template-columns: 1fr;
     }
@@ -1834,10 +1888,6 @@ async function saveTool() {
         grid-template-columns: 1fr;
     }
 
-    .server-meta {
-        grid-template-columns: minmax(0, 1fr);
-    }
-
     .server-head {
         flex-direction: column;
         gap: 10px;
@@ -1849,14 +1899,6 @@ async function saveTool() {
     }
 }
 
-.tooltip-trigger-wrapper {
-    display: inline-flex;
-    width: 100%;
-}
-
-.tooltip-trigger-wrapper :deep(.el-button) {
-    width: 100%;
-}
 
 .tooltip-trigger-wrapper :deep(.el-button.is-disabled),
 .tooltip-trigger-wrapper :deep(.el-button.is-loading) {

--- a/packages/extension-agent/client/components/skills/skills-detail.vue
+++ b/packages/extension-agent/client/components/skills/skills-detail.vue
@@ -10,7 +10,50 @@
         <div class="page-header">
             <div class="headline">
                 <div class="page-title">{{ skill.name }} Skill 设置</div>
-                <div class="page-description">调整当前 Skill 的注入方式与可见范围。</div>
+                <div class="page-tags">
+                    <el-tag
+                        size="small"
+                        effect="plain"
+                        :type="draft.main ? 'success' : 'info'"
+                    >
+                        主 Agent {{ draft.main ? '可用' : '不可用' }}
+                    </el-tag>
+                    <el-tag
+                        size="small"
+                        effect="plain"
+                        :type="draft.chatluna ? 'success' : 'info'"
+                    >
+                        主插件 {{ draft.chatluna ? '可用' : '不可用' }}
+                    </el-tag>
+                    <el-tag
+                        size="small"
+                        effect="plain"
+                        :type="draft.character ? 'warning' : 'info'"
+                    >
+                        伪装 {{ draft.character ? '可用' : '不可用' }}
+                    </el-tag>
+                    <el-tag
+                        v-if="skill.homepage"
+                        size="small"
+                        effect="plain"
+                        type="info"
+                        class="page-tag-link"
+                        @click="openHomepage"
+                    >
+                        主页
+                    </el-tag>
+                    <el-tag
+                        v-if="hasDiagnostics"
+                        size="small"
+                        effect="plain"
+                        type="danger"
+                    >
+                        有错误
+                    </el-tag>
+                </div>
+                <div v-if="hasDiagnostics" class="page-alert">
+                    当前 Skill 存在依赖或诊断问题，请检查配置后再启用。
+                </div>
             </div>
 
             <el-button type="primary" class="save-btn" @click="$emit('save')">
@@ -317,6 +360,31 @@ const tabs = [
     { value: 'subagent', label: 'Sub Agent 权限' }
 ] as const
 
+const hasDiagnostics = computed(() => {
+    return (
+        props.skill.state !== 'ready' ||
+        !props.skill.available ||
+        (props.skill.diagnostics?.length ?? 0) > 0
+    )
+})
+
+function openHomepage() {
+    const value = props.skill.homepage?.trim()
+    if (!value) return
+
+    try {
+        const parsed = new URL(value)
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+            ElMessage.warning('当前主页链接不是 http 或 https 地址。')
+            return
+        }
+
+        window.open(parsed.toString(), '_blank', 'noopener,noreferrer')
+    } catch {
+        ElMessage.warning('当前主页链接格式无效。')
+    }
+}
+
 const modeOptions = [
     { label: '描述', value: 'description' },
     { label: '全文', value: 'full' }
@@ -477,10 +545,26 @@ function agentLabel(item: SubAgentInfo) {
     color: var(--k-text-dark);
 }
 
-.page-description {
+.page-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 10px;
+}
+
+.page-tags :deep(.el-tag) {
+    border-radius: 6px;
+}
+
+.page-tag-link {
+    cursor: pointer;
+}
+
+.page-alert {
     margin-top: 8px;
-    font-size: 13px;
-    color: var(--k-text-light);
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--el-color-danger);
 }
 
 .back-link {

--- a/packages/extension-agent/client/components/skills/skills-page.vue
+++ b/packages/extension-agent/client/components/skills/skills-page.vue
@@ -199,92 +199,7 @@
                                 }}
                             </div>
 
-                            <div class="skill-chips">
-                                <el-tag
-                                    size="small"
-                                    effect="plain"
-                                    :type="item.main ? 'success' : 'info'"
-                                >
-                                    {{
-                                        item.main
-                                            ? '主 Agent 启用'
-                                            : '主 Agent 禁用'
-                                    }}
-                                </el-tag>
-                                <el-tag
-                                    size="small"
-                                    effect="plain"
-                                    :type="
-                                        item.chatlunaEnabled
-                                            ? 'success'
-                                            : 'info'
-                                    "
-                                >
-                                    {{
-                                        item.chatlunaEnabled
-                                            ? 'ChatLuna 启用'
-                                            : 'ChatLuna 禁用'
-                                    }}
-                                </el-tag>
-                                <el-tag
-                                    size="small"
-                                    effect="plain"
-                                    :type="
-                                        item.characterEnabled
-                                            ? 'success'
-                                            : 'info'
-                                    "
-                                >
-                                    {{
-                                        item.characterEnabled
-                                            ? 'Character 启用'
-                                            : 'Character 禁用'
-                                    }}
-                                </el-tag>
-                                <el-tag
-                                    size="small"
-                                    effect="plain"
-                                    :type="
-                                        subAgentModeType(item.subAgents.mode)
-                                    "
-                                >
-                                    {{ subAgentModeLabel(item.subAgents.mode) }}
-                                </el-tag>
-                            </div>
-
                             <div class="skill-footer">
-                                <div v-if="!hideDesc" class="skill-meta">
-                                    {{ item.path || '当前没有可用路径' }}
-                                </div>
-
-                                <div
-                                    v-if="!hideDesc && item.homepage"
-                                    class="skill-meta"
-                                >
-                                    主页：{{ item.homepage }}
-                                </div>
-
-                                <div
-                                    v-if="!hideDesc && item.compatibility"
-                                    class="skill-meta"
-                                >
-                                    兼容性：{{ item.compatibility }}
-                                </div>
-
-                                <div
-                                    v-if="!hideDesc && formatRequires(item)"
-                                    class="skill-meta"
-                                >
-                                    依赖要求：{{ formatRequires(item) }}
-                                </div>
-
-                                <div
-                                    v-if="!hideDesc && formatInstall(item)"
-                                    class="skill-meta"
-                                >
-                                    安装方式：{{ formatInstall(item) }}
-                                </div>
-
                                 <div class="skill-actions" @click.stop>
                                     <div class="skill-actions-main">
                                         <el-button
@@ -295,7 +210,7 @@
                                             "
                                             @click.stop="previewSkill(item)"
                                         >
-                                            查看/编辑内容
+                                            查看
                                         </el-button>
                                         <el-button
                                             size="small"
@@ -303,7 +218,7 @@
                                             :disabled="!canExport(item)"
                                             @click.stop="exportSkill(item)"
                                         >
-                                            导出 ZIP
+                                            导出
                                         </el-button>
                                         <el-button
                                             class="danger-soft"
@@ -317,25 +232,6 @@
                                             @click.stop="removeSkill(item)"
                                         >
                                             删除
-                                        </el-button>
-                                        <el-button
-                                            v-if="hasDiagnostics(item)"
-                                            class="warning-soft"
-                                            size="small"
-                                            plain
-                                            @click.stop="openDiagnostics(item)"
-                                        >
-                                            错误信息
-                                        </el-button>
-                                        <el-button
-                                            v-if="item.homepage"
-                                            size="small"
-                                            plain
-                                            @click.stop="
-                                                openLink(item.homepage)
-                                            "
-                                        >
-                                            打开主页
                                         </el-button>
                                     </div>
                                 </div>
@@ -724,18 +620,6 @@ function scheduleSave() {
     if (!dirty.value) return
     localDirty.value = true
     saveDraft()
-}
-
-function subAgentModeLabel(mode: PermissionRule['mode']) {
-    if (mode === 'allow') return '仅指定 sub-agent'
-    if (mode === 'deny') return '排除指定 sub-agent'
-    return '全部 sub-agent'
-}
-
-function subAgentModeType(mode: PermissionRule['mode']) {
-    if (mode === 'allow') return 'success'
-    if (mode === 'deny') return 'warning'
-    return 'info'
 }
 
 function cloneConfig(value: SkillsConfig): SkillsConfig {
@@ -1209,7 +1093,7 @@ function base64ToBlob(data: string, type: string) {
 }
 
 .card-list {
-    --card-cols: 5;
+    --card-cols: 4;
     display: grid;
     grid-template-columns: repeat(var(--card-cols), minmax(0, 1fr));
     gap: 16px;
@@ -1310,7 +1194,6 @@ function base64ToBlob(data: string, type: string) {
 
 .skill-name,
 .skill-description,
-.skill-meta,
 .preview-meta {
     margin-top: 4px;
     font-size: 12px;
@@ -1321,26 +1204,24 @@ function base64ToBlob(data: string, type: string) {
 
 .skill-description {
     display: -webkit-box;
-    -webkit-line-clamp: 3;
+    -webkit-line-clamp: 4;
     -webkit-box-orient: vertical;
     overflow: hidden;
+    min-height: calc(12px * 1.6 * 4);
+    height: calc(12px * 1.6 * 4);
 }
 
 .card-list.compact .skill-description {
-    -webkit-line-clamp: 2;
-}
-
-.skill-chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
+    -webkit-line-clamp: 4;
+    min-height: calc(12px * 1.6 * 4);
+    height: calc(12px * 1.6 * 4);
 }
 
 .skill-footer {
-    margin-top: auto;
+    margin-top: 4px;
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 10px;
 }
 
 .skill-actions {
@@ -1350,15 +1231,16 @@ function base64ToBlob(data: string, type: string) {
 }
 
 .skill-actions-main {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(108px, 1fr));
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
     gap: 8px;
+    min-width: 0;
 }
 
 .skill-actions-main :deep(.el-button) {
-    width: 100%;
-    min-width: 0;
     margin: 0;
+    padding-inline: 12px;
 }
 
 .skill-actions-main :deep(.danger-soft.el-button) {
@@ -1523,6 +1405,7 @@ function base64ToBlob(data: string, type: string) {
     .card-list,
     .card-list.compact {
         --card-cols: 1;
+        grid-template-columns: 1fr;
     }
 }
 </style>

--- a/packages/extension-agent/client/components/sub-agent/sub-agent-catalog.vue
+++ b/packages/extension-agent/client/components/sub-agent/sub-agent-catalog.vue
@@ -102,60 +102,14 @@
                     {{ item.description || '这个 agent 暂时没有说明。' }}
                 </div>
 
-                <div v-if="!props.hideDesc" class="agent-meta">
-                    <div class="agent-path">
-                        {{ item.path || item.preset || '内置定义' }}
-                    </div>
-                </div>
-
                 <div class="agent-footer">
-                    <div class="agent-tags">
-                        <el-tag v-if="item.scope" size="small" effect="plain">
-                            {{ item.scope }}
-                        </el-tag>
-                        <el-tag
-                            size="small"
-                            effect="plain"
-                            :type="item.enabled ? 'success' : 'info'"
-                        >
-                            {{ item.enabled ? '启用' : '禁用' }}
-                        </el-tag>
-                        <el-tag
-                            v-if="item.hidden"
-                            size="small"
-                            effect="plain"
-                            type="warning"
-                        >
-                            已隐藏
-                        </el-tag>
-                        <el-tag
-                            size="small"
-                            effect="plain"
-                            :type="
-                                item.state === 'ready' &&
-                                !item.hidden &&
-                                !item.shadowedBy
-                                    ? 'success'
-                                    : 'info'
-                            "
-                        >
-                            {{
-                                item.state === 'ready' &&
-                                !item.hidden &&
-                                !item.shadowedBy
-                                    ? '可用'
-                                    : '不可用'
-                            }}
-                        </el-tag>
-                    </div>
-
                     <div class="agent-actions" @click.stop>
                         <el-button
                             size="small"
                             plain
                             @click="$emit('preview', item)"
                         >
-                            查看/修改内容
+                            查看
                         </el-button>
                         <el-button
                             size="small"
@@ -163,7 +117,7 @@
                             :disabled="!canExport(item)"
                             @click="$emit('export', item)"
                         >
-                            导出 MD
+                            导出
                         </el-button>
                         <el-button
                             v-if="canRemove(item)"
@@ -175,19 +129,6 @@
                         >
                             删除
                         </el-button>
-                    </div>
-
-                    <div
-                        v-if="item.diagnostics.length > 0"
-                        class="diagnostic-box"
-                    >
-                        <div
-                            v-for="line in item.diagnostics.slice(0, 3)"
-                            :key="line"
-                            class="diagnostic-line"
-                        >
-                            {{ line }}
-                        </div>
                     </div>
                 </div>
             </div>
@@ -356,7 +297,7 @@ function canExport(item: SubAgentInfo) {
 }
 
 .card-list {
-    --card-cols: 5;
+    --card-cols: 4;
     display: grid;
     grid-template-columns: repeat(var(--card-cols), minmax(0, 1fr));
     gap: 16px;
@@ -376,6 +317,7 @@ function canExport(item: SubAgentInfo) {
     display: flex;
     flex-direction: column;
     gap: 12px;
+    min-width: 0;
     cursor: pointer;
     overflow: hidden;
     box-sizing: border-box;
@@ -441,9 +383,7 @@ function canExport(item: SubAgentInfo) {
 }
 
 .agent-name,
-.agent-desc,
-.agent-path,
-.diagnostic-line {
+.agent-desc {
     margin-top: 4px;
     font-size: 12px;
     line-height: 1.6;
@@ -453,13 +393,17 @@ function canExport(item: SubAgentInfo) {
 
 .agent-desc {
     display: -webkit-box;
-    -webkit-line-clamp: 3;
+    -webkit-line-clamp: 4;
     -webkit-box-orient: vertical;
     overflow: hidden;
+    min-height: calc(12px * 1.6 * 4);
+    height: calc(12px * 1.6 * 4);
 }
 
 .card-list.compact .agent-desc {
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: 4;
+    min-height: calc(12px * 1.6 * 4);
+    height: calc(12px * 1.6 * 4);
 }
 
 .agent-icon {
@@ -474,33 +418,24 @@ function canExport(item: SubAgentInfo) {
     flex: 0 0 auto;
 }
 
-.agent-path {
-    font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
-}
-
-.agent-tags {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-}
-
 .agent-footer {
-    margin-top: auto;
+    margin-top: 4px;
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 10px;
 }
 
 .agent-actions {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(108px, 1fr));
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
     gap: 8px;
+    min-width: 0;
 }
 
 .agent-actions :deep(.el-button) {
-    width: 100%;
-    min-width: 0;
     margin: 0;
+    padding-inline: 12px;
 }
 
 .agent-actions :deep(.danger-soft.el-button) {
@@ -519,12 +454,6 @@ function canExport(item: SubAgentInfo) {
         var(--el-color-danger),
         var(--k-text-dark) 22%
     );
-}
-
-.diagnostic-box {
-    padding: 12px 14px;
-    border-radius: 10px;
-    background: color-mix(in srgb, var(--el-color-warning), transparent 95%);
 }
 
 .empty-state {

--- a/packages/extension-agent/client/components/sub-agent/sub-agent-detail.vue
+++ b/packages/extension-agent/client/components/sub-agent/sub-agent-detail.vue
@@ -10,7 +10,41 @@
         <div class="page-header">
             <div class="headline">
                 <div class="page-title">{{ agent.name }} 配置</div>
-                <div class="page-description">调整当前 Sub Agent 的详细配置。</div>
+                <div class="page-tags">
+                    <el-tag
+                        size="small"
+                        effect="plain"
+                        :type="draft.chatluna ? 'success' : 'info'"
+                    >
+                        主插件 {{ draft.chatluna ? '可用' : '不可用' }}
+                    </el-tag>
+                    <el-tag
+                        size="small"
+                        effect="plain"
+                        :type="draft.character ? 'warning' : 'info'"
+                    >
+                        伪装 {{ draft.character ? '可用' : '不可用' }}
+                    </el-tag>
+                    <el-tag
+                        v-if="draft.hidden"
+                        size="small"
+                        effect="plain"
+                        type="danger"
+                    >
+                        已隐藏
+                    </el-tag>
+                    <el-tag
+                        v-if="hasDiagnostics"
+                        size="small"
+                        effect="plain"
+                        type="danger"
+                    >
+                        有错误
+                    </el-tag>
+                </div>
+                <div v-if="hasDiagnostics" class="page-alert">
+                    当前 Sub Agent 存在诊断问题，请检查配置后再启用。
+                </div>
             </div>
 
             <div class="editor-actions">
@@ -419,6 +453,13 @@ const tabs = [
     { value: 'feature', label: '功能权限' }
 ] as const
 
+const hasDiagnostics = computed(() => {
+    return (
+        props.agent.state !== 'ready' ||
+        (props.agent.diagnostics?.length ?? 0) > 0
+    )
+})
+
 const scopeOptions = [
     { label: '全局', value: 'all' },
     { label: '白名单', value: 'allow' },
@@ -571,10 +612,22 @@ function clearIds() {
     color: var(--k-text-dark);
 }
 
-.page-description {
+.page-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 10px;
+}
+
+.page-tags :deep(.el-tag) {
+    border-radius: 6px;
+}
+
+.page-alert {
     margin-top: 8px;
-    font-size: 13px;
-    color: var(--k-text-light);
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--el-color-danger);
 }
 
 .back-link {

--- a/packages/extension-agent/client/components/tool/tool-detail.vue
+++ b/packages/extension-agent/client/components/tool/tool-detail.vue
@@ -10,7 +10,29 @@
         <div class="page-header">
             <div class="headline">
                 <div class="page-title">{{ tool.name }} 工具设置</div>
-                <div class="page-description">调整当前工具的详细配置。</div>
+                <div class="page-tags">
+                    <el-tag
+                        size="small"
+                        effect="plain"
+                        :type="draft.main ? 'success' : 'info'"
+                    >
+                        主 Agent {{ draft.main ? '可用' : '不可用' }}
+                    </el-tag>
+                    <el-tag
+                        size="small"
+                        effect="plain"
+                        :type="draft.chatluna ? 'success' : 'info'"
+                    >
+                        主插件 {{ draft.chatluna ? '可用' : '不可用' }}
+                    </el-tag>
+                    <el-tag
+                        size="small"
+                        effect="plain"
+                        :type="draft.character ? 'warning' : 'info'"
+                    >
+                        伪装 {{ draft.character ? '可用' : '不可用' }}
+                    </el-tag>
+                </div>
             </div>
             
             <el-button type="primary" class="save-btn" @click="$emit('save')">
@@ -487,10 +509,15 @@ function agentLabel(item: SubAgentInfo) {
     color: var(--k-text-dark);
 }
 
-.page-description {
-    margin-top: 8px;
-    font-size: 13px;
-    color: var(--k-text-light);
+.page-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 10px;
+}
+
+.page-tags :deep(.el-tag) {
+    border-radius: 6px;
 }
 
 .back-link {

--- a/packages/extension-agent/client/components/tool/tool-page.vue
+++ b/packages/extension-agent/client/components/tool/tool-page.vue
@@ -715,13 +715,17 @@ function cloneRule(rule?: PermissionRule): PermissionRule {
 
 .tool-description {
     display: -webkit-box;
-    -webkit-line-clamp: 3;
+    -webkit-line-clamp: 4;
     -webkit-box-orient: vertical;
     overflow: hidden;
+    min-height: calc(12px * 1.6 * 4);
+    height: calc(12px * 1.6 * 4);
 }
 
 .card-list.compact .tool-description {
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: 4;
+    min-height: calc(12px * 1.6 * 4);
+    height: calc(12px * 1.6 * 4);
 }
 
 @media (max-width: 1680px) {

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-agent",
     "description": "Agent framework for ChatLuna",
-    "version": "1.0.39",
+    "version": "1.0.40",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -67,12 +67,12 @@
         "atsc": "^2.1.0",
         "koishi": "^4.18.9",
         "koishi-plugin-adapter-onebot": "^6.8.0",
-        "koishi-plugin-chatluna-agent": "^1.0.39"
+        "koishi-plugin-chatluna-agent": "^1.0.40"
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
         "koishi-plugin-chatluna": "^1.4.0-alpha.38",
-        "koishi-plugin-chatluna-agent": "^1.0.39",
+        "koishi-plugin-chatluna-agent": "^1.0.40",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -70,13 +70,13 @@
     "devDependencies": {
         "atsc": "^2.1.0",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna-agent": "^1.0.39",
+        "koishi-plugin-chatluna-agent": "^1.0.40",
         "koishi-plugin-puppeteer": "^3.9.0"
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
         "koishi-plugin-chatluna": "^1.4.0-alpha.38",
-        "koishi-plugin-chatluna-agent": "^1.0.39"
+        "koishi-plugin-chatluna-agent": "^1.0.40"
     },
     "peerDependenciesMeta": {
         "koishi-plugin-chatluna-agent": {


### PR DESCRIPTION
This pr polishes the agent console UI and bumps the agent package version.

## New Features
- None

## Bug Fixes
- None

## Other Changes
- Polish agent console UI for MCP servers, skills, sub-agent, and tool pages/details
- Bump `koishi-plugin-chatluna-agent` to `1.0.40` and sync dependent package ranges in `extension-tools` and `service-search`

## Validation
- yarn lint-fix (0 errors, 2 existing warnings)