### PR TITLE
fix(gemini): preserve thought signatures for tool calls

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -46,7 +46,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.45",
+        "@chatluna/v1-shared-adapter": "^1.0.46",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -47,7 +47,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.45",
+        "@chatluna/v1-shared-adapter": "^1.0.46",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.45",
+        "@chatluna/v1-shared-adapter": "^1.0.46",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.45",
+        "@chatluna/v1-shared-adapter": "^1.0.46",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.4.0-alpha.12",
+    "version": "1.4.0-alpha.13",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
     ],
     "dependencies": {
         "@anatine/zod-openapi": "^2.2.8",
-        "@chatluna/v1-shared-adapter": "^1.0.45",
+        "@chatluna/v1-shared-adapter": "^1.0.46",
         "@langchain/core": "^0.3.80",
         "openapi3-ts": "^4.5.0",
         "zod": "3.25.76",
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -738,7 +738,7 @@ export class GeminiRequester
         const sig = chunk['thoughtSignature']
         let thoughtData: Record<string, unknown> | undefined
         if (sig != null) {
-            const id = chunk['functionCall']?.id
+            const id = functionCall?.id ?? chunk['functionCall']?.id
             if (id != null) {
                 thoughtData = {
                     [id]: {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.45",
+        "@chatluna/v1-shared-adapter": "^1.0.46",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.45",
+        "@chatluna/v1-shared-adapter": "^1.0.46",
         "@langchain/core": "^0.3.80"
     },
     "devDependencies": {
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.45",
+        "@chatluna/v1-shared-adapter": "^1.0.46",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.45",
+        "@chatluna/v1-shared-adapter": "^1.0.46",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.45",
+        "@chatluna/v1-shared-adapter": "^1.0.46",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.45",
+        "@chatluna/v1-shared-adapter": "^1.0.46",
         "@langchain/core": "^0.3.80",
         "zod-to-json-schema": "3.23.5"
     },
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -61,7 +61,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.45",
+        "@chatluna/v1-shared-adapter": "^1.0.46",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.45",
+        "@chatluna/v1-shared-adapter": "^1.0.46",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.45",
+        "@chatluna/v1-shared-adapter": "^1.0.46",
         "@langchain/core": "^0.3.80",
         "jsonwebtoken": "^9.0.2",
         "zod": "3.25.76",
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.4.0-alpha.38",
+    "version": "1.4.0-alpha.39",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -22,6 +22,7 @@ import {
 import { parseRawModelName } from 'koishi-plugin-chatluna/llm-core/utils/count_tokens'
 import { getBase64EncodedSize } from 'koishi-plugin-chatluna/utils/base64'
 import type { QQ } from '@koishijs/plugin-adapter-qq'
+import { modelInfoSupportsElement } from '../../utils/model'
 import { parsePresetLaneInput } from '../../utils/message_content'
 
 const CHATLUNA_DOWNLOAD_USER_AGENT =
@@ -788,25 +789,11 @@ function modelSupportsElement(
     model: string | undefined,
     type: 'img' | 'file' | 'video' | 'audio'
 ) {
-    const info = model != null ? ctx.chatluna.platform.findModel(model) : null
-    if (info?.value == null) return true
-
-    switch (type) {
-        case 'img':
-            return info.value.capabilities.includes(
-                ModelCapabilities.ImageInput
-            )
-        case 'audio':
-            return info.value.capabilities.includes(
-                ModelCapabilities.AudioInput
-            )
-        case 'video':
-            return info.value.capabilities.includes(
-                ModelCapabilities.VideoInput
-            )
-        default:
-            return info.value.capabilities.includes(ModelCapabilities.FileInput)
-    }
+    if (model == null || model.length < 1) return false
+    return modelInfoSupportsElement(
+        ctx.chatluna.platform.findModel(model).value,
+        type
+    )
 }
 
 function setElementUrl(element: h, url: string) {

--- a/packages/core/src/utils/model.ts
+++ b/packages/core/src/utils/model.ts
@@ -1,3 +1,8 @@
+import {
+    ModelCapabilities,
+    ModelInfo
+} from 'koishi-plugin-chatluna/llm-core/platform/types'
+
 export function parseRawModelName(
     modelName: string
 ): [string | undefined, string | undefined] {
@@ -17,4 +22,22 @@ export function parseRawModelName(
     }
 
     return [value.slice(0, index), value.slice(index + 1)]
+}
+
+export function modelInfoSupportsElement(
+    info: ModelInfo | undefined,
+    type: 'img' | 'file' | 'video' | 'audio'
+) {
+    if (info == null) return false
+
+    switch (type) {
+        case 'img':
+            return info.capabilities.includes(ModelCapabilities.ImageInput)
+        case 'audio':
+            return info.capabilities.includes(ModelCapabilities.AudioInput)
+        case 'video':
+            return info.capabilities.includes(ModelCapabilities.VideoInput)
+        default:
+            return info.capabilities.includes(ModelCapabilities.FileInput)
+    }
 }

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -91,7 +91,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39",
         "koishi-plugin-chatluna-agent": "^1.0.40",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },

--- a/packages/extension-usage/package.json
+++ b/packages/extension-usage/package.json
@@ -61,7 +61,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39",
         "koishi-plugin-puppeteer": "^3.9.0"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "koishi": {
         "description": {

--- a/packages/service-multimodal/package.json
+++ b/packages/service-multimodal/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39",
         "koishi-plugin-ffmpeg-path": "^2.0.0"
     },
     "peerDependenciesMeta": {

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39",
         "koishi-plugin-chatluna-agent": "^1.0.40"
     },
     "peerDependenciesMeta": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@chatluna/v1-shared-adapter",
     "description": "chatluna shared adapter",
-    "version": "1.0.45",
+    "version": "1.0.46",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.38"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.39"
     }
 }

--- a/packages/shared-adapter/src/client.ts
+++ b/packages/shared-adapter/src/client.ts
@@ -123,6 +123,8 @@ export function getModelMaxContextSize(info: ModelInfo): number {
         'gemini-3.1-pro': 1_097_152,
         'gemini-2.0': 2097152,
         deepseek: 1_000_000,
+        'grok-4.5': 500_000,
+        'grok-4.3': 1_000_000,
         'llama3.1': 128000,
         'command-r-plus': 128000,
         'moonshot-v1-8k': 8192,


### PR DESCRIPTION
This pr fixes Gemini tool-call thought signature handling, adds grok context sizes, and bumps related package versions.

Closes https://github.com/ChatLunaLab/chatluna/issues/970

## New Features
- Add `grok-4.5` / `grok-4.3` max context size mappings

## Bug Fixes
- Fix Gemini adapter storing thought signatures under the normalized tool call id so second-round tool requests keep `thoughtSignature`
- Tighten model capability checks when model info is missing

## Other Changes
- Bump `koishi-plugin-chatluna` to `1.4.0-alpha.39`
- Bump `@chatluna/v1-shared-adapter` to `1.0.46`
- Bump `koishi-plugin-chatluna-google-gemini-adapter` to `1.4.0-alpha.13`
- Sync peer dependency ranges across packages

## Validation
- yarn lint-fix (0 errors, 2 existing warnings)