### PR TITLE
fix(claude): improve model listing and context sizes

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -46,7 +46,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.46",
+        "@chatluna/v1-shared-adapter": "^1.0.47",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-claude-adapter",
     "description": "claude adapter for chatluna",
-    "version": "1.4.0-alpha.8",
+    "version": "1.4.0-alpha.9",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -47,7 +47,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.46",
+        "@chatluna/v1-shared-adapter": "^1.0.47",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-claude/src/client.ts
+++ b/packages/adapter-claude/src/client.ts
@@ -13,6 +13,10 @@ import {
 import { Config, logger } from '.'
 import { ClaudeRequester } from './requester'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
+import {
+    getModelMaxContextSizeByName,
+    supportImageInput
+} from '@chatluna/v1-shared-adapter'
 
 import type { ModelUsageReporter } from 'koishi-plugin-chatluna/llm-core/platform/usage'
 
@@ -86,26 +90,11 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
             return additionalModels
         }
 
-        const fallbackModels = [
-            'claude-3-5-sonnet-20241022',
-            'claude-3-7-sonnet-20250219',
-            'claude-opus-4-20250514',
-            'claude-sonnet-4-20250514',
-            'claude-sonnet-4-5-20250929',
-            'claude-opus-4-5-20251101',
-            'claude-opus-4-6',
-            'claude-opus-4-7',
-            'claude-sonnet-4-6',
-            'claude-opus-4-1-20250805',
-            'claude-haiku-4-5-20251001',
-            'claude-3-5-haiku-20241022'
-        ]
-
         let fetchedModels: ModelInfo[] = []
 
         try {
             // Anthropic lists newer models first; we keep the API order.
-            const modelIds: string[] = []
+            const models = new Set<string>()
             let afterId: string | undefined
 
             // Page through /v1/models until has_more is false.
@@ -116,26 +105,15 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
                 })
 
                 for (const item of resp.data ?? []) {
-                    if (item?.id) modelIds.push(item.id)
+                    if (item?.id) models.add(item.id)
                 }
 
                 if (!resp.has_more || !resp.last_id) break
                 afterId = resp.last_id
             }
 
-            const uniqueModels = Array.from(new Set(modelIds))
-            if (uniqueModels.length > 0) {
-                fetchedModels = uniqueModels.map((model) => ({
-                    name: model,
-                    // Use a fixed max context length (200K) for Claude models.
-                    maxTokens: 200_000,
-                    capabilities: [
-                        ModelCapabilities.ToolCall,
-                        ModelCapabilities.ImageInput,
-                        ModelCapabilities.FileInput
-                    ],
-                    type: ModelType.llm
-                }))
+            if (models.size > 0) {
+                fetchedModels = Array.from(models).map(createModelInfo)
             }
         } catch (e) {
             logger.warn(
@@ -145,17 +123,7 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
         }
 
         if (fetchedModels.length === 0) {
-            fetchedModels = fallbackModels.map((model) => ({
-                name: model,
-                // Use a fixed max context length (200K) for Claude models.
-                maxTokens: 200_000,
-                capabilities: [
-                    ModelCapabilities.ToolCall,
-                    ModelCapabilities.ImageInput,
-                    ModelCapabilities.FileInput
-                ],
-                type: ModelType.llm
-            }))
+            fetchedModels = FALLBACK_MODELS.map(createModelInfo)
         }
 
         this._requester.setModels(
@@ -219,8 +187,58 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
 }
 
 const THINKING_MODELS = [
-    'claude-3-7-sonnet-',
-    'claude-opus-4',
-    'claude-sonnet-4',
+    'claude-opus-4-5',
+    'claude-opus-4-6',
+    'claude-sonnet-4-5',
     'claude-haiku-4-5'
 ]
+
+const CLAUDE_1M_MODELS = [
+    'claude-fable-5',
+    'claude-mythos-5',
+    'claude-mythos-preview',
+    'claude-opus-4-8',
+    'claude-opus-4-7',
+    'claude-opus-4-6',
+    'claude-sonnet-5',
+    'claude-sonnet-4-6'
+]
+
+const FALLBACK_MODELS = [
+    'claude-fable-5',
+    'claude-opus-4-8',
+    'claude-sonnet-5',
+    'claude-opus-4-7',
+    'claude-opus-4-6',
+    'claude-opus-4-5-20251101',
+    'claude-sonnet-4-5-20250929',
+    'claude-haiku-4-5-20251001'
+]
+
+function createModelInfo(name: string): ModelInfo {
+    if (!name.toLowerCase().includes('claude')) {
+        const capabilities = [ModelCapabilities.ToolCall]
+        if (supportImageInput(name)) {
+            capabilities.push(ModelCapabilities.ImageInput)
+        }
+        return {
+            name,
+            type: ModelType.llm,
+            maxTokens: getModelMaxContextSizeByName(name),
+            capabilities
+        }
+    }
+
+    return {
+        name,
+        type: ModelType.llm,
+        maxTokens: CLAUDE_1M_MODELS.some((item) => name.includes(item))
+            ? 1_000_000
+            : 200_000,
+        capabilities: [
+            ModelCapabilities.ToolCall,
+            ModelCapabilities.ImageInput,
+            ModelCapabilities.FileInput
+        ]
+    }
+}

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.46",
+        "@chatluna/v1-shared-adapter": "^1.0.47",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.46",
+        "@chatluna/v1-shared-adapter": "^1.0.47",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -63,7 +63,7 @@
     ],
     "dependencies": {
         "@anatine/zod-openapi": "^2.2.8",
-        "@chatluna/v1-shared-adapter": "^1.0.46",
+        "@chatluna/v1-shared-adapter": "^1.0.47",
         "@langchain/core": "^0.3.80",
         "openapi3-ts": "^4.5.0",
         "zod": "3.25.76",

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.46",
+        "@chatluna/v1-shared-adapter": "^1.0.47",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.46",
+        "@chatluna/v1-shared-adapter": "^1.0.47",
         "@langchain/core": "^0.3.80"
     },
     "devDependencies": {

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.46",
+        "@chatluna/v1-shared-adapter": "^1.0.47",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.46",
+        "@chatluna/v1-shared-adapter": "^1.0.47",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.46",
+        "@chatluna/v1-shared-adapter": "^1.0.47",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.46",
+        "@chatluna/v1-shared-adapter": "^1.0.47",
         "@langchain/core": "^0.3.80",
         "zod-to-json-schema": "3.23.5"
     },

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -61,7 +61,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.46",
+        "@chatluna/v1-shared-adapter": "^1.0.47",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.46",
+        "@chatluna/v1-shared-adapter": "^1.0.47",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.46",
+        "@chatluna/v1-shared-adapter": "^1.0.47",
         "@langchain/core": "^0.3.80",
         "jsonwebtoken": "^9.0.2",
         "zod": "3.25.76",

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@chatluna/v1-shared-adapter",
     "description": "chatluna shared adapter",
-    "version": "1.0.46",
+    "version": "1.0.47",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/shared-adapter/src/client.ts
+++ b/packages/shared-adapter/src/client.ts
@@ -93,13 +93,12 @@ export function isRerankerModel(modelName: string): boolean {
 }
 
 export function getModelMaxContextSize(info: ModelInfo): number {
-    const maxTokens = info.maxTokens
+    if (info.maxTokens != null) return info.maxTokens
+    return getModelMaxContextSizeByName(info.name)
+}
 
-    if (maxTokens != null) {
-        return maxTokens
-    }
-
-    const modelName = normalizeOpenAIModelName(info.name)
+export function getModelMaxContextSizeByName(name: string): number {
+    const modelName = normalizeOpenAIModelName(name)
 
     if (
         modelName.startsWith('gpt') ||
@@ -112,7 +111,13 @@ export function getModelMaxContextSize(info: ModelInfo): number {
 
     // compatible with Anthropic, Google, ...
     const modelMaxContextSizeTable: { [key: string]: number } = {
-        claude: 2000000,
+        'claude-fable-5': 1_000_000,
+        'claude-opus-4-8': 1_000_000,
+        'claude-opus-4-7': 1_000_000,
+        'claude-opus-4-6': 1_000_000,
+        'claude-sonnet-5': 1_000_000,
+        'claude-sonnet-4-6': 1_000_000,
+        claude: 200_000,
         'gemini-1.5-pro': 1048576,
         'gemini-1.5-flash': 2097152,
         'gemini-1.0-pro': 30720,
@@ -126,6 +131,7 @@ export function getModelMaxContextSize(info: ModelInfo): number {
         'grok-4.5': 500_000,
         'grok-4.3': 1_000_000,
         'llama3.1': 128000,
+        'glm-5.2': 1_000_000,
         'command-r-plus': 128000,
         'moonshot-v1-8k': 8192,
         'moonshot-v1-32k': 32000,


### PR DESCRIPTION
This pr improves Claude model listing/context sizing and updates shared model context mappings.

## New Features
- Add Claude 1M context model mappings and updated fallback model list
- Add `glm-5.2` max context size mapping

## Bug Fixes
- Build Claude model info from API results with correct context window sizes
- Use shared helpers for non-Claude model context/image capability detection

## Other Changes
- Bump `koishi-plugin-chatluna-claude-adapter` to `1.4.0-alpha.9`
- Bump `@chatluna/v1-shared-adapter` to `1.0.47` and sync adapter dependencies

## Validation
- yarn lint-fix (0 errors, 2 existing warnings)