### PR TITLE
fix(core): stabilize message queue and thinking timeout

### DIFF
--- a/packages/core/src/chains/chain.ts
+++ b/packages/core/src/chains/chain.ts
@@ -46,6 +46,7 @@ export class ChatChain {
             timeoutObj.autoRecallTimeout &&
                 clearTimeout(timeoutObj.autoRecallTimeout)
 
+            timeoutObj.setQueueCount(0)
             timeoutObj.recallFunc && (await timeoutObj.recallFunc())
 
             timeoutObj.timeout = null
@@ -71,11 +72,12 @@ export class ChatChain {
         context.recallThinkingMessage =
             this._createRecallThinkingMessage(context)
 
-        const result = await this._runMiddleware(session, context)
-
-        await context.recallThinkingMessage()
-
-        return result
+        try {
+            return await this._runMiddleware(session, context)
+        } finally {
+            await context.options.completeMessageTurn?.()
+            await context.recallThinkingMessage()
+        }
     }
 
     async receiveCommand(
@@ -124,11 +126,13 @@ export class ChatChain {
         context.recallThinkingMessage =
             this._createRecallThinkingMessage(context)
 
-        const ok = await this._runMiddleware(session, context)
-
-        await context.recallThinkingMessage()
-
-        return { ok, context }
+        try {
+            const ok = await this._runMiddleware(session, context)
+            return { ok, context }
+        } finally {
+            await context.options.completeMessageTurn?.()
+            await context.recallThinkingMessage()
+        }
     }
 
     middleware<T extends keyof ChainMiddlewareName>(

--- a/packages/core/src/middlewares/chat/message_delay.ts
+++ b/packages/core/src/middlewares/chat/message_delay.ts
@@ -130,38 +130,9 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
         .after('transform_chat_message')
         .before('lifecycle-handle_command')
 
-    const completeTurn = async (conversationId: string) => {
-        const conversation = queues.get(conversationId)
-        if (!conversation) {
-            return
-        }
-
-        const current = conversation.turns.shift()
-        conversation.inFlight = false
-
-        if (current?.timeout) {
-            current.timeout()
-        }
-        if (current?.starter) {
-            current.starter.resolve(ChainMiddlewareRunStatus.STOP)
-            current.starter = undefined
-        }
-
-        if (conversation.turns.length === 0) {
-            queues.delete(conversationId)
-            return
-        }
-
-        tryStartHeadTurn(conversationId, conversation)
-
-        if (current) {
-            logger.debug(
-                `Completing turn for ${conversationId}, remaining: ${conversation.turns.length}`
-            )
-        }
-    }
-
-    ctx.on('chatluna/after-chat', completeTurn)
+    ctx.on('chatluna/after-chat', (conversationId) =>
+        completeTurn(conversationId)
+    )
 
     ctx.on('chatluna/after-chat-error', (_error, conversationId) =>
         completeTurn(conversationId)
@@ -207,6 +178,40 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
     ctx.on('chatluna/after-conversation-delete', async (payload) =>
         clearTurn(payload.conversation.id)
     )
+}
+
+async function completeTurn(conversationId: string, expected?: MessageTurn) {
+    const conversation = queues.get(conversationId)
+    if (
+        !conversation ||
+        (expected != null && conversation.turns[0] !== expected)
+    ) {
+        return
+    }
+
+    const current = conversation.turns.shift()
+    conversation.inFlight = false
+
+    if (current?.timeout) {
+        current.timeout()
+    }
+    if (current?.starter) {
+        current.starter.resolve(ChainMiddlewareRunStatus.STOP)
+        current.starter = undefined
+    }
+
+    if (conversation.turns.length === 0) {
+        queues.delete(conversationId)
+        return
+    }
+
+    tryStartHeadTurn(conversationId, conversation)
+
+    if (current) {
+        logger.debug(
+            `Completing turn for ${conversationId}, remaining: ${conversation.turns.length}`
+        )
+    }
 }
 
 function awaitTurnStart(
@@ -294,6 +299,8 @@ function startHeadTurn(
 
     conversation.inFlight = true
     head.state = 'processing'
+    starter.context.options.completeMessageTurn = () =>
+        completeTurn(conversationId, head)
     starter.context.options.inputMessage = mergeMessages(
         head.messages
             .sort((a, b) => a.timestamp - b.timestamp)
@@ -363,5 +370,6 @@ declare module '../../chains/chain' {
 
     interface ChainMiddlewareContextOptions {
         messageId?: string
+        completeMessageTurn?: () => Promise<void>
     }
 }

--- a/packages/core/src/middlewares/chat/thinking_message_send.ts
+++ b/packages/core/src/middlewares/chat/thinking_message_send.ts
@@ -1,11 +1,8 @@
 import { Context, Logger } from 'koishi'
 import { Config } from '../../config'
-import {
-    ChainMiddlewareContextOptions,
-    ChainMiddlewareRunStatus,
-    ChatChain
-} from '../../chains/chain'
+import { ChainMiddlewareRunStatus, ChatChain } from '../../chains/chain'
 import { createLogger } from 'koishi-plugin-chatluna/utils/logger'
+import { withResolver } from 'koishi-plugin-chatluna/utils/promise'
 
 let logger: Logger
 
@@ -17,14 +14,15 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 return ChainMiddlewareRunStatus.SKIPPED
             }
 
-            const thinkingTimeoutObject: ThinkingTimeoutObject = {}
+            const queue = withResolver<number>()
+            const thinkingTimeoutObject: ThinkingTimeoutObject = {
+                queueCount: queue.promise,
+                setQueueCount: queue.resolve
+            }
             context.options.thinkingTimeoutObject = thinkingTimeoutObject
 
             thinkingTimeoutObject.timeout = setTimeout(async () => {
-                const queueCount = await getQueueCount(
-                    thinkingTimeoutObject,
-                    context.options
-                )
+                const queueCount = await thinkingTimeoutObject.queueCount
 
                 if (thinkingTimeoutObject.timeout == null || queueCount < 1) {
                     return
@@ -63,23 +61,9 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
         .before('lifecycle-prepare')
 }
 
-async function getQueueCount(
-    obj: ThinkingTimeoutObject,
-    options: ChainMiddlewareContextOptions
-) {
-    await new Promise((resolve, reject) => {
-        const timer = setInterval(() => {
-            if (obj.timeout != null && options.queueCount != null) {
-                clearInterval(timer)
-                resolve(undefined)
-            }
-        })
-    })
-
-    return options.queueCount
-}
-
 export interface ThinkingTimeoutObject {
+    queueCount: Promise<number>
+    setQueueCount: (count: number) => void
     timeout?: NodeJS.Timeout
     recallFunc?: () => PromiseLike<void>
     autoRecallTimeout?: NodeJS.Timeout

--- a/packages/core/src/middlewares/conversation/request_conversation.ts
+++ b/packages/core/src/middlewares/conversation/request_conversation.ts
@@ -193,7 +193,7 @@ function createChatCallbacks(
                   await stream.write({ type: 'content', chunk })
               },
         'llm-queue-waiting': async (count: number) => {
-            context.options.queueCount = count
+            context.options.thinkingTimeoutObject?.setQueueCount(count)
         },
         'llm-usage': async (usage: UsageMetadata) => {
             if (context.options.invocation != null) {
@@ -293,6 +293,5 @@ declare module '../../chains/chain' {
         responseMessage?: Message
         finalResponseMessage?: Message
         inputMessage?: Message
-        queueCount?: number
     }
 }

--- a/packages/core/src/services/conversation_runtime.ts
+++ b/packages/core/src/services/conversation_runtime.ts
@@ -80,7 +80,8 @@ export class ConversationRuntime {
                     message,
                     options
                 ),
-            options.signal
+            options.signal,
+            options.event?.['llm-queue-waiting']
         )
     }
 
@@ -268,7 +269,8 @@ export class ConversationRuntime {
     async withConversationAndPlatformLock<T>(
         conversation: ConversationRecord,
         callback: (config: ClientConfig) => Promise<T>,
-        signal?: AbortSignal
+        signal?: AbortSignal,
+        onQueueWaiting?: ChatEvents['llm-queue-waiting']
     ): Promise<T> {
         const requestId = randomUUID()
         const modelRequestId = randomUUID()
@@ -293,6 +295,13 @@ export class ConversationRuntime {
                 this.conversationQueue.add(conversation.id, requestId),
                 this.modelQueue.add(platform, modelRequestId)
             ])
+            if (onQueueWaiting != null) {
+                const sizes = await Promise.all([
+                    this.conversationQueue.getQueueLength(conversation.id),
+                    this.modelQueue.getQueueLength(platform)
+                ])
+                await onQueueWaiting(Math.max(...sizes))
+            }
             const waiting = Promise.all([
                 this.conversationQueue.wait(
                     conversation.id,


### PR DESCRIPTION
This pr stabilizes conversation message turn completion and thinking-message queue waiting to avoid race/crash paths.

## New Features
- None

## Bug Fixes
- Complete message turns in `ChatChain` finally blocks so queue cleanup always runs
- Bind `completeMessageTurn` to the active turn to avoid completing the wrong queued turn
- Replace thinking-message queue polling with a promise resolver for queue count
- Report queue waiting length when acquiring conversation/platform locks

## Other Changes
- None

## Validation
- yarn lint-fix (0 errors, 2 existing warnings)