### PR TITLE
fix(core): wrap split render parts as messages

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.4.0-alpha.40",
+    "version": "1.4.0-alpha.41",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/core/src/render/base.ts
+++ b/packages/core/src/render/base.ts
@@ -107,7 +107,14 @@ export abstract class BufferedRenderStreamSession implements RenderStreamSession
 
         const result: h[] = []
         for (const part of parts) {
-            result.push(...(await this.renderText(part)))
+            const elements = await this.renderText(part)
+            result.push(
+                ...(this.options.split && this.options.split !== 'none'
+                    ? elements.map((el) =>
+                          el.type === 'message' ? el : h('message', el)
+                      )
+                    : elements)
+            )
         }
         return result.length > 0 ? result : null
     }

--- a/packages/core/src/render/koishi-element.ts
+++ b/packages/core/src/render/koishi-element.ts
@@ -74,7 +74,12 @@ class KoishiElementStreamSession implements RenderStreamSession {
             return transformAndEscape([h.text(this.text + '●')])
         }
 
-        const elements = this.splitter.writeText(text)
+        let elements = this.splitter.writeText(text)
+        if (this.options.split && this.options.split !== 'none') {
+            elements = elements.map((el) =>
+                el.type === 'message' ? el : h('message', el)
+            )
+        }
         return elements.length > 0 ? elements : null
     }
 
@@ -84,7 +89,12 @@ class KoishiElementStreamSession implements RenderStreamSession {
             return transformAndEscape([h.text(this.text)])
         }
 
-        const elements = this.splitter.flush()
+        let elements = this.splitter.flush()
+        if (this.options.split && this.options.split !== 'none') {
+            elements = elements.map((el) =>
+                el.type === 'message' ? el : h('message', el)
+            )
+        }
         return elements.length > 0 ? elements : null
     }
 }

--- a/packages/core/src/render/stream.ts
+++ b/packages/core/src/render/stream.ts
@@ -174,7 +174,7 @@ export class ReplyStream {
             return await this.queue.edit(processed)
         }
 
-        await this.context.send(processed)
+        await this.context.send([processed])
     }
 
     private async censor(elements: h[]) {

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -91,7 +91,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41",
         "koishi-plugin-chatluna-agent": "^1.0.41",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },

--- a/packages/extension-usage/package.json
+++ b/packages/extension-usage/package.json
@@ -61,7 +61,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41",
         "koishi-plugin-puppeteer": "^3.9.0"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "koishi": {
         "description": {

--- a/packages/service-multimodal/package.json
+++ b/packages/service-multimodal/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41",
         "koishi-plugin-ffmpeg-path": "^2.0.0"
     },
     "peerDependenciesMeta": {

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41",
         "koishi-plugin-chatluna-agent": "^1.0.41"
     },
     "peerDependenciesMeta": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.40"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
     }
 }


### PR DESCRIPTION
This pr fixes split markdown/element rendering so each split part is sent as a separate message.

## New Features
- None

## Bug Fixes
- Wrap non-message elements in `h('message')` when split mode is enabled for text and koishi-element renderers
- Send stream reply content as a message array so split parts dispatch correctly

## Other Changes
- Bump `koishi-plugin-chatluna` to `1.4.0-alpha.41` and sync peer dependency ranges

## Validation
- yarn lint-fix (0 errors, 2 existing warnings)