### PR TITLE
fix(gemini): serialize multimodal tool responses correctly

### DIFF
--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.4.0-alpha.14",
+    "version": "1.4.0-alpha.15",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-gemini/src/types.ts
+++ b/packages/adapter-gemini/src/types.ts
@@ -81,9 +81,8 @@ export type ChatFunctionCallingPart = {
 export type ChatFunctionResponsePart = {
     functionResponse: {
         name: string
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        response?: any
-        parts?: (ChatMessagePart | ChatInlineDataPart | ChatUploadDataPart)[]
+        response: Record<string, unknown>
+        parts?: (ChatInlineDataPart | ChatUploadDataPart)[]
         id?: string
     }
 }

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -145,13 +145,18 @@ export function extractSystemMessages(
     ]
 }
 
-function parseJsonArgs(args: string) {
+function parseJsonArgs(args: string): Record<string, unknown> {
     try {
-        const result = JSON.parse(args)
-        if (typeof result === 'string') return { response: result }
-        if (Array.isArray(result)) return { response: result }
+        const result: unknown = JSON.parse(args)
+        if (
+            typeof result === 'object' &&
+            result != null &&
+            !Array.isArray(result)
+        ) {
+            return result as Record<string, unknown>
+        }
 
-        return result
+        return { response: result }
     } catch {
         return { response: args }
     }
@@ -222,19 +227,35 @@ async function processFunctionMessage(
 
     const finalMessage = message as ToolMessage
 
-    const functionResponse: ChatFunctionResponsePart['functionResponse'] =
-        Array.isArray(message.content)
-            ? {
-                  name: message.name,
-                  parts: await processGeminiContentParts(
-                      plugin,
-                      message.content
-                  )
-              }
-            : {
-                  name: message.name,
-                  response: parseJsonArgs(message.content as string)
-              }
+    const functionResponse: ChatFunctionResponsePart['functionResponse'] = {
+        name: message.name,
+        response: {}
+    }
+
+    if (Array.isArray(message.content)) {
+        const texts = message.content.flatMap((part) => {
+            if (isMessageContentText(part)) return [part.text]
+            return []
+        })
+
+        if (texts.length > 0) {
+            functionResponse.response = parseJsonArgs(texts.join(''))
+        }
+
+        const parts = await processGeminiContentParts(
+            plugin,
+            message.content.filter(
+                (part) =>
+                    isMessageContentImageUrl(part) ||
+                    isGeminiFileLikeContent(part)
+            )
+        )
+        if (parts.length > 0) {
+            functionResponse.parts = parts
+        }
+    } else {
+        functionResponse.response = parseJsonArgs(message.content as string)
+    }
 
     if (!removeId || finalMessage.tool_call_id) {
         functionResponse.id = finalMessage.tool_call_id


### PR DESCRIPTION
This pr fixes Gemini FunctionResponse serialization for multimodal tool results.

Closes https://github.com/ChatLunaLab/chatluna/issues/977

## New Features
- None

## Bug Fixes
- Put tool text/JSON content into `functionResponse.response` instead of `parts`
- Keep image/file/audio/video tool content in `functionResponse.parts`
- Always provide a `response` object for FunctionResponse payloads

## Other Changes
- Tighten Gemini `ChatFunctionResponsePart` typing

## Validation
- yarn lint-fix (0 errors, 2 existing warnings)