### PR TITLE
fix(renderer-image): support bold markdown beside CJK text

### DIFF
--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-image-renderer",
     "description": "image renderer for chatluna",
-    "version": "1.4.0-alpha.0",
+    "version": "1.4.0-alpha.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/renderer-image/src/renders/image.ts
+++ b/packages/renderer-image/src/renders/image.ts
@@ -23,6 +23,7 @@ import {
 import { MessageContent } from '@langchain/core/messages'
 import type {} from 'koishi-plugin-puppeteer'
 import { Config } from '..'
+import { relaxedStrong } from '../utils'
 import path from 'path'
 import fs from 'fs/promises'
 
@@ -69,7 +70,8 @@ export class ImageRenderer extends Renderer {
                         hljs.highlightAuto(code, [lang]).value
                     }</code></pre>`
                 }
-            })
+            }),
+            relaxedStrong
         )
 
         ctx.on('dispose', async () => {

--- a/packages/renderer-image/src/renders/mixed-image.ts
+++ b/packages/renderer-image/src/renders/mixed-image.ts
@@ -26,6 +26,7 @@ import {
     renderTemplate,
     transformMessageContentToMarkdown
 } from './image'
+import { relaxedStrong } from '../utils'
 import fs from 'fs/promises'
 
 let logger: Logger
@@ -65,7 +66,8 @@ export class MixedImageRenderer extends Renderer {
                         hljs.highlightAuto(code, [lang]).value
                     }</code></pre>`
                 }
-            })
+            }),
+            relaxedStrong
         )
 
         ctx.on('dispose', async () => {

--- a/packages/renderer-image/src/utils.ts
+++ b/packages/renderer-image/src/utils.ts
@@ -1,0 +1,20 @@
+import type { MarkedExtension } from 'marked'
+
+export const relaxedStrong: MarkedExtension = {
+    tokenizer: {
+        emStrong(src) {
+            // Accept LLM-style bold beside CJK text without consuming ***.
+            const match = /^\*\*(?!\*)(?=\S)([\s\S]*?[^*\s])\*\*(?!\*)/.exec(
+                src
+            )
+            if (!match) return false
+
+            return {
+                type: 'strong',
+                raw: match[0],
+                text: match[1],
+                tokens: this.lexer.inlineTokens(match[1])
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pr fixes bold markdown rendering for image replies, including bold text beside CJK characters.

Closes https://github.com/ChatLunaLab/chatluna/issues/979

## New Features
- None

## Bug Fixes
- Add a relaxed marked strong tokenizer so `**bold**` works next to CJK text in image and mixed-image renderers

## Other Changes
- None

## Validation
- yarn lint-fix (0 errors, 2 existing warnings)