### PR TITLE
fix(agent): decouple MCP startup and improve console UI

### DIFF
--- a/packages/extension-agent/client/components/layout/agent-shell.vue
+++ b/packages/extension-agent/client/components/layout/agent-shell.vue
@@ -95,7 +95,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import { send, store } from '@koishijs/client'
+import { send, socket, store } from '@koishijs/client'
 import { ElMessage } from 'element-plus'
 import AgentSidebar from './agent-sidebar.vue'
 import McpPage from '../mcp/mcp-page.vue'
@@ -109,6 +109,7 @@ import type { AgentConfig } from '../../../src/types'
 const activeTab = ref('mcp')
 const pending = ref(false)
 let refreshTask: Promise<void> | undefined
+let refreshQueued = false
 const data = computed(() => store.chatluna_agent_webui)
 const config = computed(() => data.value?.config)
 const mcpCfg = computed(() => data.value?.config?.mcp)
@@ -123,8 +124,14 @@ const subAgentStatus = computed(() => data.value?.status?.subAgent)
 const toolStatus = computed(() => data.value?.status?.tool)
 const triggerStatus = computed(() => data.value?.status?.trigger)
 const loading = computed(() => pending.value || !data.value)
+const isConsoleConnected = () => socket.value?.readyState === 1
 
 const refreshData = async () => {
+    if (!isConsoleConnected()) {
+        refreshQueued = true
+        return
+    }
+
     if (refreshTask) {
         await refreshTask
         return
@@ -133,8 +140,21 @@ const refreshData = async () => {
     refreshTask = (async () => {
         try {
             pending.value = true
-            await send('chatluna-agent/refreshConsoleData')
-        } catch {
+            refreshQueued = false
+            const task = send(
+                'chatluna-agent/refreshConsoleData'
+            ) as Promise<unknown> | undefined
+            if (!task) {
+                refreshQueued = true
+                return
+            }
+            await task
+        } catch (error) {
+            console.warn('[chatluna-agent] 刷新控制台数据失败', error)
+            if (!isConsoleConnected()) {
+                refreshQueued = true
+                return
+            }
             ElMessage.error('刷新 Agent 数据失败')
         } finally {
             pending.value = false
@@ -149,14 +169,9 @@ const handleTabChange = (tab: string) => {
     activeTab.value = tab
 }
 
-watch(activeTab, async (tab) => {
-    if (
-        tab === 'skills' ||
-        tab === 'subAgent' ||
-        tab === 'tool' ||
-        tab === 'trigger'
-    ) {
-        await refreshData()
+watch(socket, (value) => {
+    if (value?.readyState === 1 && refreshQueued) {
+        void refreshData()
     }
 })
 

--- a/packages/extension-agent/client/components/layout/agent-shell.vue
+++ b/packages/extension-agent/client/components/layout/agent-shell.vue
@@ -124,10 +124,9 @@ const subAgentStatus = computed(() => data.value?.status?.subAgent)
 const toolStatus = computed(() => data.value?.status?.tool)
 const triggerStatus = computed(() => data.value?.status?.trigger)
 const loading = computed(() => pending.value || !data.value)
-const isConsoleConnected = () => socket.value?.readyState === 1
 
 const refreshData = async () => {
-    if (!isConsoleConnected()) {
+    if (socket.value?.readyState !== 1) {
         refreshQueued = true
         return
     }
@@ -141,17 +140,10 @@ const refreshData = async () => {
         try {
             pending.value = true
             refreshQueued = false
-            const task = send(
-                'chatluna-agent/refreshConsoleData'
-            ) as Promise<unknown> | undefined
-            if (!task) {
-                refreshQueued = true
-                return
-            }
-            await task
+            await send('chatluna-agent/refreshConsoleData')
         } catch (error) {
             console.warn('[chatluna-agent] 刷新控制台数据失败', error)
-            if (!isConsoleConnected()) {
+            if (socket.value?.readyState !== 1) {
                 refreshQueued = true
                 return
             }
@@ -169,9 +161,20 @@ const handleTabChange = (tab: string) => {
     activeTab.value = tab
 }
 
-watch(socket, (value) => {
+watch(activeTab, async (tab) => {
+    if (
+        tab === 'skills' ||
+        tab === 'subAgent' ||
+        tab === 'tool' ||
+        tab === 'trigger'
+    ) {
+        await refreshData()
+    }
+})
+
+watch(socket, async (value) => {
     if (value?.readyState === 1 && refreshQueued) {
-        void refreshData()
+        await refreshData()
     }
 })
 

--- a/packages/extension-agent/client/components/mcp/mcp-servers-view.vue
+++ b/packages/extension-agent/client/components/mcp/mcp-servers-view.vue
@@ -1,50 +1,42 @@
 <template>
     <div class="servers-view">
-        <div class="panel">
-            <div class="panel-header">
-                <div>
-                    <div class="panel-title">服务器</div>
-                    <div class="panel-description">
-                        管理 MCP 服务器的连接方式、运行状态和重连操作。
-                    </div>
-                </div>
-
-                <div class="panel-actions">
-                    <el-button :loading="reloading" @click="reloadMcp">
-                        <el-icon><RefreshRight /></el-icon>
+        <div class="catalog-section">
+            <div class="catalog-controls">
+                <div class="section-title">服务器</div>
+                <div class="catalog-actions">
+                    <el-button
+                        :loading="reloading"
+                        :icon="RefreshRight"
+                        @click="reloadMcp"
+                    >
                         重新加载
                     </el-button>
-                    <el-button type="primary" @click="openCreate">
-                        <el-icon><Plus /></el-icon>
+                    <el-button type="primary" :icon="Plus" @click="openCreate">
                         添加服务器
                     </el-button>
                 </div>
             </div>
 
-            <div v-if="servers.length > 0" class="card-list server-grid">
+            <div
+                v-if="servers.length > 0"
+                class="card-list server-grid"
+                :class="{ compact: props.compactMode }"
+            >
                 <div
                     v-for="item in servers"
                     :key="item.name"
                     class="server-card"
                     :class="{
                         busy: item.updating,
+                        centered: props.hideDesc,
                         selected: selectedServerName === item.name
                     }"
                     role="button"
                     tabindex="0"
-                    :aria-pressed="selectedServerName === item.name"
                     @click="selectedServerName = item.name"
                     @keydown.enter.prevent="selectedServerName = item.name"
                     @keydown.space.prevent="selectedServerName = item.name"
                 >
-                    <span
-                        v-if="selectedServerName === item.name"
-                        class="server-selected-mark"
-                        aria-hidden="true"
-                    >
-                        <el-icon><Check /></el-icon>
-                    </span>
-
                     <div class="server-head">
                         <div class="server-brand">
                             <div class="server-icon">
@@ -69,83 +61,94 @@
                                     {{ item.status.title }}
                                 </div>
                                 <div class="server-name">{{ item.name }}</div>
-                                <div v-if="!props.hideDesc" class="server-kind">
-                                    <span>{{ item.kind }}</span>
-                                    <span v-if="item.status?.version">
-                                        v{{ item.status.version }}
-                                    </span>
+                                <div
+                                    v-if="
+                                        !props.hideDesc && item.status?.version
+                                    "
+                                    class="server-sub"
+                                >
+                                    v{{ item.status.version }}
                                 </div>
                             </div>
                         </div>
 
-                        <el-tag
-                            :type="
-                                stateTag(
-                                    item.updating
-                                        ? 'reconnecting'
-                                        : item.status?.state
-                                )
-                            "
-                            round
-                            effect="plain"
-                        >
-                            {{
-                                stateLabel(
-                                    item.updating
-                                        ? 'reconnecting'
-                                        : item.status?.state
-                                )
-                            }}
-                        </el-tag>
+                        <div class="server-controls">
+                            <div class="server-state" :class="stateClass(item)">
+                                <span class="state-dot" />
+                                <span>
+                                    {{
+                                        stateLabel(
+                                            item.updating
+                                                ? 'reconnecting'
+                                                : item.status?.state
+                                        )
+                                    }}
+                                </span>
+                            </div>
+                            <el-switch
+                                :model-value="item.tools.some((t) => t.enabled)"
+                                :loading="serverToolsBusy[item.name]"
+                                :disabled="
+                                    serverToolsBusy[item.name] ||
+                                    item.updating ||
+                                    item.tools.length === 0 ||
+                                    item.tools.some((t) => t.updating)
+                                "
+                                @click.stop
+                                @change="toggleServerTools(item.name)"
+                            />
+                        </div>
                     </div>
 
-                    <div class="server-chips">
-                        <el-tag size="small" effect="plain">
-                            {{ item.kind }}
-                        </el-tag>
-                        <el-tag size="small" effect="plain">
-                            {{ item.tools.length }} 工具
-                        </el-tag>
-                        <el-tag size="small" effect="plain">
-                            启动 {{ item.server.startupTimeout ?? 20 }}s
-                        </el-tag>
-                        <el-tag
-                            v-if="item.status?.attempts"
-                            size="small"
-                            type="warning"
-                            effect="plain"
-                        >
-                            重试 {{ item.status.attempts }}/{{
-                                item.status.maxAttempts ?? 5
-                            }}
-                        </el-tag>
+                    <div class="server-meta">
+                        <div class="meta-chips">
+                            <el-tag size="small" effect="plain" type="info">
+                                传输 {{ item.kind }}
+                            </el-tag>
+                            <el-tag size="small" effect="plain" type="success">
+                                工具 {{ item.tools.length }}
+                            </el-tag>
+                            <el-tag size="small" effect="plain" type="warning">
+                                超时 {{ item.server.timeout ?? 60 }}s
+                            </el-tag>
+                            <el-tag
+                                v-if="item.status?.attempts"
+                                size="small"
+                                effect="plain"
+                                type="danger"
+                            >
+                                重试 {{ item.status.attempts }}/{{
+                                    item.status.maxAttempts ?? 5
+                                }}
+                            </el-tag>
+                        </div>
                     </div>
 
                     <div v-if="item.status?.error" class="error-box">
                         {{ item.status.error }}
                     </div>
 
-                    <div class="server-actions" @click.stop @keydown.stop>
-                        <el-dropdown trigger="click" placement="bottom-end">
+                    <div class="server-footer">
+                        <el-dropdown
+                            trigger="click"
+                            @command="(cmd) => onServerMenu(cmd, item)"
+                        >
                             <el-button
-                                class="server-menu"
+                                class="more-btn"
                                 text
-                                circle
-                                :disabled="item.updating"
-                                :aria-label="`管理服务器 ${item.name}`"
-                            >
-                                <el-icon><MoreFilled /></el-icon>
-                            </el-button>
+                                :icon="More"
+                                @click.stop
+                            />
                             <template #dropdown>
                                 <el-dropdown-menu>
                                     <el-dropdown-item
+                                        command="toggle-tools"
                                         :disabled="
                                             serverToolsBusy[item.name] ||
                                             item.updating ||
                                             item.tools.length === 0 ||
                                             item.tools.some((t) => t.updating)
                                         "
-                                        @click="toggleServerTools(item.name)"
                                     >
                                         {{
                                             item.tools.some((t) => t.enabled)
@@ -154,20 +157,23 @@
                                         }}
                                     </el-dropdown-item>
                                     <el-dropdown-item
-                                        @click="openEdit(item.name)"
+                                        command="edit"
+                                        :disabled="item.updating"
                                     >
-                                        编辑服务器
+                                        编辑
                                     </el-dropdown-item>
                                     <el-dropdown-item
-                                        @click="reconnect(item.name)"
+                                        command="reconnect"
+                                        :disabled="item.updating"
                                     >
-                                        重新连接
+                                        {{ item.updating ? '重连中' : '重连' }}
                                     </el-dropdown-item>
                                     <el-dropdown-item
+                                        command="remove"
                                         divided
-                                        @click="removeServer(item.name)"
+                                        :disabled="item.updating"
                                     >
-                                        删除服务器
+                                        删除
                                     </el-dropdown-item>
                                 </el-dropdown-menu>
                             </template>
@@ -176,40 +182,37 @@
                 </div>
             </div>
 
-            <div v-else class="empty-state server-empty">
+            <div v-else class="empty-state">
                 <el-empty description="还没有 MCP 服务器，先添加一个。" />
             </div>
+        </div>
 
-            <div class="tool-section">
-                <div class="panel-header tool-panel-header">
-                    <div>
-                        <div class="panel-title">
-                            工具
-                            <span v-if="selectedServer" class="panel-count">
-                                {{ visibleTools.length }}
-                            </span>
-                        </div>
-                        <div v-if="selectedServer" class="panel-description">
-                            {{
-                                selectedServer.status?.title ||
-                                selectedServer.name
-                            }}
-                        </div>
-                    </div>
+        <div class="catalog-section">
+            <div class="catalog-controls tools-controls">
+                <div class="section-title">
+                    工具{{
+                        selectedServerName ? ` · ${selectedServerName}` : ''
+                    }}
                 </div>
+            </div>
 
-                <div v-if="visibleTools.length > 0" class="card-list tool-grid">
-                    <div
-                        v-for="item in visibleTools"
-                        :key="item.name"
-                        class="tool-card"
-                        :class="{ busy: item.updating }"
-                        role="button"
-                        tabindex="0"
-                        @click="openTool(item)"
-                        @keydown.enter.prevent="openTool(item)"
-                        @keydown.space.prevent="openTool(item)"
-                    >
+            <div
+                v-if="visibleTools.length > 0"
+                class="card-list tool-grid"
+                :class="{ compact: props.compactMode }"
+            >
+                <div
+                    v-for="item in visibleTools"
+                    :key="item.name"
+                    class="tool-card"
+                    :class="{ busy: item.updating, centered: props.hideDesc }"
+                    role="button"
+                    tabindex="0"
+                    @click="openTool(item)"
+                    @keydown.enter.prevent="openTool(item)"
+                    @keydown.space.prevent="openTool(item)"
+                >
+                    <div class="tool-top">
                         <div class="tool-brand">
                             <div class="tool-icon">
                                 <img
@@ -217,7 +220,7 @@
                                     :src="item.icon.src"
                                     alt=""
                                 />
-                                <el-icon v-else :size="14">
+                                <el-icon v-else :size="16">
                                     <Tools />
                                 </el-icon>
                             </div>
@@ -226,41 +229,37 @@
                                 <div class="tool-title">
                                     {{ item.title || item.name }}
                                 </div>
-                                <div
-                                    v-if="
-                                        item.title && item.title !== item.name
-                                    "
-                                    class="tool-name"
-                                >
-                                    {{ item.name }}
+                                <div v-if="!props.hideDesc" class="tool-name">
+                                    {{ item.server }}
                                 </div>
                             </div>
                         </div>
 
-                        <div class="tool-controls" @click.stop @keydown.stop>
-                            <el-switch
-                                :model-value="item.enabled"
-                                :loading="item.updating"
-                                :disabled="item.updating"
-                                :aria-label="`${item.enabled ? '禁用' : '启用'}工具 ${item.name}`"
-                                @change="
-                                    (value) =>
-                                        toggleTool(item, value as boolean)
-                                "
-                            />
-                        </div>
+                        <el-switch
+                            :model-value="item.enabled"
+                            :loading="item.updating"
+                            :disabled="item.updating"
+                            @click.stop
+                            @change="
+                                (value) => toggleTool(item, value as boolean)
+                            "
+                        />
+                    </div>
+
+                    <div v-if="!props.hideDesc" class="tool-description">
+                        {{ item.description || '这个工具暂时没有说明。' }}
                     </div>
                 </div>
+            </div>
 
-                <div v-else class="empty-state empty-tools">
-                    <el-empty
-                        :description="
-                            selectedServer
-                                ? '该服务器当前没有可用工具。'
-                                : '请先添加一个 MCP 服务器。'
-                        "
-                    />
-                </div>
+            <div v-else class="empty-state empty-tools">
+                <el-empty
+                    :description="
+                        selectedServerName
+                            ? '该服务器当前没有可用工具。'
+                            : '请先添加一个 MCP 服务器。'
+                    "
+                />
             </div>
         </div>
 
@@ -484,16 +483,6 @@
                                 </div>
 
                                 <div
-                                    v-if="form.type === 'stdio' && form.command"
-                                    class="preview-field"
-                                >
-                                    <span class="field-label">命令</span>
-                                    <span class="field-value">
-                                        {{ form.command }}
-                                    </span>
-                                </div>
-
-                                <div
                                     v-if="form.type !== 'stdio' && form.url"
                                     class="preview-field"
                                 >
@@ -511,7 +500,9 @@
                                 </div>
 
                                 <div class="preview-field">
-                                    <span class="field-label">工具调用超时</span>
+                                    <span class="field-label">
+                                        工具调用超时
+                                    </span>
                                     <span class="field-value">
                                         {{ form.timeout }}s
                                     </span>
@@ -550,13 +541,17 @@
                     <el-input :model-value="toolForm.name" disabled />
                 </div>
 
-                <div class="form-span tool-description-field">
+                <div class="form-group">
+                    <label class="form-label">来源服务器</label>
+                    <el-input :model-value="toolForm.server" disabled />
+                </div>
+
+                <div class="form-span">
                     <label class="form-label">工具描述</label>
                     <el-input
                         :model-value="toolForm.description || '暂无工具描述'"
                         type="textarea"
                         :rows="4"
-                        resize="none"
                         readonly
                     />
                 </div>
@@ -597,14 +592,13 @@ import { computed, reactive, ref, watch } from 'vue'
 import { send } from '@koishijs/client'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import {
-    Check,
     Connection,
-    MoreFilled,
     Plus,
     RefreshRight,
     Tools,
     Menu,
-    Document
+    Document,
+    More
 } from '@element-plus/icons-vue'
 import type {
     McpConfig,
@@ -619,23 +613,6 @@ import CodeEditor from '../shared/code-editor.vue'
 function getServerType(config: McpServerConfig) {
     return config.type ?? (config.url ? 'http' : 'stdio')
 }
-
-function stateTag(state?: McpServerState) {
-    if (state === 'connected') {
-        return 'success'
-    }
-
-    if (state === 'connecting' || state === 'reconnecting') {
-        return 'warning'
-    }
-
-    if (state === 'error') {
-        return 'danger'
-    }
-
-    return 'info'
-}
-
 function stateLabel(state?: McpServerState) {
     if (state === 'connected') {
         return '已连接'
@@ -955,6 +932,7 @@ const form = reactive({
 
 const toolForm = reactive({
     name: '',
+    server: '',
     description: '',
     enabled: true,
     timeout: 0,
@@ -986,11 +964,9 @@ const tools = computed(() =>
         .sort((a, b) => a.name.localeCompare(b.name))
 )
 
-const selectedServer = computed(() =>
-    servers.value.find((server) => server.name === selectedServerName.value)
+const visibleTools = computed(() =>
+    tools.value.filter((tool) => tool.server === selectedServerName.value)
 )
-
-const visibleTools = computed(() => selectedServer.value?.tools ?? [])
 
 watch(
     servers,
@@ -1002,12 +978,15 @@ watch(
     { immediate: true }
 )
 
-function envCount(server: McpServerConfig) {
-    return Object.keys(server.env || {}).length
-}
-
-function headerCount(server: McpServerConfig) {
-    return Object.keys(server.headers || {}).length
+function stateClass(item: {
+    updating: boolean
+    status?: { state?: McpServerState }
+}) {
+    const state = item.updating ? 'reconnecting' : item.status?.state
+    if (state === 'connected') return 'is-connected'
+    if (state === 'connecting' || state === 'reconnecting') return 'is-pending'
+    if (state === 'error') return 'is-error'
+    return 'is-idle'
 }
 
 function getFormConfig() {
@@ -1136,8 +1115,37 @@ function openEdit(name: string) {
     showServerDialog.value = true
 }
 
+function onServerMenu(
+    command: string,
+    item: {
+        name: string
+        updating: boolean
+        tools: { enabled: boolean; updating?: boolean }[]
+    }
+) {
+    if (command === 'toggle-tools') {
+        toggleServerTools(item.name)
+        return
+    }
+
+    if (command === 'edit') {
+        openEdit(item.name)
+        return
+    }
+
+    if (command === 'reconnect') {
+        reconnect(item.name)
+        return
+    }
+
+    if (command === 'remove') {
+        removeServer(item.name)
+    }
+}
+
 function openTool(item: McpToolInfo) {
     toolForm.name = item.name
+    toolForm.server = item.server
     toolForm.description = item.description
     toolForm.enabled = item.enabled
     toolForm.timeout = item.timeout ?? 0
@@ -1331,122 +1339,98 @@ async function saveTool() {
 .servers-view {
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    gap: 24px;
+    min-width: 0;
 }
 
-.panel {
-    border: 1px solid
-        color-mix(in srgb, var(--k-color-divider), transparent 18%);
-    border-radius: 16px;
-    background: color-mix(in srgb, var(--k-side-bg), var(--k-page-bg) 20%);
-    overflow: hidden;
-    box-sizing: border-box;
+.catalog-section {
+    min-width: 0;
 }
 
-.panel-header {
+.catalog-controls {
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    padding: 16px 18px;
-    border-bottom: 1px solid
-        color-mix(in srgb, var(--k-color-divider), transparent 20%);
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 16px;
+    min-width: 0;
+    flex-wrap: wrap;
+}
+
+.tools-controls {
+    justify-content: flex-start;
+}
+
+.section-title {
+    font-size: 20px;
+    font-weight: 600;
+    line-height: 1.3;
+    color: var(--k-text-dark);
+    min-width: 0;
+}
+
+.catalog-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    min-width: 0;
+    margin-left: auto;
+}
+
+.catalog-actions :deep(.el-button) {
+    margin: 0;
+}
+
+.card-list {
+    --card-cols: 3;
+    display: grid;
+    grid-template-columns: repeat(var(--card-cols), minmax(0, 1fr));
     gap: 16px;
     box-sizing: border-box;
 }
 
-.panel-title {
-    font-size: 17px;
-    font-weight: 600;
-    color: var(--k-text-dark);
+.server-grid,
+.server-grid.compact {
+    --card-cols: 3;
 }
 
-.panel-description {
-    margin-top: 4px;
-    font-size: 12px;
-    line-height: 1.6;
-    color: var(--k-text-light);
+.tool-grid {
+    --card-cols: 5;
 }
 
-.panel-count {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 22px;
-    height: 20px;
-    margin-left: 6px;
-    padding: 0 6px;
-    border-radius: 6px;
-    background: color-mix(in srgb, var(--k-color-primary), transparent 88%);
-    color: var(--k-color-primary);
-    font-size: 12px;
-    font-weight: 600;
-    vertical-align: 2px;
-    box-sizing: border-box;
+.tool-grid.compact {
+    --card-cols: 4;
 }
 
-.panel-actions {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
-.card-list {
-    display: grid;
-    box-sizing: border-box;
-}
-
-.server-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 12px;
-    padding: 14px;
-}
-
-.server-card {
-    position: relative;
+.server-card,
+.tool-card {
     border: 1px solid
         color-mix(in srgb, var(--k-color-divider), transparent 18%);
-    border-radius: 8px;
-    background: color-mix(in srgb, var(--k-activity-bg), var(--k-page-bg) 18%);
-    padding: 12px;
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--k-activity-bg), var(--k-page-bg) 16%);
+    padding: 14px;
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 12px;
     box-sizing: border-box;
-    transition:
-        border-color 0.18s ease,
-        background-color 0.18s ease,
-        box-shadow 0.18s ease;
+    transition: border-color 0.2s ease;
     min-width: 0;
     overflow: hidden;
-    cursor: pointer;
-    outline: none;
 }
 
-.server-card:hover {
-    border-color: color-mix(in srgb, var(--k-color-primary), transparent 48%);
-    background: color-mix(
-        in srgb,
-        var(--k-color-primary),
-        var(--k-activity-bg) 95%
-    );
-}
-
-.server-card:focus-visible {
-    box-shadow: 0 0 0 2px
-        color-mix(in srgb, var(--k-color-primary), transparent 72%);
+.server-card:hover,
+.tool-card:hover {
+    border-color: color-mix(in srgb, var(--k-color-primary), transparent 40%);
 }
 
 .server-card.selected {
     border-color: var(--k-color-primary);
-    background: color-mix(
-        in srgb,
-        var(--k-color-primary),
-        var(--k-activity-bg) 92%
-    );
-    box-shadow: inset 3px 0 0 var(--k-color-primary);
+    box-shadow: 0 0 0 1px var(--k-color-primary);
 }
 
-.server-card.busy {
+.server-card.busy,
+.tool-card.busy {
     border-color: color-mix(in srgb, var(--el-color-warning), transparent 68%);
     background: color-mix(
         in srgb,
@@ -1455,78 +1439,49 @@ async function saveTool() {
     );
 }
 
-.server-card.selected.busy {
-    box-shadow: inset 3px 0 0 var(--el-color-warning);
-}
-
-.server-selected-mark {
-    position: absolute;
-    top: 0;
-    right: 0;
-    width: 24px;
-    height: 24px;
-    border-radius: 0 7px 0 8px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--k-color-primary);
-    color: white;
-    font-size: 13px;
-}
-
-.server-head {
+.server-head,
+.tool-top {
     display: flex;
     justify-content: space-between;
-    gap: 10px;
+    gap: 12px;
     align-items: flex-start;
-    padding-right: 28px;
+}
+
+.server-card.centered .server-head {
+    align-items: center;
+    min-height: 34px;
+}
+
+.tool-card.centered .tool-top {
+    align-items: center;
+    min-height: 34px;
 }
 
 .server-brand,
 .tool-brand {
     display: flex;
-    align-items: center;
-    gap: 8px;
+    gap: 10px;
     min-width: 0;
     flex: 1 1 auto;
 }
 
-.server-icon {
-    width: 32px;
-    height: 32px;
-    border-radius: 8px;
-    border: 1px solid
-        color-mix(in srgb, var(--k-color-divider), transparent 18%);
-    background: color-mix(in srgb, var(--k-side-bg), transparent 8%);
-    display: inline-flex;
+.server-card.centered .server-brand,
+.tool-card.centered .tool-brand {
     align-items: center;
-    justify-content: center;
-    color: color-mix(in srgb, var(--k-text-dark), var(--k-color-primary) 28%);
-    flex-shrink: 0;
-    overflow: hidden;
 }
 
+.server-icon,
 .tool-icon {
-    width: 26px;
-    height: 26px;
-    border-radius: 6px;
-    border: 1px solid
-        color-mix(in srgb, var(--k-color-divider), transparent 25%);
-    background: color-mix(in srgb, var(--k-side-bg), transparent 8%);
+    width: 34px;
+    height: 34px;
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--k-side-bg), var(--k-color-primary) 8%);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    color: color-mix(in srgb, var(--k-text-dark), var(--k-color-primary) 28%);
+    color: color-mix(in srgb, var(--k-text-dark), var(--k-color-primary) 36%);
     flex-shrink: 0;
     overflow: hidden;
-}
-
-.server-icon :deep(.el-icon) {
-    font-size: 16px;
-}
-
-.tool-icon :deep(.el-icon) {
-    font-size: 14px;
 }
 
 .server-icon img,
@@ -1542,303 +1497,182 @@ async function saveTool() {
     flex: 1 1 auto;
 }
 
-.server-title {
+.server-card.centered .server-copy,
+.tool-card.centered .tool-copy {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.server-title,
+.tool-name,
+.server-sub {
     font-size: 12px;
     color: var(--k-text-light);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    line-height: 1.45;
 }
 
-.server-name {
-    margin-top: 2px;
-    font-size: 15px;
-    font-weight: 600;
-    color: var(--k-text-dark);
-    line-height: 1.3;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
+.server-name,
 .tool-title {
-    font-size: 13px;
+    font-size: 16px;
     font-weight: 600;
     color: var(--k-text-dark);
-    line-height: 1.3;
+    line-height: 1.4;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
-.tool-name {
-    margin-top: 2px;
-    font-size: 10px;
-    line-height: 1.2;
+.server-state {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 6px;
+    flex: 0 0 auto;
+    font-size: 12px;
+    line-height: 1.4;
     color: var(--k-text-light);
-    overflow: hidden;
-    text-overflow: ellipsis;
     white-space: nowrap;
 }
 
-.server-kind {
-    margin-top: 4px;
-    display: flex;
-    gap: 8px;
-    flex-wrap: wrap;
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: var(--k-text-light);
-}
-
-.tool-section {
-    border-top: 1px solid
-        color-mix(in srgb, var(--k-color-divider), transparent 20%);
-}
-
-.tool-panel-header {
-    border-bottom: 0;
-    padding-bottom: 10px;
-}
-
-.tool-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 8px;
-    padding: 0 14px 14px;
-}
-
-.tool-card {
-    min-width: 0;
-    min-height: 52px;
-    padding: 8px 10px;
-    border: 1px solid
-        color-mix(in srgb, var(--k-color-divider), transparent 18%);
-    border-radius: 7px;
-    background: color-mix(in srgb, var(--k-activity-bg), var(--k-page-bg) 18%);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-    box-sizing: border-box;
-    transition:
-        border-color 0.18s ease,
-        background-color 0.18s ease;
-    cursor: pointer;
-    outline: none;
-}
-
-.tool-card:hover {
-    border-color: color-mix(in srgb, var(--k-color-primary), transparent 62%);
-    background: color-mix(
-        in srgb,
-        var(--k-color-primary),
-        var(--k-activity-bg) 97%
-    );
-}
-
-.tool-card:focus-visible {
-    border-color: var(--k-color-primary);
-    box-shadow: 0 0 0 2px
-        color-mix(in srgb, var(--k-color-primary), transparent 76%);
-}
-
-.tool-card.busy {
-    border-color: color-mix(in srgb, var(--el-color-warning), transparent 68%);
-    background: color-mix(
-        in srgb,
-        var(--k-activity-bg),
-        var(--el-color-warning) 4%
-    );
-}
-
-.tool-controls {
-    display: flex;
-    align-items: center;
-    gap: 4px;
+.state-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: color-mix(in srgb, var(--k-text-light), transparent 20%);
     flex: 0 0 auto;
 }
 
-.meta-grid {
+.server-state.is-connected {
+    color: var(--el-color-success);
+}
+
+.server-state.is-connected .state-dot {
+    background: var(--el-color-success);
+}
+
+.server-state.is-pending {
+    color: var(--el-color-warning);
+}
+
+.server-state.is-pending .state-dot {
+    background: var(--el-color-warning);
+}
+
+.server-state.is-error {
+    color: var(--el-color-danger);
+}
+
+.server-state.is-error .state-dot {
+    background: var(--el-color-danger);
+}
+
+.tool-description {
+    font-size: 12px;
+    line-height: 1.6;
+    color: var(--k-text-light);
+    word-break: break-word;
+    overflow-wrap: anywhere;
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.tool-grid.compact .tool-description {
+    -webkit-line-clamp: 3;
+}
+
+.server-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    min-width: 0;
+}
+
+.meta-chips {
     display: flex;
     flex-wrap: wrap;
+    gap: 6px;
+    min-width: 0;
+}
+
+.meta-chips :deep(.el-tag) {
+    border-radius: 6px;
+}
+
+.server-controls {
+    display: inline-flex;
+    align-items: center;
     gap: 8px;
-    margin-top: 12px;
+    flex: 0 0 auto;
 }
 
-.meta-card {
-    flex: 1 1 120px;
-    border-radius: 10px;
-    background: color-mix(in srgb, var(--k-activity-bg), transparent 22%);
-    padding: 8px 10px;
+.server-footer {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: auto;
 }
 
-.meta-wide {
-    flex-basis: 100%;
+.more-btn {
+    --el-button-text-color: var(--k-text-light);
+    --el-button-hover-text-color: var(--k-text-dark);
+    padding: 4px;
+    min-height: 28px;
+    min-width: 28px;
 }
 
-.meta-card span {
-    display: block;
-    font-size: 11px;
-    color: var(--k-text-light);
+.more-btn :deep(.el-icon) {
+    transform: rotate(90deg);
 }
 
-.meta-card strong {
-    display: block;
-    margin-top: 4px;
-    font-size: 13px;
-    color: var(--k-text-dark);
-    line-height: 1.4;
-    word-break: break-word;
+.tool-card {
+    cursor: pointer;
 }
 
 @media (max-width: 1680px) {
+    .server-grid,
+    .server-grid.compact {
+        --card-cols: 3;
+    }
+
     .tool-grid {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
+        --card-cols: 5;
+    }
+
+    .tool-grid.compact {
+        --card-cols: 4;
     }
 }
 
 @media (max-width: 1320px) {
+    .server-grid {
+        --card-cols: 2;
+    }
+
+    .server-grid.compact {
+        --card-cols: 2;
+    }
+
     .tool-grid {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+        --card-cols: 3;
+    }
+
+    .tool-grid.compact {
+        --card-cols: 2;
     }
 }
 
-.detail-list {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    margin-top: 10px;
-}
-
-.detail-row {
-    display: flex;
-    justify-content: space-between;
-    gap: 10px;
-    font-size: 11px;
-    color: var(--k-text-light);
-}
-
-.detail-row span:last-child {
-    color: var(--k-text-dark);
-    text-align: right;
-    word-break: break-word;
-}
-
-.server-chips {
-    display: flex;
-    gap: 6px;
-    flex-wrap: wrap;
-    padding-right: 32px;
-}
-
 .error-box {
-    margin-top: 10px;
-    padding: 10px 12px;
-    border-radius: 10px;
-    background: color-mix(in srgb, var(--el-color-danger), transparent 95%);
-    color: color-mix(in srgb, var(--el-color-danger), var(--k-text-dark) 36%);
-    font-size: 11px;
-    line-height: 1.5;
+    padding: 8px 10px;
+    border-radius: 8px;
+    border-left: 3px solid var(--el-color-danger);
+    background: color-mix(in srgb, var(--el-color-danger), transparent 94%);
+    color: var(--el-color-danger);
+    font-size: 12px;
+    line-height: 1.45;
     word-break: break-word;
     overflow-wrap: anywhere;
-}
-
-.server-actions {
-    position: absolute;
-    right: 7px;
-    bottom: 7px;
-    display: flex;
-    align-items: center;
-}
-
-.server-menu {
-    width: 28px;
-    height: 28px;
-    color: var(--k-text-light);
-}
-
-.server-actions :deep(.neutral-outline.el-button) {
-    --el-button-bg-color: transparent;
-    --el-button-border-color: color-mix(
-        in srgb,
-        var(--k-color-divider),
-        transparent 12%
-    );
-    --el-button-text-color: var(--k-text-dark);
-    --el-button-hover-bg-color: color-mix(
-        in srgb,
-        var(--k-side-bg),
-        var(--k-page-bg) 18%
-    );
-    --el-button-hover-border-color: color-mix(
-        in srgb,
-        var(--k-color-divider),
-        transparent 0%
-    );
-    --el-button-hover-text-color: var(--k-text-dark);
-    --el-button-active-bg-color: color-mix(
-        in srgb,
-        var(--k-side-bg),
-        var(--k-page-bg) 26%
-    );
-    --el-button-active-border-color: color-mix(
-        in srgb,
-        var(--k-color-divider),
-        transparent 0%
-    );
-    --el-button-active-text-color: var(--k-text-dark);
-    --el-button-disabled-bg-color: color-mix(
-        in srgb,
-        var(--k-side-bg),
-        transparent 10%
-    );
-    --el-button-disabled-border-color: color-mix(
-        in srgb,
-        var(--k-color-divider),
-        transparent 24%
-    );
-    --el-button-disabled-text-color: var(--k-text-light);
-}
-
-.server-actions :deep(.danger-soft.el-button) {
-    --el-button-bg-color: color-mix(
-        in srgb,
-        var(--el-color-danger),
-        transparent 92%
-    );
-    --el-button-border-color: color-mix(
-        in srgb,
-        var(--el-color-danger),
-        transparent 68%
-    );
-    --el-button-text-color: color-mix(
-        in srgb,
-        var(--el-color-danger),
-        var(--k-text-dark) 22%
-    );
-    --el-button-hover-bg-color: color-mix(
-        in srgb,
-        var(--el-color-danger),
-        transparent 86%
-    );
-    --el-button-hover-border-color: color-mix(
-        in srgb,
-        var(--el-color-danger),
-        transparent 52%
-    );
-    --el-button-hover-text-color: var(--el-color-danger);
-    --el-button-active-bg-color: color-mix(
-        in srgb,
-        var(--el-color-danger),
-        transparent 82%
-    );
-    --el-button-active-border-color: color-mix(
-        in srgb,
-        var(--el-color-danger),
-        transparent 44%
-    );
-    --el-button-active-text-color: var(--el-color-danger);
 }
 
 .empty-state {
@@ -1981,15 +1815,6 @@ async function saveTool() {
     overflow-wrap: anywhere;
 }
 
-.dialog-copy {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-    margin-bottom: 24px;
-    padding-bottom: 20px;
-    border-bottom: 1px solid var(--k-color-divider);
-}
-
 .dialog-head {
     display: flex;
     justify-content: center;
@@ -2016,12 +1841,6 @@ async function saveTool() {
     flex: 1 1 100%;
 }
 
-.tool-description-field :deep(.el-textarea__inner) {
-    line-height: 1.6;
-    color: var(--k-text-dark);
-    background: color-mix(in srgb, var(--k-activity-bg), var(--k-page-bg) 35%);
-}
-
 .form-label {
     display: block;
     margin-bottom: 8px;
@@ -2037,14 +1856,34 @@ async function saveTool() {
 }
 
 @media (max-width: 768px) {
-    .server-grid,
-    .tool-grid {
+    .card-list,
+    .card-list.compact,
+    .tool-grid,
+    .tool-grid.compact {
+        --card-cols: 1;
         grid-template-columns: 1fr;
     }
 
-    .panel-header {
+    .catalog-controls {
         flex-direction: column;
-        align-items: flex-start;
+        align-items: stretch;
+        gap: 10px;
+        width: 100%;
+    }
+
+    .catalog-actions {
+        width: 100%;
+        margin-left: 0;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 10px;
+    }
+
+    .catalog-actions :deep(.el-button) {
+        width: 100%;
+        min-width: 0;
+        margin: 0;
+        justify-content: center;
     }
 
     .dialog-grid > .form-group,
@@ -2056,19 +1895,22 @@ async function saveTool() {
     .server-card,
     .tool-card {
         width: 100%;
+        min-width: 0;
     }
 
     .json-layout {
         grid-template-columns: 1fr;
     }
 
-    .meta-wide {
-        flex-basis: 100%;
+    .server-head {
+        flex-direction: column;
+        gap: 10px;
     }
-}
 
-.tooltip-trigger-wrapper {
-    display: inline-flex;
+    .server-state {
+        width: 100%;
+        justify-content: flex-start;
+    }
 }
 
 .tooltip-trigger-wrapper :deep(.el-button.is-disabled),

--- a/packages/extension-agent/client/components/mcp/mcp-servers-view.vue
+++ b/packages/extension-agent/client/components/mcp/mcp-servers-view.vue
@@ -1,33 +1,50 @@
 <template>
     <div class="servers-view">
-        <div class="catalog-section">
-            <div class="catalog-controls">
-                <div class="section-title">服务器</div>
-                <div class="catalog-actions">
-                    <el-button
-                        :loading="reloading"
-                        :icon="RefreshRight"
-                        @click="reloadMcp"
-                    >
+        <div class="panel">
+            <div class="panel-header">
+                <div>
+                    <div class="panel-title">服务器</div>
+                    <div class="panel-description">
+                        管理 MCP 服务器的连接方式、运行状态和重连操作。
+                    </div>
+                </div>
+
+                <div class="panel-actions">
+                    <el-button :loading="reloading" @click="reloadMcp">
+                        <el-icon><RefreshRight /></el-icon>
                         重新加载
                     </el-button>
-                    <el-button type="primary" :icon="Plus" @click="openCreate">
+                    <el-button type="primary" @click="openCreate">
+                        <el-icon><Plus /></el-icon>
                         添加服务器
                     </el-button>
                 </div>
             </div>
 
-            <div
-                v-if="servers.length > 0"
-                class="card-list server-grid"
-                :class="{ compact: props.compactMode }"
-            >
+            <div v-if="servers.length > 0" class="card-list server-grid">
                 <div
                     v-for="item in servers"
                     :key="item.name"
                     class="server-card"
-                    :class="{ busy: item.updating, centered: props.hideDesc }"
+                    :class="{
+                        busy: item.updating,
+                        selected: selectedServerName === item.name
+                    }"
+                    role="button"
+                    tabindex="0"
+                    :aria-pressed="selectedServerName === item.name"
+                    @click="selectedServerName = item.name"
+                    @keydown.enter.prevent="selectedServerName = item.name"
+                    @keydown.space.prevent="selectedServerName = item.name"
                 >
+                    <span
+                        v-if="selectedServerName === item.name"
+                        class="server-selected-mark"
+                        aria-hidden="true"
+                    >
+                        <el-icon><Check /></el-icon>
+                    </span>
+
                     <div class="server-head">
                         <div class="server-brand">
                             <div class="server-icon">
@@ -52,102 +69,83 @@
                                     {{ item.status.title }}
                                 </div>
                                 <div class="server-name">{{ item.name }}</div>
-                                <div
-                                    v-if="
-                                        !props.hideDesc && item.status?.version
-                                    "
-                                    class="server-sub"
-                                >
-                                    v{{ item.status.version }}
+                                <div v-if="!props.hideDesc" class="server-kind">
+                                    <span>{{ item.kind }}</span>
+                                    <span v-if="item.status?.version">
+                                        v{{ item.status.version }}
+                                    </span>
                                 </div>
                             </div>
                         </div>
 
-                        <div class="server-controls">
-                            <div class="server-state" :class="stateClass(item)">
-                                <span class="state-dot" />
-                                <span>
-                                    {{
-                                        stateLabel(
-                                            item.updating
-                                                ? 'reconnecting'
-                                                : item.status?.state
-                                        )
-                                    }}
-                                </span>
-                            </div>
-                            <el-switch
-                                :model-value="item.tools.some((t) => t.enabled)"
-                                :loading="serverToolsBusy[item.name]"
-                                :disabled="
-                                    serverToolsBusy[item.name] ||
-                                    item.updating ||
-                                    item.tools.length === 0 ||
-                                    item.tools.some((t) => t.updating)
-                                "
-                                @click.stop
-                                @change="toggleServerTools(item.name)"
-                            />
-                        </div>
+                        <el-tag
+                            :type="
+                                stateTag(
+                                    item.updating
+                                        ? 'reconnecting'
+                                        : item.status?.state
+                                )
+                            "
+                            round
+                            effect="plain"
+                        >
+                            {{
+                                stateLabel(
+                                    item.updating
+                                        ? 'reconnecting'
+                                        : item.status?.state
+                                )
+                            }}
+                        </el-tag>
                     </div>
 
-                    <div class="server-meta">
-                        <div class="meta-chips">
-                            <el-tag size="small" effect="plain" type="info">
-                                传输 {{ item.kind }}
-                            </el-tag>
-                            <el-tag size="small" effect="plain" type="success">
-                                工具 {{ item.tools.length }}
-                            </el-tag>
-                            <el-tag size="small" effect="plain" type="warning">
-                                超时 {{ item.server.timeout ?? 60 }}s
-                            </el-tag>
-                            <el-tag
-                                v-if="item.status?.attempts"
-                                size="small"
-                                effect="plain"
-                                type="danger"
-                            >
-                                重试 {{ item.status.attempts }}/{{
-                                    item.status.maxAttempts ?? 5
-                                }}
-                            </el-tag>
-                        </div>
-                        <div class="meta-endpoint">
-                            <span>
-                                {{ item.kind === 'stdio' ? '命令' : '入口' }}
-                            </span>
-                            <code :title="endpointLabel(item)">
-                                {{ endpointLabel(item) }}
-                            </code>
-                        </div>
+                    <div class="server-chips">
+                        <el-tag size="small" effect="plain">
+                            {{ item.kind }}
+                        </el-tag>
+                        <el-tag size="small" effect="plain">
+                            {{ item.tools.length }} 工具
+                        </el-tag>
+                        <el-tag size="small" effect="plain">
+                            启动 {{ item.server.startupTimeout ?? 20 }}s
+                        </el-tag>
+                        <el-tag
+                            v-if="item.status?.attempts"
+                            size="small"
+                            type="warning"
+                            effect="plain"
+                        >
+                            重试 {{ item.status.attempts }}/{{
+                                item.status.maxAttempts ?? 5
+                            }}
+                        </el-tag>
                     </div>
 
                     <div v-if="item.status?.error" class="error-box">
                         {{ item.status.error }}
                     </div>
 
-                    <div class="server-footer">
-                        <el-dropdown
-                            trigger="click"
-                            @command="(cmd) => onServerMenu(cmd, item)"
-                        >
+                    <div class="server-actions" @click.stop @keydown.stop>
+                        <el-dropdown trigger="click" placement="bottom-end">
                             <el-button
-                                class="more-btn"
+                                class="server-menu"
                                 text
-                                :icon="More"
-                                @click.stop
-                            />
+                                circle
+                                :disabled="item.updating"
+                                :aria-label="`管理服务器 ${item.name}`"
+                            >
+                                <el-icon><MoreFilled /></el-icon>
+                            </el-button>
                             <template #dropdown>
                                 <el-dropdown-menu>
                                     <el-dropdown-item
-                                        command="toggle-tools"
                                         :disabled="
                                             serverToolsBusy[item.name] ||
                                             item.updating ||
                                             item.tools.length === 0 ||
                                             item.tools.some((t) => t.updating)
                                         "
+                                        @click="toggleServerTools(item.name)"
                                     >
                                         {{
                                             item.tools.some((t) => t.enabled)
@@ -156,23 +154,20 @@
                                         }}
                                     </el-dropdown-item>
                                     <el-dropdown-item
-                                        command="edit"
-                                        :disabled="item.updating"
+                                        @click="openEdit(item.name)"
                                     >
-                                        编辑
+                                        编辑服务器
                                     </el-dropdown-item>
                                     <el-dropdown-item
-                                        command="reconnect"
-                                        :disabled="item.updating"
+                                        @click="reconnect(item.name)"
                                     >
-                                        {{ item.updating ? '重连中' : '重连' }}
+                                        重新连接
                                     </el-dropdown-item>
                                     <el-dropdown-item
-                                        command="remove"
                                         divided
-                                        :disabled="item.updating"
+                                        @click="removeServer(item.name)"
                                     >
-                                        删除
+                                        删除服务器
                                     </el-dropdown-item>
                                 </el-dropdown-menu>
                             </template>
@@ -181,33 +176,40 @@
                 </div>
             </div>
 
-            <div v-else class="empty-state">
+            <div v-else class="empty-state server-empty">
                 <el-empty description="还没有 MCP 服务器，先添加一个。" />
             </div>
-        </div>
 
-        <div class="catalog-section">
-            <div class="catalog-controls tools-controls">
-                <div class="section-title">工具</div>
-            </div>
+            <div class="tool-section">
+                <div class="panel-header tool-panel-header">
+                    <div>
+                        <div class="panel-title">
+                            工具
+                            <span v-if="selectedServer" class="panel-count">
+                                {{ visibleTools.length }}
+                            </span>
+                        </div>
+                        <div v-if="selectedServer" class="panel-description">
+                            {{
+                                selectedServer.status?.title ||
+                                selectedServer.name
+                            }}
+                        </div>
+                    </div>
+                </div>
 
-            <div
-                v-if="tools.length > 0"
-                class="card-list tool-grid"
-                :class="{ compact: props.compactMode }"
-            >
-                <div
-                    v-for="item in tools"
-                    :key="item.name"
-                    class="tool-card"
-                    :class="{ busy: item.updating, centered: props.hideDesc }"
-                    role="button"
-                    tabindex="0"
-                    @click="openTool(item)"
-                    @keydown.enter.prevent="openTool(item)"
-                    @keydown.space.prevent="openTool(item)"
-                >
-                    <div class="tool-top">
+                <div v-if="visibleTools.length > 0" class="card-list tool-grid">
+                    <div
+                        v-for="item in visibleTools"
+                        :key="item.name"
+                        class="tool-card"
+                        :class="{ busy: item.updating }"
+                        role="button"
+                        tabindex="0"
+                        @click="openTool(item)"
+                        @keydown.enter.prevent="openTool(item)"
+                        @keydown.space.prevent="openTool(item)"
+                    >
                         <div class="tool-brand">
                             <div class="tool-icon">
                                 <img
@@ -215,7 +217,7 @@
                                     :src="item.icon.src"
                                     alt=""
                                 />
-                                <el-icon v-else :size="16">
+                                <el-icon v-else :size="14">
                                     <Tools />
                                 </el-icon>
                             </div>
@@ -224,31 +226,41 @@
                                 <div class="tool-title">
                                     {{ item.title || item.name }}
                                 </div>
-                                <div v-if="!props.hideDesc" class="tool-name">
-                                    {{ item.server }}
+                                <div
+                                    v-if="
+                                        item.title && item.title !== item.name
+                                    "
+                                    class="tool-name"
+                                >
+                                    {{ item.name }}
                                 </div>
                             </div>
                         </div>
 
-                        <el-switch
-                            :model-value="item.enabled"
-                            :loading="item.updating"
-                            :disabled="item.updating"
-                            @click.stop
-                            @change="
-                                (value) => toggleTool(item, value as boolean)
-                            "
-                        />
-                    </div>
-
-                    <div v-if="!props.hideDesc" class="tool-description">
-                        {{ item.description || '这个工具暂时没有说明。' }}
+                        <div class="tool-controls" @click.stop @keydown.stop>
+                            <el-switch
+                                :model-value="item.enabled"
+                                :loading="item.updating"
+                                :disabled="item.updating"
+                                :aria-label="`${item.enabled ? '禁用' : '启用'}工具 ${item.name}`"
+                                @change="
+                                    (value) =>
+                                        toggleTool(item, value as boolean)
+                                "
+                            />
+                        </div>
                     </div>
                 </div>
-            </div>
 
-            <div v-else class="empty-state empty-tools">
-                <el-empty description="当前还没有可用工具。" />
+                <div v-else class="empty-state empty-tools">
+                    <el-empty
+                        :description="
+                            selectedServer
+                                ? '该服务器当前没有可用工具。'
+                                : '请先添加一个 MCP 服务器。'
+                        "
+                    />
+                </div>
             </div>
         </div>
 
@@ -359,7 +371,17 @@
                 </div>
 
                 <div class="form-group">
-                    <label class="form-label">超时时间 (秒)</label>
+                    <label class="form-label">启动超时 (秒)</label>
+                    <el-input-number
+                        v-model="form.startupTimeout"
+                        :min="1"
+                        :max="300"
+                        style="width: 100%"
+                    />
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label">工具调用超时 (秒)</label>
                     <el-input-number
                         v-model="form.timeout"
                         :min="1"
@@ -482,7 +504,14 @@
                                 </div>
 
                                 <div class="preview-field">
-                                    <span class="field-label">超时</span>
+                                    <span class="field-label">启动超时</span>
+                                    <span class="field-value">
+                                        {{ form.startupTimeout }}s
+                                    </span>
+                                </div>
+
+                                <div class="preview-field">
+                                    <span class="field-label">工具调用超时</span>
                                     <span class="field-value">
                                         {{ form.timeout }}s
                                     </span>
@@ -521,9 +550,15 @@
                     <el-input :model-value="toolForm.name" disabled />
                 </div>
 
-                <div class="form-group">
-                    <label class="form-label">来源服务器</label>
-                    <el-input :model-value="toolForm.server" disabled />
+                <div class="form-span tool-description-field">
+                    <label class="form-label">工具描述</label>
+                    <el-input
+                        :model-value="toolForm.description || '暂无工具描述'"
+                        type="textarea"
+                        :rows="4"
+                        resize="none"
+                        readonly
+                    />
                 </div>
 
                 <div class="form-group">
@@ -562,13 +597,14 @@ import { computed, reactive, ref, watch } from 'vue'
 import { send } from '@koishijs/client'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import {
+    Check,
     Connection,
+    MoreFilled,
     Plus,
     RefreshRight,
     Tools,
     Menu,
-    Document,
-    More
+    Document
 } from '@element-plus/icons-vue'
 import type {
     McpConfig,
@@ -583,6 +619,23 @@ import CodeEditor from '../shared/code-editor.vue'
 function getServerType(config: McpServerConfig) {
     return config.type ?? (config.url ? 'http' : 'stdio')
 }
+
+function stateTag(state?: McpServerState) {
+    if (state === 'connected') {
+        return 'success'
+    }
+
+    if (state === 'connecting' || state === 'reconnecting') {
+        return 'warning'
+    }
+
+    if (state === 'error') {
+        return 'danger'
+    }
+
+    return 'info'
+}
+
 function stateLabel(state?: McpServerState) {
     if (state === 'connected') {
         return '已连接'
@@ -824,6 +877,7 @@ const savingServer = ref(false)
 const savingTool = ref(false)
 const reloading = ref(false)
 const editing = ref('')
+const selectedServerName = ref('')
 const serverMode = ref<'form' | 'json'>('form')
 const serverJson = ref('')
 const syncing = ref(false)
@@ -893,6 +947,7 @@ const form = reactive({
     env: '{}',
     url: '',
     headers: '{}',
+    startupTimeout: 20,
     timeout: 60,
     cwd: '',
     proxy: ''
@@ -900,7 +955,7 @@ const form = reactive({
 
 const toolForm = reactive({
     name: '',
-    server: '',
+    description: '',
     enabled: true,
     timeout: 0,
     selector: ''
@@ -911,7 +966,6 @@ const servers = computed(() =>
         .map(([name, server]) => ({
             name,
             kind: getServerType(server),
-            endpoint: server.command || server.url || '',
             server,
             status: props.status.servers[name],
             updating:
@@ -932,34 +986,34 @@ const tools = computed(() =>
         .sort((a, b) => a.name.localeCompare(b.name))
 )
 
-function endpointLabel(item: {
-    kind: string
-    endpoint: string
-    server: McpServerConfig
-}) {
-    if (item.kind === 'stdio') {
-        const cmd = item.server.command || item.endpoint
-        const args = (item.server.args ?? []).join(' ')
-        if (!cmd) return '尚未填写入口'
-        return args ? `${cmd} ${args}` : cmd
-    }
-    return item.endpoint || '尚未填写入口'
+const selectedServer = computed(() =>
+    servers.value.find((server) => server.name === selectedServerName.value)
+)
+
+const visibleTools = computed(() => selectedServer.value?.tools ?? [])
+
+watch(
+    servers,
+    (value) => {
+        if (!value.some((server) => server.name === selectedServerName.value)) {
+            selectedServerName.value = value[0]?.name ?? ''
+        }
+    },
+    { immediate: true }
+)
+
+function envCount(server: McpServerConfig) {
+    return Object.keys(server.env || {}).length
 }
 
-function stateClass(item: {
-    updating: boolean
-    status?: { state?: McpServerState }
-}) {
-    const state = item.updating ? 'reconnecting' : item.status?.state
-    if (state === 'connected') return 'is-connected'
-    if (state === 'connecting' || state === 'reconnecting') return 'is-pending'
-    if (state === 'error') return 'is-error'
-    return 'is-idle'
+function headerCount(server: McpServerConfig) {
+    return Object.keys(server.headers || {}).length
 }
 
 function getFormConfig() {
     const config: McpServerConfig = {
         type: form.type,
+        startupTimeout: form.startupTimeout,
         timeout: form.timeout
     }
 
@@ -1002,6 +1056,7 @@ function fillForm(name: string, server: McpServerConfig) {
     form.env = JSON.stringify(next.env ?? {}, null, 2)
     form.url = next.url ?? ''
     form.headers = JSON.stringify(next.headers ?? {}, null, 2)
+    form.startupTimeout = next.startupTimeout ?? 20
     form.timeout = next.timeout ?? 60
     form.cwd = next.cwd ?? ''
     form.proxy = next.proxy ?? ''
@@ -1029,6 +1084,7 @@ function syncJsonToForm() {
         form.env = JSON.stringify(parsed.config.env ?? {}, null, 2)
         form.url = parsed.config.url ?? ''
         form.headers = JSON.stringify(parsed.config.headers ?? {}, null, 2)
+        form.startupTimeout = parsed.config.startupTimeout ?? 20
         form.timeout = parsed.config.timeout ?? 60
         form.cwd = parsed.config.cwd ?? ''
         form.proxy = parsed.config.proxy ?? ''
@@ -1080,37 +1136,9 @@ function openEdit(name: string) {
     showServerDialog.value = true
 }
 
-function onServerMenu(
-    command: string,
-    item: {
-        name: string
-        updating: boolean
-        tools: { enabled: boolean; updating?: boolean }[]
-    }
-) {
-    if (command === 'toggle-tools') {
-        toggleServerTools(item.name)
-        return
-    }
-
-    if (command === 'edit') {
-        openEdit(item.name)
-        return
-    }
-
-    if (command === 'reconnect') {
-        reconnect(item.name)
-        return
-    }
-
-    if (command === 'remove') {
-        removeServer(item.name)
-    }
-}
-
 function openTool(item: McpToolInfo) {
     toolForm.name = item.name
-    toolForm.server = item.server
+    toolForm.description = item.description
     toolForm.enabled = item.enabled
     toolForm.timeout = item.timeout ?? 0
     toolForm.selector = item.selector.join('\n')
@@ -1303,93 +1331,122 @@ async function saveTool() {
 .servers-view {
     display: flex;
     flex-direction: column;
-    gap: 24px;
-    min-width: 0;
+    gap: 18px;
 }
 
-.catalog-section {
-    min-width: 0;
+.panel {
+    border: 1px solid
+        color-mix(in srgb, var(--k-color-divider), transparent 18%);
+    border-radius: 16px;
+    background: color-mix(in srgb, var(--k-side-bg), var(--k-page-bg) 20%);
+    overflow: hidden;
+    box-sizing: border-box;
 }
 
-.catalog-controls {
+.panel-header {
     display: flex;
-    align-items: center;
     justify-content: space-between;
-    gap: 12px;
-    margin-bottom: 16px;
-    min-width: 0;
-    flex-wrap: wrap;
-}
-
-.tools-controls {
-    justify-content: flex-start;
-}
-
-.section-title {
-    font-size: 20px;
-    font-weight: 600;
-    line-height: 1.3;
-    color: var(--k-text-dark);
-    min-width: 0;
-}
-
-.catalog-actions {
-    display: flex;
     align-items: center;
-    gap: 8px;
-    flex-wrap: wrap;
-    min-width: 0;
-    margin-left: auto;
-}
-
-.catalog-actions :deep(.el-button) {
-    margin: 0;
-}
-
-.card-list {
-    --card-cols: 3;
-    display: grid;
-    grid-template-columns: repeat(var(--card-cols), minmax(0, 1fr));
+    padding: 16px 18px;
+    border-bottom: 1px solid
+        color-mix(in srgb, var(--k-color-divider), transparent 20%);
     gap: 16px;
     box-sizing: border-box;
 }
 
-.server-grid,
-.server-grid.compact {
-    --card-cols: 3;
+.panel-title {
+    font-size: 17px;
+    font-weight: 600;
+    color: var(--k-text-dark);
 }
 
-.tool-grid {
-    --card-cols: 5;
+.panel-description {
+    margin-top: 4px;
+    font-size: 12px;
+    line-height: 1.6;
+    color: var(--k-text-light);
 }
 
-.tool-grid.compact {
-    --card-cols: 4;
+.panel-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    height: 20px;
+    margin-left: 6px;
+    padding: 0 6px;
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--k-color-primary), transparent 88%);
+    color: var(--k-color-primary);
+    font-size: 12px;
+    font-weight: 600;
+    vertical-align: 2px;
+    box-sizing: border-box;
 }
 
-.server-card,
-.tool-card {
+.panel-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.card-list {
+    display: grid;
+    box-sizing: border-box;
+}
+
+.server-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+    padding: 14px;
+}
+
+.server-card {
+    position: relative;
     border: 1px solid
         color-mix(in srgb, var(--k-color-divider), transparent 18%);
-    border-radius: 12px;
-    background: color-mix(in srgb, var(--k-activity-bg), var(--k-page-bg) 16%);
-    padding: 14px;
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--k-activity-bg), var(--k-page-bg) 18%);
+    padding: 12px;
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 8px;
     box-sizing: border-box;
-    transition: border-color 0.2s ease;
+    transition:
+        border-color 0.18s ease,
+        background-color 0.18s ease,
+        box-shadow 0.18s ease;
     min-width: 0;
     overflow: hidden;
+    cursor: pointer;
+    outline: none;
 }
 
-.server-card:hover,
-.tool-card:hover {
-    border-color: color-mix(in srgb, var(--k-color-primary), transparent 40%);
+.server-card:hover {
+    border-color: color-mix(in srgb, var(--k-color-primary), transparent 48%);
+    background: color-mix(
+        in srgb,
+        var(--k-color-primary),
+        var(--k-activity-bg) 95%
+    );
 }
 
-.server-card.busy,
-.tool-card.busy {
+.server-card:focus-visible {
+    box-shadow: 0 0 0 2px
+        color-mix(in srgb, var(--k-color-primary), transparent 72%);
+}
+
+.server-card.selected {
+    border-color: var(--k-color-primary);
+    background: color-mix(
+        in srgb,
+        var(--k-color-primary),
+        var(--k-activity-bg) 92%
+    );
+    box-shadow: inset 3px 0 0 var(--k-color-primary);
+}
+
+.server-card.busy {
     border-color: color-mix(in srgb, var(--el-color-warning), transparent 68%);
     background: color-mix(
         in srgb,
@@ -1398,49 +1455,78 @@ async function saveTool() {
     );
 }
 
-.server-head,
-.tool-top {
+.server-card.selected.busy {
+    box-shadow: inset 3px 0 0 var(--el-color-warning);
+}
+
+.server-selected-mark {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 24px;
+    height: 24px;
+    border-radius: 0 7px 0 8px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--k-color-primary);
+    color: white;
+    font-size: 13px;
+}
+
+.server-head {
     display: flex;
     justify-content: space-between;
-    gap: 12px;
+    gap: 10px;
     align-items: flex-start;
-}
-
-.server-card.centered .server-head {
-    align-items: center;
-    min-height: 34px;
-}
-
-.tool-card.centered .tool-top {
-    align-items: center;
-    min-height: 34px;
+    padding-right: 28px;
 }
 
 .server-brand,
 .tool-brand {
     display: flex;
-    gap: 10px;
+    align-items: center;
+    gap: 8px;
     min-width: 0;
     flex: 1 1 auto;
 }
 
-.server-card.centered .server-brand,
-.tool-card.centered .tool-brand {
-    align-items: center;
-}
-
-.server-icon,
-.tool-icon {
-    width: 34px;
-    height: 34px;
-    border-radius: 10px;
-    background: color-mix(in srgb, var(--k-side-bg), var(--k-color-primary) 8%);
+.server-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    border: 1px solid
+        color-mix(in srgb, var(--k-color-divider), transparent 18%);
+    background: color-mix(in srgb, var(--k-side-bg), transparent 8%);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    color: color-mix(in srgb, var(--k-text-dark), var(--k-color-primary) 36%);
+    color: color-mix(in srgb, var(--k-text-dark), var(--k-color-primary) 28%);
     flex-shrink: 0;
     overflow: hidden;
+}
+
+.tool-icon {
+    width: 26px;
+    height: 26px;
+    border-radius: 6px;
+    border: 1px solid
+        color-mix(in srgb, var(--k-color-divider), transparent 25%);
+    background: color-mix(in srgb, var(--k-side-bg), transparent 8%);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: color-mix(in srgb, var(--k-text-dark), var(--k-color-primary) 28%);
+    flex-shrink: 0;
+    overflow: hidden;
+}
+
+.server-icon :deep(.el-icon) {
+    font-size: 16px;
+}
+
+.tool-icon :deep(.el-icon) {
+    font-size: 14px;
 }
 
 .server-icon img,
@@ -1456,209 +1542,303 @@ async function saveTool() {
     flex: 1 1 auto;
 }
 
-.server-card.centered .server-copy,
-.tool-card.centered .tool-copy {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-}
-
-.server-title,
-.tool-name,
-.server-sub {
+.server-title {
     font-size: 12px;
     color: var(--k-text-light);
-    line-height: 1.45;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.server-name,
-.tool-title {
-    font-size: 16px;
+.server-name {
+    margin-top: 2px;
+    font-size: 15px;
     font-weight: 600;
     color: var(--k-text-dark);
-    line-height: 1.4;
+    line-height: 1.3;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
-.server-state {
-    display: inline-flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 6px;
-    flex: 0 0 auto;
-    font-size: 12px;
-    line-height: 1.4;
-    color: var(--k-text-light);
-    white-space: nowrap;
-}
-
-.state-dot {
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    background: color-mix(in srgb, var(--k-text-light), transparent 20%);
-    flex: 0 0 auto;
-}
-
-.server-state.is-connected {
-    color: var(--el-color-success);
-}
-
-.server-state.is-connected .state-dot {
-    background: var(--el-color-success);
-}
-
-.server-state.is-pending {
-    color: var(--el-color-warning);
-}
-
-.server-state.is-pending .state-dot {
-    background: var(--el-color-warning);
-}
-
-.server-state.is-error {
-    color: var(--el-color-danger);
-}
-
-.server-state.is-error .state-dot {
-    background: var(--el-color-danger);
-}
-
-.tool-description {
-    font-size: 12px;
-    line-height: 1.6;
-    color: var(--k-text-light);
-    word-break: break-word;
-    overflow-wrap: anywhere;
-    display: -webkit-box;
-    -webkit-line-clamp: 4;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-}
-
-.tool-grid.compact .tool-description {
-    -webkit-line-clamp: 3;
-}
-
-.server-meta {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    min-width: 0;
-}
-
-.meta-chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    min-width: 0;
-}
-
-.meta-chips :deep(.el-tag) {
-    border-radius: 6px;
-}
-
-.meta-endpoint {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    min-width: 0;
-}
-
-.meta-endpoint span {
-    font-size: 11px;
-    line-height: 1.4;
-    color: var(--k-text-light);
-}
-
-.meta-endpoint code {
-    display: block;
-    min-width: 0;
+.tool-title {
+    font-size: 13px;
+    font-weight: 600;
     color: var(--k-text-dark);
-    font-family:
-        ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
-        'Courier New', monospace;
-    font-size: 11px;
-    line-height: 1.5;
+    line-height: 1.3;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
-.server-controls {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    flex: 0 0 auto;
+.tool-name {
+    margin-top: 2px;
+    font-size: 10px;
+    line-height: 1.2;
+    color: var(--k-text-light);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.server-footer {
+.server-kind {
+    margin-top: 4px;
     display: flex;
-    justify-content: flex-end;
-    margin-top: auto;
+    gap: 8px;
+    flex-wrap: wrap;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--k-text-light);
 }
 
-.more-btn {
-    --el-button-text-color: var(--k-text-light);
-    --el-button-hover-text-color: var(--k-text-dark);
-    padding: 4px;
-    min-height: 28px;
-    min-width: 28px;
+.tool-section {
+    border-top: 1px solid
+        color-mix(in srgb, var(--k-color-divider), transparent 20%);
 }
 
-.more-btn :deep(.el-icon) {
-    transform: rotate(90deg);
+.tool-panel-header {
+    border-bottom: 0;
+    padding-bottom: 10px;
+}
+
+.tool-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 8px;
+    padding: 0 14px 14px;
 }
 
 .tool-card {
+    min-width: 0;
+    min-height: 52px;
+    padding: 8px 10px;
+    border: 1px solid
+        color-mix(in srgb, var(--k-color-divider), transparent 18%);
+    border-radius: 7px;
+    background: color-mix(in srgb, var(--k-activity-bg), var(--k-page-bg) 18%);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    box-sizing: border-box;
+    transition:
+        border-color 0.18s ease,
+        background-color 0.18s ease;
     cursor: pointer;
+    outline: none;
+}
+
+.tool-card:hover {
+    border-color: color-mix(in srgb, var(--k-color-primary), transparent 62%);
+    background: color-mix(
+        in srgb,
+        var(--k-color-primary),
+        var(--k-activity-bg) 97%
+    );
+}
+
+.tool-card:focus-visible {
+    border-color: var(--k-color-primary);
+    box-shadow: 0 0 0 2px
+        color-mix(in srgb, var(--k-color-primary), transparent 76%);
+}
+
+.tool-card.busy {
+    border-color: color-mix(in srgb, var(--el-color-warning), transparent 68%);
+    background: color-mix(
+        in srgb,
+        var(--k-activity-bg),
+        var(--el-color-warning) 4%
+    );
+}
+
+.tool-controls {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex: 0 0 auto;
+}
+
+.meta-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.meta-card {
+    flex: 1 1 120px;
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--k-activity-bg), transparent 22%);
+    padding: 8px 10px;
+}
+
+.meta-wide {
+    flex-basis: 100%;
+}
+
+.meta-card span {
+    display: block;
+    font-size: 11px;
+    color: var(--k-text-light);
+}
+
+.meta-card strong {
+    display: block;
+    margin-top: 4px;
+    font-size: 13px;
+    color: var(--k-text-dark);
+    line-height: 1.4;
+    word-break: break-word;
 }
 
 @media (max-width: 1680px) {
-    .server-grid,
-    .server-grid.compact {
-        --card-cols: 3;
-    }
-
     .tool-grid {
-        --card-cols: 5;
-    }
-
-    .tool-grid.compact {
-        --card-cols: 4;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
     }
 }
 
 @media (max-width: 1320px) {
-    .server-grid {
-        --card-cols: 2;
-    }
-
-    .server-grid.compact {
-        --card-cols: 2;
-    }
-
     .tool-grid {
-        --card-cols: 3;
-    }
-
-    .tool-grid.compact {
-        --card-cols: 2;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 }
 
+.detail-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 10px;
+}
+
+.detail-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    font-size: 11px;
+    color: var(--k-text-light);
+}
+
+.detail-row span:last-child {
+    color: var(--k-text-dark);
+    text-align: right;
+    word-break: break-word;
+}
+
+.server-chips {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    padding-right: 32px;
+}
+
 .error-box {
-    padding: 8px 10px;
-    border-radius: 8px;
-    border-left: 3px solid var(--el-color-danger);
-    background: color-mix(in srgb, var(--el-color-danger), transparent 94%);
-    color: var(--el-color-danger);
-    font-size: 12px;
-    line-height: 1.45;
+    margin-top: 10px;
+    padding: 10px 12px;
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--el-color-danger), transparent 95%);
+    color: color-mix(in srgb, var(--el-color-danger), var(--k-text-dark) 36%);
+    font-size: 11px;
+    line-height: 1.5;
     word-break: break-word;
     overflow-wrap: anywhere;
+}
+
+.server-actions {
+    position: absolute;
+    right: 7px;
+    bottom: 7px;
+    display: flex;
+    align-items: center;
+}
+
+.server-menu {
+    width: 28px;
+    height: 28px;
+    color: var(--k-text-light);
+}
+
+.server-actions :deep(.neutral-outline.el-button) {
+    --el-button-bg-color: transparent;
+    --el-button-border-color: color-mix(
+        in srgb,
+        var(--k-color-divider),
+        transparent 12%
+    );
+    --el-button-text-color: var(--k-text-dark);
+    --el-button-hover-bg-color: color-mix(
+        in srgb,
+        var(--k-side-bg),
+        var(--k-page-bg) 18%
+    );
+    --el-button-hover-border-color: color-mix(
+        in srgb,
+        var(--k-color-divider),
+        transparent 0%
+    );
+    --el-button-hover-text-color: var(--k-text-dark);
+    --el-button-active-bg-color: color-mix(
+        in srgb,
+        var(--k-side-bg),
+        var(--k-page-bg) 26%
+    );
+    --el-button-active-border-color: color-mix(
+        in srgb,
+        var(--k-color-divider),
+        transparent 0%
+    );
+    --el-button-active-text-color: var(--k-text-dark);
+    --el-button-disabled-bg-color: color-mix(
+        in srgb,
+        var(--k-side-bg),
+        transparent 10%
+    );
+    --el-button-disabled-border-color: color-mix(
+        in srgb,
+        var(--k-color-divider),
+        transparent 24%
+    );
+    --el-button-disabled-text-color: var(--k-text-light);
+}
+
+.server-actions :deep(.danger-soft.el-button) {
+    --el-button-bg-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 92%
+    );
+    --el-button-border-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 68%
+    );
+    --el-button-text-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        var(--k-text-dark) 22%
+    );
+    --el-button-hover-bg-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 86%
+    );
+    --el-button-hover-border-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 52%
+    );
+    --el-button-hover-text-color: var(--el-color-danger);
+    --el-button-active-bg-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 82%
+    );
+    --el-button-active-border-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 44%
+    );
+    --el-button-active-text-color: var(--el-color-danger);
 }
 
 .empty-state {
@@ -1801,6 +1981,15 @@ async function saveTool() {
     overflow-wrap: anywhere;
 }
 
+.dialog-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid var(--k-color-divider);
+}
+
 .dialog-head {
     display: flex;
     justify-content: center;
@@ -1827,6 +2016,12 @@ async function saveTool() {
     flex: 1 1 100%;
 }
 
+.tool-description-field :deep(.el-textarea__inner) {
+    line-height: 1.6;
+    color: var(--k-text-dark);
+    background: color-mix(in srgb, var(--k-activity-bg), var(--k-page-bg) 35%);
+}
+
 .form-label {
     display: block;
     margin-bottom: 8px;
@@ -1842,34 +2037,14 @@ async function saveTool() {
 }
 
 @media (max-width: 768px) {
-    .card-list,
-    .card-list.compact,
-    .tool-grid,
-    .tool-grid.compact {
-        --card-cols: 1;
+    .server-grid,
+    .tool-grid {
         grid-template-columns: 1fr;
     }
 
-    .catalog-controls {
+    .panel-header {
         flex-direction: column;
-        align-items: stretch;
-        gap: 10px;
-        width: 100%;
-    }
-
-    .catalog-actions {
-        width: 100%;
-        margin-left: 0;
-        display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: 10px;
-    }
-
-    .catalog-actions :deep(.el-button) {
-        width: 100%;
-        min-width: 0;
-        margin: 0;
-        justify-content: center;
+        align-items: flex-start;
     }
 
     .dialog-grid > .form-group,
@@ -1881,24 +2056,20 @@ async function saveTool() {
     .server-card,
     .tool-card {
         width: 100%;
-        min-width: 0;
     }
 
     .json-layout {
         grid-template-columns: 1fr;
     }
 
-    .server-head {
-        flex-direction: column;
-        gap: 10px;
-    }
-
-    .server-state {
-        width: 100%;
-        justify-content: flex-start;
+    .meta-wide {
+        flex-basis: 100%;
     }
 }
 
+.tooltip-trigger-wrapper {
+    display: inline-flex;
+}
 
 .tooltip-trigger-wrapper :deep(.el-button.is-disabled),
 .tooltip-trigger-wrapper :deep(.el-button.is-loading) {

--- a/packages/extension-agent/client/components/mcp/mcp-servers-view.vue
+++ b/packages/extension-agent/client/components/mcp/mcp-servers-view.vue
@@ -34,8 +34,8 @@
                     role="button"
                     tabindex="0"
                     @click="selectedServerName = item.name"
-                    @keydown.enter.prevent="selectedServerName = item.name"
-                    @keydown.space.prevent="selectedServerName = item.name"
+                    @keydown.enter.self.prevent="selectedServerName = item.name"
+                    @keydown.space.self.prevent="selectedServerName = item.name"
                 >
                     <div class="server-head">
                         <div class="server-brand">
@@ -209,8 +209,8 @@
                     role="button"
                     tabindex="0"
                     @click="openTool(item)"
-                    @keydown.enter.prevent="openTool(item)"
-                    @keydown.space.prevent="openTool(item)"
+                    @keydown.enter.self.prevent="openTool(item)"
+                    @keydown.space.self.prevent="openTool(item)"
                 >
                     <div class="tool-top">
                         <div class="tool-brand">

--- a/packages/extension-agent/src/service/mcp.ts
+++ b/packages/extension-agent/src/service/mcp.ts
@@ -49,8 +49,7 @@ export class ChatLunaAgentMcpService {
             ([name, cfg]) => {
                 this._servers.set(name, {
                     state: 'idle',
-                    attempts: 0,
-                    generation: 0
+                    attempts: 0
                 })
                 return this._connect(name, cfg)
             }
@@ -64,13 +63,14 @@ export class ChatLunaAgentMcpService {
         this._stopped = true
 
         for (const srv of this._servers.values()) {
-            srv.generation += 1
             srv.reconnectDispose?.()
             srv.connectTask = undefined
-            if (srv.client) {
-                srv.client.onclose = undefined
-                srv.client.onerror = undefined
-                await srv.client.close().catch(() => {})
+            const client = srv.client
+            srv.client = undefined
+            if (client) {
+                client.onclose = undefined
+                client.onerror = undefined
+                await client.close().catch(() => {})
             }
         }
 
@@ -115,8 +115,7 @@ export class ChatLunaAgentMcpService {
         } else {
             this._servers.set(name, {
                 state: 'reconnecting',
-                attempts: 0,
-                generation: 0
+                attempts: 0
             })
         }
 
@@ -256,31 +255,47 @@ export class ChatLunaAgentMcpService {
             return false
         }
 
-        const generation = srv.generation + 1
-        srv.generation = generation
         srv.state = reconnecting ? 'reconnecting' : 'connecting'
         srv.error = undefined
         this.ctx.chatluna_agent?.refreshConsoleData()
 
-        let task: Promise<boolean>
-        task = (async () => {
+        const client = new Client({
+            name: 'ChatLuna',
+            version: '1.0.0',
+            title: 'ChatLuna ModelContext Protocol Client'
+        })
+        srv.client = client
+
+        const task = (async () => {
             logger.debug(`Connecting to server ${name}`)
             const startupTimeout = calcStartupTimeout(cfg)
-            const client = new Client({
-                name: 'ChatLuna',
-                version: '1.0.0',
-                title: 'ChatLuna ModelContext Protocol Client'
+            this._setupHandlers(client, name, cfg)
+            let clearTimer: (() => void) | undefined
+            const timeout = new Promise<never>((_resolve, reject) => {
+                clearTimer = this.ctx.setTimeout(() => {
+                    reject(
+                        new Error(
+                            `MCP server startup timed out after ${startupTimeout}ms`
+                        )
+                    )
+                }, startupTimeout)
             })
 
             try {
-                srv.client = client
-                this._setupHandlers(client, name, cfg, generation)
-                await client.connect(createTransport(name, cfg, this.plugin), {
-                    timeout: startupTimeout
-                })
+                try {
+                    await Promise.race([
+                        client.connect(
+                            createTransport(name, cfg, this.plugin),
+                            { timeout: startupTimeout }
+                        ),
+                        timeout
+                    ])
+                } finally {
+                    clearTimer?.()
+                }
 
                 const meta = client.getServerVersion()
-                if (!this._isCurrent(name, generation, client)) {
+                if (!this._isCurrent(name, client)) {
                     await client.close().catch(() => {})
                     return false
                 }
@@ -289,13 +304,8 @@ export class ChatLunaAgentMcpService {
                 srv.version = meta?.version
                 srv.icon = selectIcon(meta?.icons)
 
-                const toolCount = await this._registerTools(
-                    client,
-                    name,
-                    cfg,
-                    generation
-                )
-                if (toolCount == null || !this._isCurrent(name, generation, client)) {
+                const toolCount = await this._registerTools(client, name, cfg)
+                if (toolCount == null || !this._isCurrent(name, client)) {
                     await client.close().catch(() => {})
                     return false
                 }
@@ -309,12 +319,12 @@ export class ChatLunaAgentMcpService {
                 )
                 return true
             } catch (error) {
-                if (this._isCurrent(name, generation, client)) {
+                if (this._isCurrent(name, client)) {
                     await this._fail(
                         name,
                         cfg,
                         error instanceof Error ? error.message : String(error),
-                        generation
+                        client
                     )
                     logger.error(`Failed to connect to server ${name}`, error)
                 } else {
@@ -330,31 +340,33 @@ export class ChatLunaAgentMcpService {
             return await task
         } finally {
             const current = this._servers.get(name)
-            if (
-                current?.generation === generation &&
-                current.connectTask === task
-            ) {
+            if (current?.connectTask === task) {
                 current.connectTask = undefined
             }
         }
     }
 
-    private _setupHandlers(
-        client: Client,
-        name: string,
-        cfg: McpServerConfig,
-        generation: number
-    ) {
+    private _setupHandlers(client: Client, name: string, cfg: McpServerConfig) {
         client.onerror = (error) => {
-            if (this._isCurrent(name, generation, client)) {
-                void this._fail(name, cfg, error.message, generation)
+            if (this._isCurrent(name, client)) {
+                this._fail(name, cfg, error.message, client).catch((error) => {
+                    logger.error(
+                        `Failed to handle MCP error for ${name}`,
+                        error
+                    )
+                })
             }
         }
 
         client.onclose = () => {
-            if (this._isCurrent(name, generation, client)) {
+            if (this._isCurrent(name, client)) {
                 logger.debug(`Client closed: ${name}`)
-                void this._fail(name, cfg, '连接已断开', generation)
+                this._fail(name, cfg, '连接已断开', client).catch((error) => {
+                    logger.error(
+                        `Failed to handle MCP close for ${name}`,
+                        error
+                    )
+                })
             }
         }
 
@@ -366,8 +378,7 @@ export class ChatLunaAgentMcpService {
                     const toolCount = await this._registerTools(
                         client,
                         name,
-                        cfg,
-                        generation
+                        cfg
                     )
                     if (toolCount == null) {
                         return
@@ -377,13 +388,13 @@ export class ChatLunaAgentMcpService {
                             name,
                             cfg,
                             '工具列表为空，等待重连',
-                            generation
+                            client
                         )
                         return
                     }
 
                     const srv = this._servers.get(name)
-                    if (srv?.generation === generation) {
+                    if (srv?.client === client) {
                         srv.error = undefined
                         srv.state = 'connected'
                     }
@@ -394,7 +405,7 @@ export class ChatLunaAgentMcpService {
                         name,
                         cfg,
                         error instanceof Error ? error.message : String(error),
-                        generation
+                        client
                     )
                     logger.error(
                         `Failed to handle tool list change for ${name}`,
@@ -409,12 +420,12 @@ export class ChatLunaAgentMcpService {
         name: string,
         cfg: McpServerConfig,
         error: string,
-        generation?: number
+        client: Client
     ) {
         if (this._stopped) return
 
         const srv = this._servers.get(name)
-        if (!srv || (generation != null && srv.generation !== generation)) {
+        if (srv?.client !== client) {
             return
         }
         srv.error = error
@@ -453,13 +464,12 @@ export class ChatLunaAgentMcpService {
     private async _registerTools(
         client: Client,
         serverName: string,
-        cfg: McpServerConfig,
-        generation: number
+        cfg: McpServerConfig
     ): Promise<number | undefined> {
         const mcpTools = await client.listTools(undefined, {
             timeout: calcStartupTimeout(cfg)
         })
-        if (!this._isCurrent(serverName, generation, client)) {
+        if (!this._isCurrent(serverName, client)) {
             return
         }
         const serverCfg = this.config.mcp.mcpServers[serverName]
@@ -572,34 +582,32 @@ export class ChatLunaAgentMcpService {
     }
 
     private _runInBackground(tasks: Promise<unknown>[], reason: string) {
-        void Promise.allSettled(tasks).then(() => {
+        Promise.allSettled(tasks).then(() => {
             if (this._stopped) return
-            logger.info(`${reason} finished with ${this._disposers.size} tool(s)`)
+            logger.info(
+                `${reason} finished with ${this._disposers.size} tool(s)`
+            )
             this.ctx.chatluna_agent?.refreshConsoleData()
         })
     }
 
-    private _isCurrent(name: string, generation: number, client: Client) {
+    private _isCurrent(name: string, client: Client) {
         const srv = this._servers.get(name)
-        return (
-            !this._stopped &&
-            srv?.generation === generation &&
-            srv.client === client
-        )
+        return !this._stopped && srv?.client === client
     }
 
     private async _drop(name: string, clearTools = true) {
         const srv = this._servers.get(name)
         if (srv) {
-            srv.generation += 1
             srv.reconnectDispose?.()
             srv.reconnectDispose = undefined
             srv.connectTask = undefined
-            if (srv.client) {
-                srv.client.onclose = undefined
-                srv.client.onerror = undefined
-                await srv.client.close().catch(() => {})
-                srv.client = undefined
+            const client = srv.client
+            srv.client = undefined
+            if (client) {
+                client.onclose = undefined
+                client.onerror = undefined
+                await client.close().catch(() => {})
             }
         }
 
@@ -648,7 +656,6 @@ type ServerInfo = {
     state: McpServerState
     error?: string
     attempts: number
-    generation: number
     reconnectDispose?: () => void
     connectTask?: Promise<boolean>
     title?: string

--- a/packages/extension-agent/src/service/mcp.ts
+++ b/packages/extension-agent/src/service/mcp.ts
@@ -45,14 +45,18 @@ export class ChatLunaAgentMcpService {
             return
         }
 
-        await Promise.all(
-            Object.entries(this.config.mcp.mcpServers).map(([name, cfg]) => {
-                this._servers.set(name, { state: 'idle', attempts: 0 })
+        const tasks = Object.entries(this.config.mcp.mcpServers).map(
+            ([name, cfg]) => {
+                this._servers.set(name, {
+                    state: 'idle',
+                    attempts: 0,
+                    generation: 0
+                })
                 return this._connect(name, cfg)
-            })
+            }
         )
 
-        logger.info(`MCP service started with ${this._disposers.size} tool(s)`)
+        this._runInBackground(tasks, 'MCP startup')
         this.ctx.chatluna_agent?.refreshConsoleData()
     }
 
@@ -60,8 +64,12 @@ export class ChatLunaAgentMcpService {
         this._stopped = true
 
         for (const srv of this._servers.values()) {
+            srv.generation += 1
             srv.reconnectDispose?.()
+            srv.connectTask = undefined
             if (srv.client) {
+                srv.client.onclose = undefined
+                srv.client.onerror = undefined
                 await srv.client.close().catch(() => {})
             }
         }
@@ -84,7 +92,10 @@ export class ChatLunaAgentMcpService {
 
         const names = Object.keys(this.config.mcp.mcpServers)
         if (names.length > 0) {
-            await Promise.all(names.map((name) => this.reconnect(name)))
+            this._runInBackground(
+                names.map((name) => this.reconnect(name)),
+                'MCP reload'
+            )
         }
         this.ctx.chatluna_agent?.refreshConsoleData()
     }
@@ -102,7 +113,11 @@ export class ChatLunaAgentMcpService {
             srv.error = undefined
             srv.state = 'reconnecting'
         } else {
-            this._servers.set(name, { state: 'reconnecting', attempts: 0 })
+            this._servers.set(name, {
+                state: 'reconnecting',
+                attempts: 0,
+                generation: 0
+            })
         }
 
         this.ctx.chatluna_agent?.refreshConsoleData()
@@ -157,8 +172,9 @@ export class ChatLunaAgentMcpService {
         this.ctx.chatluna_agent?.refreshConsoleData()
 
         if (changed.size > 0) {
-            await Promise.all(
-                Array.from(changed).map((name) => this.reconnect(name))
+            this._runInBackground(
+                Array.from(changed).map((name) => this.reconnect(name)),
+                'MCP config sync'
             )
         }
     }
@@ -236,81 +252,109 @@ export class ChatLunaAgentMcpService {
         if (srv?.connectTask) {
             return srv.connectTask
         }
+        if (!srv || this._stopped) {
+            return false
+        }
 
-        const task = (async () => {
+        const generation = srv.generation + 1
+        srv.generation = generation
+        srv.state = reconnecting ? 'reconnecting' : 'connecting'
+        srv.error = undefined
+        this.ctx.chatluna_agent?.refreshConsoleData()
+
+        let task: Promise<boolean>
+        task = (async () => {
             logger.debug(`Connecting to server ${name}`)
-            const srv = this._servers.get(name)
-            if (srv) {
-                srv.state = reconnecting ? 'reconnecting' : 'connecting'
-                srv.error = undefined
-            }
-            this.ctx.chatluna_agent?.refreshConsoleData()
+            const startupTimeout = calcStartupTimeout(cfg)
+            const client = new Client({
+                name: 'ChatLuna',
+                version: '1.0.0',
+                title: 'ChatLuna ModelContext Protocol Client'
+            })
 
             try {
-                await this._drop(name, false)
-
-                const client = new Client({
-                    name: 'ChatLuna',
-                    version: '1.0.0',
-                    title: 'ChatLuna ModelContext Protocol Client'
+                srv.client = client
+                this._setupHandlers(client, name, cfg, generation)
+                await client.connect(createTransport(name, cfg, this.plugin), {
+                    timeout: startupTimeout
                 })
 
-                this._setupHandlers(client, name, cfg)
-                await client.connect(createTransport(name, cfg, this.plugin))
-
                 const meta = client.getServerVersion()
-                const srv = this._servers.get(name)
-                if (srv) {
-                    srv.client = client
-                    srv.state = 'connected'
-                    srv.error = undefined
-                    srv.attempts = 0
-                    srv.title = meta?.title ?? meta?.name
-                    srv.version = meta?.version
-                    srv.icon = selectIcon(meta?.icons)
+                if (!this._isCurrent(name, generation, client)) {
+                    await client.close().catch(() => {})
+                    return false
                 }
 
-                await this._registerTools(client, name)
-                this.ctx.chatluna_agent?.refreshConsoleData()
-                logger.debug(`MCP client connected: ${name}`)
-                return true
-            } catch (error) {
-                await this._fail(
+                srv.title = meta?.title ?? meta?.name
+                srv.version = meta?.version
+                srv.icon = selectIcon(meta?.icons)
+
+                const toolCount = await this._registerTools(
+                    client,
                     name,
                     cfg,
-                    error instanceof Error ? error.message : String(error)
+                    generation
                 )
-                logger.error(`Failed to connect to server ${name}`, error)
+                if (toolCount == null || !this._isCurrent(name, generation, client)) {
+                    await client.close().catch(() => {})
+                    return false
+                }
+
+                srv.state = 'connected'
+                srv.error = undefined
+                srv.attempts = 0
+                this.ctx.chatluna_agent?.refreshConsoleData()
+                logger.info(
+                    `MCP client connected: ${name} (${toolCount} tool(s))`
+                )
+                return true
+            } catch (error) {
+                if (this._isCurrent(name, generation, client)) {
+                    await this._fail(
+                        name,
+                        cfg,
+                        error instanceof Error ? error.message : String(error),
+                        generation
+                    )
+                    logger.error(`Failed to connect to server ${name}`, error)
+                } else {
+                    await client.close().catch(() => {})
+                }
                 return false
             }
         })()
 
-        const srv2 = this._servers.get(name)
-        if (srv2) {
-            srv2.connectTask = task
-        }
+        srv.connectTask = task
 
         try {
             return await task
         } finally {
-            const srv3 = this._servers.get(name)
-            if (srv3) {
-                srv3.connectTask = undefined
+            const current = this._servers.get(name)
+            if (
+                current?.generation === generation &&
+                current.connectTask === task
+            ) {
+                current.connectTask = undefined
             }
         }
     }
 
-    private _setupHandlers(client: Client, name: string, cfg: McpServerConfig) {
+    private _setupHandlers(
+        client: Client,
+        name: string,
+        cfg: McpServerConfig,
+        generation: number
+    ) {
         client.onerror = (error) => {
-            if (!this._stopped) {
-                this._fail(name, cfg, error.message)
+            if (this._isCurrent(name, generation, client)) {
+                void this._fail(name, cfg, error.message, generation)
             }
         }
 
         client.onclose = () => {
-            if (!this._stopped) {
+            if (this._isCurrent(name, generation, client)) {
                 logger.debug(`Client closed: ${name}`)
-                this._fail(name, cfg, '连接已断开')
+                void this._fail(name, cfg, '连接已断开', generation)
             }
         }
 
@@ -319,15 +363,27 @@ export class ChatLunaAgentMcpService {
             async () => {
                 logger.info(`Tool list changed for server: ${name}`)
                 try {
-                    const mcpTools = await client.listTools()
-                    if (mcpTools.tools.length === 0) {
-                        await this._fail(name, cfg, '工具列表为空，等待重连')
+                    const toolCount = await this._registerTools(
+                        client,
+                        name,
+                        cfg,
+                        generation
+                    )
+                    if (toolCount == null) {
+                        return
+                    }
+                    if (toolCount === 0) {
+                        await this._fail(
+                            name,
+                            cfg,
+                            '工具列表为空，等待重连',
+                            generation
+                        )
                         return
                     }
 
-                    await this._registerTools(client, name)
                     const srv = this._servers.get(name)
-                    if (srv) {
+                    if (srv?.generation === generation) {
                         srv.error = undefined
                         srv.state = 'connected'
                     }
@@ -337,7 +393,8 @@ export class ChatLunaAgentMcpService {
                     await this._fail(
                         name,
                         cfg,
-                        error instanceof Error ? error.message : String(error)
+                        error instanceof Error ? error.message : String(error),
+                        generation
                     )
                     logger.error(
                         `Failed to handle tool list change for ${name}`,
@@ -348,29 +405,33 @@ export class ChatLunaAgentMcpService {
         )
     }
 
-    private async _fail(name: string, cfg: McpServerConfig, error: string) {
+    private async _fail(
+        name: string,
+        cfg: McpServerConfig,
+        error: string,
+        generation?: number
+    ) {
         if (this._stopped) return
 
         const srv = this._servers.get(name)
-        if (srv) {
-            srv.error = error
-            srv.state = 'error'
+        if (!srv || (generation != null && srv.generation !== generation)) {
+            return
         }
+        srv.error = error
+        srv.state = 'error'
 
         await this._drop(name, false)
         this.ctx.chatluna_agent?.refreshConsoleData()
 
-        const attempts = srv?.attempts ?? 0
+        if (this._stopped || !this.config.mcp.mcpServers[name]) return
+
+        const attempts = srv.attempts
         if (attempts >= 5) {
             logger.error(`Max reconnect attempts reached for ${name}`)
             return
         }
 
-        if (srv) {
-            srv.state = 'reconnecting'
-        }
-        this.ctx.chatluna_agent?.refreshConsoleData()
-
+        srv.state = 'reconnecting'
         const delay = Math.min(1000 * Math.pow(2, attempts), 30000)
         logger.info(
             `Scheduling reconnect in ${delay}ms (attempt ${attempts + 1}/5)`
@@ -385,13 +446,22 @@ export class ChatLunaAgentMcpService {
             await this._connect(name, cfg, true)
         }, delay)
 
-        if (srv) {
-            srv.reconnectDispose = dispose
-        }
+        srv.reconnectDispose = dispose
+        this.ctx.chatluna_agent?.refreshConsoleData()
     }
 
-    private async _registerTools(client: Client, serverName: string) {
-        const mcpTools = await client.listTools()
+    private async _registerTools(
+        client: Client,
+        serverName: string,
+        cfg: McpServerConfig,
+        generation: number
+    ): Promise<number | undefined> {
+        const mcpTools = await client.listTools(undefined, {
+            timeout: calcStartupTimeout(cfg)
+        })
+        if (!this._isCurrent(serverName, generation, client)) {
+            return
+        }
         const serverCfg = this.config.mcp.mcpServers[serverName]
         if (!serverCfg) return
 
@@ -498,12 +568,33 @@ export class ChatLunaAgentMcpService {
         }
 
         this.ctx.chatluna_agent?.permission.invalidateCache()
+        return mcpTools.tools.length
+    }
+
+    private _runInBackground(tasks: Promise<unknown>[], reason: string) {
+        void Promise.allSettled(tasks).then(() => {
+            if (this._stopped) return
+            logger.info(`${reason} finished with ${this._disposers.size} tool(s)`)
+            this.ctx.chatluna_agent?.refreshConsoleData()
+        })
+    }
+
+    private _isCurrent(name: string, generation: number, client: Client) {
+        const srv = this._servers.get(name)
+        return (
+            !this._stopped &&
+            srv?.generation === generation &&
+            srv.client === client
+        )
     }
 
     private async _drop(name: string, clearTools = true) {
         const srv = this._servers.get(name)
         if (srv) {
+            srv.generation += 1
             srv.reconnectDispose?.()
+            srv.reconnectDispose = undefined
+            srv.connectTask = undefined
             if (srv.client) {
                 srv.client.onclose = undefined
                 srv.client.onerror = undefined
@@ -557,6 +648,7 @@ type ServerInfo = {
     state: McpServerState
     error?: string
     attempts: number
+    generation: number
     reconnectDispose?: () => void
     connectTask?: Promise<boolean>
     title?: string
@@ -573,6 +665,10 @@ function calcTimeout(
     serverTimeout: number | undefined
 ) {
     return ((toolTimeout ?? 0) || serverTimeout || 60) * 1000
+}
+
+function calcStartupTimeout(server: McpServerConfig) {
+    return Math.max(1, server.startupTimeout ?? 20) * 1000
 }
 
 function stateText(

--- a/packages/extension-agent/src/types/mcp.ts
+++ b/packages/extension-agent/src/types/mcp.ts
@@ -21,6 +21,8 @@ export interface McpServerConfig {
     type?: 'stdio' | 'sse' | 'http' | 'streamable_http'
     url?: string
     headers?: Record<string, string>
+    /** MCP initialize/listTools timeout in seconds. */
+    startupTimeout?: number
     timeout?: number
     cwd?: string
     proxy?: string

--- a/packages/extension-agent/src/types/mcp.ts
+++ b/packages/extension-agent/src/types/mcp.ts
@@ -21,7 +21,7 @@ export interface McpServerConfig {
     type?: 'stdio' | 'sse' | 'http' | 'streamable_http'
     url?: string
     headers?: Record<string, string>
-    /** MCP initialize/listTools timeout in seconds. */
+    /** MCP connection and tool discovery timeout in seconds. */
     startupTimeout?: number
     timeout?: number
     cwd?: string


### PR DESCRIPTION
1. MCP 启动与 WebUI 解耦：各 MCP Server 改为独立后台连接，慢服务器不再阻塞 Agent 和控制台启动；连接与工具发现使用独立启动超时，并增加连接代次校验、重连清理与 WebSocket 断线期间的刷新排队，避免用户进入 WebUI 或切换页面时等待全部 MCP 完成以及出现刷新失败提示。

2. MCP 工具界面优化：将 Server 作为一级选择入口，使用紧凑且带连接状态、传输类型、工具数量和选中态的服务器卡片，不再展示 stdio 命令；Tool 区域只显示当前 Server 的工具，点击工具卡片直接进入包含工具名称与描述的设置界面，从而降低工具数量较多时的视觉压力。