### PR TITLE
feat(multimodal): cache image descriptions by URL

### DIFF
--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -146,7 +146,12 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                         resolved.constraint,
                         resolved.conversation
                     ) ?? '',
-                    undefined,
+                    {
+                        content: '',
+                        name: session.username,
+                        conversationId: resolved.conversation?.id,
+                        additional_kwargs: {}
+                    },
                     {
                         quote: false,
                         includeQuoteReply: config.includeQuoteReply

--- a/packages/core/src/middlewares/chat/rollback_chat.ts
+++ b/packages/core/src/middlewares/chat/rollback_chat.ts
@@ -204,7 +204,12 @@ async function rollbackConversation(
             transformMessageContentToElements(humanContent),
             ctx.chatluna.conversation.pickModel(resolved.constraint, current) ??
                 current.model,
-            undefined,
+            {
+                content: '',
+                name: session.username,
+                conversationId: current.id,
+                additional_kwargs: {}
+            },
             {
                 quote: false,
                 includeQuoteReply: config.includeQuoteReply

--- a/packages/core/src/services/message_transform.ts
+++ b/packages/core/src/services/message_transform.ts
@@ -67,6 +67,7 @@ export class MessageTransformer {
                 {
                     content: '',
                     name: session.username,
+                    conversationId: message.conversationId,
                     additional_kwargs: {}
                 },
                 {

--- a/packages/service-multimodal/src/plugins/image.ts
+++ b/packages/service-multimodal/src/plugins/image.ts
@@ -1,17 +1,20 @@
 import { Context } from 'koishi'
-import { Message } from 'koishi-plugin-chatluna'
-import { ChatLunaChatModel } from 'koishi-plugin-chatluna/llm-core/platform/model'
 import { ModelCapabilities } from 'koishi-plugin-chatluna/llm-core/platform/types'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { Config, logger } from '..'
 import {
     addImageToContent,
     addTextToContent,
-    imageDescriptions,
+    buildDescribeMessage,
+    getOrDescribeImage,
     parseGifToFrames,
     processImageWithModel,
-    readImage
+    readImage,
+    singleFlight
 } from '../utils'
+
+type ImageData = Awaited<ReturnType<typeof readImage>>
+const imageLoads = new Map<string, Promise<ImageData>>()
 
 /**
  * Intercept image elements. Native-capable models receive the data URL
@@ -39,40 +42,74 @@ export async function apply(
                     return false
                 }
 
-                const cached = imageDescriptions.get(url)
-                if (!native && cached != null) {
-                    if (
-                        cached.mimeType === 'image/gif' &&
-                        !config.enableContextGifHandling
-                    ) {
-                        return false
-                    }
-                    addTextToContent(message, '\n\n' + cached.description)
+                const scope = message.conversationId
+                const imageData = await singleFlight(
+                    imageLoads,
+                    scope == null ? undefined : `${scope}\0${url}`,
+                    () => readImage(ctx, url)
+                )
+                if (imageData.buffer == null || imageData.ext == null) {
                     return false
                 }
 
-                const imageData = await readImage(ctx, url)
-                if (imageData.ext == null) return false
-
-                const isGif = imageData.ext === 'image/gif'
-                if (isGif && !config.enableContextGifHandling) return false
+                const mime = imageData.ext
+                if (mime === 'image/gif' && !config.enableContextGifHandling) {
+                    return false
+                }
 
                 if (native) {
-                    if (isGif) {
-                        await injectGifFrames(message, imageData.buffer, config)
+                    if (mime === 'image/gif') {
+                        const frames = await parseGifToFrames(
+                            imageData.buffer,
+                            {
+                                strategy: config.gifStrategy,
+                                frameCount: config.gifFrameCount
+                            }
+                        )
+                        logger.debug(
+                            `Extracted ${frames.length} frames from GIF`
+                        )
+                        for (const frame of frames) {
+                            addImageToContent(message, frame)
+                        }
                         addTextToContent(message, '[image: GIF]')
                     }
                     return false
                 }
 
-                await describeAndInject(
-                    message,
-                    imageData,
-                    isGif,
-                    config,
-                    imageUnderstandModel.value,
-                    url
-                )
+                try {
+                    const text = await getOrDescribeImage(
+                        scope,
+                        imageData.buffer,
+                        config,
+                        async () => {
+                            const imageModel = imageUnderstandModel.value
+                            if (
+                                imageModel == null ||
+                                !imageModel.modelInfo.capabilities.includes(
+                                    ModelCapabilities.ImageInput
+                                )
+                            ) {
+                                logger.warn(
+                                    `Image-description model "${config.imageModel}" is missing or lacks image input — skip.`
+                                )
+                                return null
+                            }
+                            return processImageWithModel(
+                                imageModel,
+                                config,
+                                await buildDescribeMessage(
+                                    imageData.buffer,
+                                    mime,
+                                    config
+                                )
+                            )
+                        }
+                    )
+                    if (text != null) addTextToContent(message, '\n\n' + text)
+                } catch (error) {
+                    logger.warn(`Image describe failed:`, error)
+                }
                 return false
             },
             100
@@ -88,62 +125,4 @@ function modelAcceptsImage(ctx: Context, model: string | undefined): boolean {
             ?.value?.capabilities?.includes(ModelCapabilities.ImageInput) ===
         true
     )
-}
-
-async function injectGifFrames(
-    message: Message,
-    buffer: Buffer,
-    config: Config
-): Promise<void> {
-    const frames = await parseGifToFrames(buffer, {
-        strategy: config.gifStrategy,
-        frameCount: config.gifFrameCount
-    })
-    logger.debug(`Extracted ${frames.length} frames from GIF`)
-    for (const frame of frames) addImageToContent(message, frame)
-}
-
-async function describeAndInject(
-    message: Message,
-    imageData: Awaited<ReturnType<typeof readImage>>,
-    isGif: boolean,
-    config: Config,
-    imageModel: ChatLunaChatModel | undefined,
-    url: string
-): Promise<boolean> {
-    if (
-        imageModel == null ||
-        !imageModel.modelInfo.capabilities.includes(
-            ModelCapabilities.ImageInput
-        )
-    ) {
-        logger.warn(
-            `Image-description model "${config.imageModel}" is missing or lacks image input — skip.`
-        )
-        return false
-    }
-
-    try {
-        const fake: Message = { content: [] }
-        if (isGif) {
-            addTextToContent(fake, 'This is a GIF image. See the frames below:')
-            await injectGifFrames(fake, imageData.buffer, config)
-        } else if (imageData.base64Source) {
-            addImageToContent(fake, imageData.base64Source)
-        }
-        const result = await processImageWithModel(imageModel, config, fake)
-        if (result) {
-            if (imageData.ext != null) {
-                imageDescriptions.set(url, {
-                    mimeType: imageData.ext,
-                    description: result
-                })
-            }
-            addTextToContent(message, '\n\n' + result)
-            return true
-        }
-    } catch (error) {
-        logger.warn(`Image describe failed for ${url}:`, error)
-    }
-    return false
 }

--- a/packages/service-multimodal/src/plugins/image.ts
+++ b/packages/service-multimodal/src/plugins/image.ts
@@ -7,6 +7,7 @@ import { Config, logger } from '..'
 import {
     addImageToContent,
     addTextToContent,
+    imageDescriptions,
     parseGifToFrames,
     processImageWithModel,
     readImage
@@ -35,6 +36,18 @@ export async function apply(
 
                 const native = modelAcceptsImage(ctx, model)
                 if (!native && !config.enableContextImageDescription) {
+                    return false
+                }
+
+                const cached = imageDescriptions.get(url)
+                if (!native && cached != null) {
+                    if (
+                        cached.mimeType === 'image/gif' &&
+                        !config.enableContextGifHandling
+                    ) {
+                        return false
+                    }
+                    addTextToContent(message, '\n\n' + cached.description)
                     return false
                 }
 
@@ -120,6 +133,12 @@ async function describeAndInject(
         }
         const result = await processImageWithModel(imageModel, config, fake)
         if (result) {
+            if (imageData.ext != null) {
+                imageDescriptions.set(url, {
+                    mimeType: imageData.ext,
+                    description: result
+                })
+            }
             addTextToContent(message, '\n\n' + result)
             return true
         }

--- a/packages/service-multimodal/src/plugins/read_files.ts
+++ b/packages/service-multimodal/src/plugins/read_files.ts
@@ -19,6 +19,7 @@ import {
     convertAudioToMp3,
     detectAudioMimeType,
     IMAGE_MIME_TYPES,
+    imageDescriptions,
     parseGifToFrames,
     processImageWithModel
 } from '../utils'
@@ -106,6 +107,23 @@ export class ReadFilesTool extends StructuredTool {
                     sourceUrl,
                     'Only http/https URLs are supported.'
                 )
+                continue
+            }
+
+            const cached = imageDescriptions.get(sourceUrl)
+            if (
+                cached != null &&
+                mimeEnabled(this.config, cached.mimeType) &&
+                (model == null || !modelSupportsMime(model, cached.mimeType))
+            ) {
+                report.files.push({
+                    sourceUrl,
+                    mimeType: cached.mimeType,
+                    status: 'described',
+                    description: cached.description
+                })
+                report.successCount++
+                describedCount++
                 continue
             }
 
@@ -391,7 +409,18 @@ export class ReadFilesTool extends StructuredTool {
                     `data:${mimeType};base64,${buffer.toString('base64')}`
                 )
             }
-            return await processImageWithModel(imageModel, this.config, fake)
+            const result = await processImageWithModel(
+                imageModel,
+                this.config,
+                fake
+            )
+            if (result) {
+                imageDescriptions.set(url, {
+                    mimeType,
+                    description: result
+                })
+            }
+            return result
         } catch (error) {
             logger.warn(`Describe image ${url} error:`, error)
             return null

--- a/packages/service-multimodal/src/plugins/read_files.ts
+++ b/packages/service-multimodal/src/plugins/read_files.ts
@@ -2,7 +2,7 @@
 import { StructuredTool } from '@langchain/core/tools'
 import { HumanMessage, MessageContentComplex } from '@langchain/core/messages'
 import { Context } from 'koishi'
-import { ComputedRef, Message } from 'koishi-plugin-chatluna'
+import { ComputedRef } from 'koishi-plugin-chatluna'
 import { ChatLunaChatModel } from 'koishi-plugin-chatluna/llm-core/platform/model'
 import type { FileHandlingConfig } from 'koishi-plugin-chatluna/llm-core/platform/client'
 import {
@@ -11,22 +11,26 @@ import {
 } from 'koishi-plugin-chatluna/llm-core/platform/types'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { getBase64EncodedSize } from 'koishi-plugin-chatluna/utils/base64'
+import { getImageType } from 'koishi-plugin-chatluna/utils/string'
 import { Config, logger } from '..'
 import {
-    addImageToContent,
-    addTextToContent,
     BROWSER_UA,
+    buildDescribeMessage,
     convertAudioToMp3,
     detectAudioMimeType,
+    getOrDescribeImage,
     IMAGE_MIME_TYPES,
-    imageDescriptions,
     parseGifToFrames,
-    processImageWithModel
+    processImageWithModel,
+    singleFlight
 } from '../utils'
 import z from 'zod'
 
 const DEFAULT_MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024
 const DEFAULT_MAX_TOTAL_SIZE_BYTES = 100 * 1024 * 1024
+
+type Fetched = { buffer: Buffer; contentType: string | null } | null
+const fetchLoads = new Map<string, Promise<Fetched>>()
 
 interface NativePart {
     mimeType: string
@@ -100,6 +104,8 @@ export class ReadFilesTool extends StructuredTool {
         let totalBytes = 0
         let describedCount = 0
 
+        const scope = conversationId
+
         for (const { url: sourceUrl } of files) {
             if (!isHttp(sourceUrl)) {
                 pushError(
@@ -110,25 +116,12 @@ export class ReadFilesTool extends StructuredTool {
                 continue
             }
 
-            const cached = imageDescriptions.get(sourceUrl)
-            if (
-                cached != null &&
-                mimeEnabled(this.config, cached.mimeType) &&
-                (model == null || !modelSupportsMime(model, cached.mimeType))
-            ) {
-                report.files.push({
-                    sourceUrl,
-                    mimeType: cached.mimeType,
-                    status: 'described',
-                    description: cached.description
-                })
-                report.successCount++
-                describedCount++
-                continue
-            }
-
             try {
-                const fetched = await this._fetch(sourceUrl)
+                const fetched = await singleFlight(
+                    fetchLoads,
+                    scope == null ? undefined : `${scope}\0${sourceUrl}`,
+                    () => this._fetch(sourceUrl)
+                )
                 if (!fetched) {
                     pushError(report, sourceUrl, 'Failed to fetch URL.')
                     continue
@@ -138,7 +131,9 @@ export class ReadFilesTool extends StructuredTool {
                     ?.split(';')[0]
                     ?.trim()
                     ?.toLowerCase()
-                const mime = await detectAudioMimeType(fetched.buffer, declared)
+                const mime =
+                    getImageType(fetched.buffer) ??
+                    (await detectAudioMimeType(fetched.buffer, declared))
 
                 if (!mime) {
                     pushError(
@@ -283,7 +278,7 @@ export class ReadFilesTool extends StructuredTool {
                 // ----- Image without native support: describe via vision model -
                 if (isImage) {
                     const described = await this._describeImage(
-                        sourceUrl,
+                        scope,
                         fetched.buffer,
                         mime
                     )
@@ -374,55 +369,38 @@ export class ReadFilesTool extends StructuredTool {
     }
 
     private async _describeImage(
-        url: string,
+        scope: string | undefined,
         buffer: Buffer,
-        mimeType: string
+        mime: string
     ): Promise<string | null> {
-        const imageModel = this.imageModelRef().value
-        if (
-            !imageModel ||
-            !imageModel.modelInfo.capabilities.includes(
-                ModelCapabilities.ImageInput
-            )
-        ) {
-            logger.warn(
-                'Image model not loaded or lacks image input; cannot describe.'
-            )
-            return null
-        }
-
         try {
-            const fake: Message = { content: [] }
-            if (mimeType === 'image/gif') {
-                const frames = await parseGifToFrames(buffer, {
-                    strategy: this.config.gifStrategy,
-                    frameCount: this.config.gifFrameCount
-                })
-                addTextToContent(
-                    fake,
-                    'This is a GIF image. See the frames below:'
-                )
-                for (const frame of frames) addImageToContent(fake, frame)
-            } else {
-                addImageToContent(
-                    fake,
-                    `data:${mimeType};base64,${buffer.toString('base64')}`
-                )
-            }
-            const result = await processImageWithModel(
-                imageModel,
+            const text = await getOrDescribeImage(
+                scope,
+                buffer,
                 this.config,
-                fake
+                async () => {
+                    const imageModel = this.imageModelRef().value
+                    if (
+                        imageModel == null ||
+                        !imageModel.modelInfo.capabilities.includes(
+                            ModelCapabilities.ImageInput
+                        )
+                    ) {
+                        logger.warn(
+                            'Image model not loaded or lacks image input; cannot describe.'
+                        )
+                        return null
+                    }
+                    return processImageWithModel(
+                        imageModel,
+                        this.config,
+                        await buildDescribeMessage(buffer, mime, this.config)
+                    )
+                }
             )
-            if (result) {
-                imageDescriptions.set(url, {
-                    mimeType,
-                    description: result
-                })
-            }
-            return result
+            return text ?? null
         } catch (error) {
-            logger.warn(`Describe image ${url} error:`, error)
+            logger.warn(`Describe image error:`, error)
             return null
         }
     }

--- a/packages/service-multimodal/src/utils.ts
+++ b/packages/service-multimodal/src/utils.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import {
     HumanMessage,
     MessageContentComplex,
@@ -221,13 +222,105 @@ function hasComplexDisposal(
 }
 
 // ---------------------------------------------------------------------------
-// Image
+// Image description cache
 // ---------------------------------------------------------------------------
 
-export const imageDescriptions = new Map<
-    string,
-    { mimeType: string; description: string }
->()
+const DESC_TTL = 5 * 60 * 1000
+const DESC_MAX = 100
+
+const descs = new Map<string, { text: string; exp: number }>()
+const descPending = new Map<string, Promise<string | undefined>>()
+
+export async function singleFlight<T>(
+    pending: Map<string, Promise<T>>,
+    key: string | undefined,
+    load: () => Promise<T>
+): Promise<T> {
+    if (key == null) return load()
+    const existing = pending.get(key)
+    if (existing != null) return existing
+    const task = (async () => {
+        try {
+            return await load()
+        } finally {
+            pending.delete(key)
+        }
+    })()
+    pending.set(key, task)
+    return task
+}
+
+export async function getOrDescribeImage(
+    scope: string | undefined,
+    buffer: Buffer,
+    config: Config,
+    describe: () => Promise<string | null>
+): Promise<string | undefined> {
+    const wrap = (text: string) =>
+        config.imageInsertPrompt.replace('{img}', text)
+
+    if (scope == null) {
+        const text = await describe()
+        return text == null || text.length < 1 ? undefined : wrap(text)
+    }
+
+    const hash = createHash('sha256').update(buffer).digest('hex')
+    const key = `${scope}\0${hash}\0${config.imageModel}\0${config.imagePrompt}\0${config.gifStrategy}\0${config.gifFrameCount}`
+
+    const hit = descs.get(key)
+    if (hit != null) {
+        if (hit.exp <= Date.now()) descs.delete(key)
+        else {
+            descs.delete(key)
+            descs.set(key, hit)
+            return wrap(hit.text)
+        }
+    }
+
+    let pending = descPending.get(key)
+    if (pending == null) {
+        pending = (async () => {
+            try {
+                const text = await describe()
+                if (text == null || text.length < 1) return undefined
+                descs.delete(key)
+                descs.set(key, { text, exp: Date.now() + DESC_TTL })
+                if (descs.size > DESC_MAX) {
+                    descs.delete(descs.keys().next().value!)
+                }
+                return text
+            } finally {
+                descPending.delete(key)
+            }
+        })()
+        descPending.set(key, pending)
+    }
+    const text = await pending
+    return text == null ? undefined : wrap(text)
+}
+
+export async function buildDescribeMessage(
+    buffer: Buffer,
+    mime: string,
+    config: Config
+): Promise<Message> {
+    const msg: Message = { content: [] }
+    if (mime === 'image/gif') {
+        addTextToContent(msg, 'This is a GIF image. See the frames below:')
+        for (const frame of await parseGifToFrames(buffer, {
+            strategy: config.gifStrategy,
+            frameCount: config.gifFrameCount
+        })) {
+            addImageToContent(msg, frame)
+        }
+    } else {
+        addImageToContent(
+            msg,
+            `data:${mime};base64,${buffer.toString('base64')}`
+        )
+    }
+    return msg
+}
 
 export async function readImage(ctx: Context, url: string) {
     if (url.startsWith('data:image') && url.includes('base64')) {
@@ -271,10 +364,8 @@ export async function processImageWithModel(
             ...images
         ]
         const result = await model.invoke([new HumanMessage({ content })])
-        return config.imageInsertPrompt.replace(
-            '{img}',
-            getMessageContent(result.content)
-        )
+        const text = getMessageContent(result.content)
+        return text.length > 0 ? text : null
     } catch (error) {
         logger.warn('Failed to process image with model', error)
         return null

--- a/packages/service-multimodal/src/utils.ts
+++ b/packages/service-multimodal/src/utils.ts
@@ -224,6 +224,11 @@ function hasComplexDisposal(
 // Image
 // ---------------------------------------------------------------------------
 
+export const imageDescriptions = new Map<
+    string,
+    { mimeType: string; description: string }
+>()
+
 export async function readImage(ctx: Context, url: string) {
     if (url.startsWith('data:image') && url.includes('base64')) {
         const buffer = Buffer.from(url.split(',')[1], 'base64')

--- a/packages/service-multimodal/src/utils.ts
+++ b/packages/service-multimodal/src/utils.ts
@@ -265,7 +265,7 @@ export async function getOrDescribeImage(
     }
 
     const hash = createHash('sha256').update(buffer).digest('hex')
-    const key = `${scope}\0${hash}\0${config.imageModel}\0${config.imagePrompt}\0${config.gifStrategy}\0${config.gifFrameCount}`
+    const key = `${hash}\0${config.imageModel}\0${config.imagePrompt}\0${config.gifStrategy}\0${config.gifFrameCount}`
 
     const hit = descs.get(key)
     if (hit != null) {
@@ -351,17 +351,13 @@ export async function processImageWithModel(
     config: Config,
     message: Message
 ): Promise<string | null> {
-    const images = Array.isArray(message.content)
-        ? message.content.filter((item: MessageContentComplex) =>
-              isMessageContentImageUrl(item)
-          )
-        : []
-    if (images.length === 0) return null
+    const items = Array.isArray(message.content) ? message.content : []
+    if (!items.some((item) => isMessageContentImageUrl(item))) return null
 
     try {
         const content: MessageContentComplex[] = [
             { type: 'text', text: config.imagePrompt } as MessageContentText,
-            ...images
+            ...items
         ]
         const result = await model.invoke([new HumanMessage({ content })])
         const text = getMessageContent(result.content)


### PR DESCRIPTION
This pr caches fallback image descriptions so repeated reads of the same image URL skip re-calling the vision model.

Closes https://github.com/ChatLunaLab/chatluna/issues/984

## New Features
- Share an in-memory image description cache across `read_files` and context image description flows

## Bug Fixes
- None

## Other Changes
- Reuse cached descriptions by source URL when the current chat model cannot natively handle the image mime type

## Validation
- yarn lint-fix (0 errors, 2 existing warnings)