### PR TITLE
feat(agent): add sub-agent tool availability toggle

### DIFF
--- a/packages/core/src/llm-core/platform/types.ts
+++ b/packages/core/src/llm-core/platform/types.ts
@@ -75,6 +75,7 @@ export type ChatLunaToolCharacterScope = 'all' | 'group' | 'private' | 'none'
 export interface ChatLunaToolDefaultAvailability {
     enabled?: boolean
     main?: boolean
+    subAgent?: boolean
     chatluna?: boolean
     characterScope?: ChatLunaToolCharacterScope
 }

--- a/packages/extension-agent/client/components/tool/tool-detail.vue
+++ b/packages/extension-agent/client/components/tool/tool-detail.vue
@@ -21,9 +21,9 @@
                     <el-tag
                         size="small"
                         effect="plain"
-                        :type="draft.subAgent ? 'success' : 'info'"
+                        :type="subAgent ? 'success' : 'info'"
                     >
-                        Sub Agent {{ draft.subAgent ? '可用' : '不可用' }}
+                        Sub Agent {{ subAgent ? '可用' : '不可用' }}
                     </el-tag>
                     <el-tag
                         size="small"
@@ -142,7 +142,7 @@
                             <div class="field-subtitle">Sub Agent</div>
                             <div class="field-help">控制 Sub Agent 是否允许注入这个工具。</div>
                         </div>
-                        <el-switch v-model="draft.subAgent" />
+                        <el-switch v-model="subAgent" />
                     </div>
                 </div>
 
@@ -362,6 +362,11 @@ const props = defineProps<{
     draft: ToolItemConfig
     agentOptions: SubAgentInfo[]
 }>()
+
+const subAgent = computed({
+    get: () => props.draft.subAgent ?? props.tool.subAgent,
+    set: (value) => (props.draft.subAgent = value)
+})
 
 defineEmits<{
     back: []

--- a/packages/extension-agent/client/components/tool/tool-detail.vue
+++ b/packages/extension-agent/client/components/tool/tool-detail.vue
@@ -21,6 +21,13 @@
                     <el-tag
                         size="small"
                         effect="plain"
+                        :type="draft.subAgent ? 'success' : 'info'"
+                    >
+                        Sub Agent {{ draft.subAgent ? '可用' : '不可用' }}
+                    </el-tag>
+                    <el-tag
+                        size="small"
+                        effect="plain"
                         :type="draft.chatluna ? 'success' : 'info'"
                     >
                         主插件 {{ draft.chatluna ? '可用' : '不可用' }}
@@ -126,6 +133,16 @@
                             <div class="field-help">控制 <code>chatluna</code> 主插件整体是否允许注入这个工具。</div>
                         </div>
                         <el-switch v-model="draft.chatluna" />
+                    </div>
+                </div>
+
+                <div class="field-card flat-card" style="margin-top: 8px;">
+                    <div class="scope-row">
+                        <div>
+                            <div class="field-subtitle">Sub Agent</div>
+                            <div class="field-help">控制 Sub Agent 是否允许注入这个工具。</div>
+                        </div>
+                        <el-switch v-model="draft.subAgent" />
                     </div>
                 </div>
 

--- a/packages/extension-agent/client/components/tool/tool-page.vue
+++ b/packages/extension-agent/client/components/tool/tool-page.vue
@@ -402,7 +402,7 @@ function createItem(
     return {
         enabled: item?.enabled !== false,
         main: item?.main !== false,
-        subAgent: item?.subAgent !== false,
+        subAgent: item?.subAgent,
         chatluna:
             ((item as any)?.chatluna ?? (item as any)?.chatlunaEnabled) !==
             false,

--- a/packages/extension-agent/client/components/tool/tool-page.vue
+++ b/packages/extension-agent/client/components/tool/tool-page.vue
@@ -267,6 +267,7 @@ const tools = computed(() => {
                 ...item,
                 enabled: saved?.enabled ?? item.enabled,
                 main: saved?.main ?? item.main,
+                subAgent: saved?.subAgent ?? item.subAgent,
                 chatlunaEnabled: saved?.chatluna ?? item.chatlunaEnabled,
                 characterEnabled: saved?.character ?? item.characterEnabled,
                 characterGroupEnabled:
@@ -401,6 +402,7 @@ function createItem(
     return {
         enabled: item?.enabled !== false,
         main: item?.main !== false,
+        subAgent: item?.subAgent !== false,
         chatluna:
             ((item as any)?.chatluna ?? (item as any)?.chatlunaEnabled) !==
             false,

--- a/packages/extension-agent/src/config/defaults.ts
+++ b/packages/extension-agent/src/config/defaults.ts
@@ -92,7 +92,7 @@ export function createToolItemConfig(
     return {
         enabled: input.enabled !== false,
         main: input.main !== false,
-        subAgent: input.subAgent !== false,
+        subAgent: input.subAgent,
         chatluna: input.chatluna !== false,
         character: input.character !== false,
         characterGroup: input.characterGroup !== false,

--- a/packages/extension-agent/src/config/defaults.ts
+++ b/packages/extension-agent/src/config/defaults.ts
@@ -92,6 +92,7 @@ export function createToolItemConfig(
     return {
         enabled: input.enabled !== false,
         main: input.main !== false,
+        subAgent: input.subAgent !== false,
         chatluna: input.chatluna !== false,
         character: input.character !== false,
         characterGroup: input.characterGroup !== false,

--- a/packages/extension-agent/src/service/permissions.ts
+++ b/packages/extension-agent/src/service/permissions.ts
@@ -151,6 +151,7 @@ export class ChatLunaAgentPermissionService {
                         ...saved,
                         enabled: saved?.enabled ?? avail?.enabled ?? true,
                         main: saved?.main ?? avail?.main ?? true,
+                        subAgent: saved?.subAgent ?? avail?.subAgent ?? true,
                         chatluna: saved?.chatluna ?? avail?.chatluna ?? true,
                         character:
                             saved?.character ??
@@ -182,6 +183,7 @@ export class ChatLunaAgentPermissionService {
                     description: item.description,
                     enabled: cfg.enabled,
                     main: cfg.main,
+                    subAgent: cfg.subAgent,
                     chatlunaEnabled: cfg.chatluna,
                     characterEnabled: cfg.character,
                     characterGroupEnabled: cfg.characterGroup,
@@ -221,7 +223,10 @@ export class ChatLunaAgentPermissionService {
             mainEnabled: list.filter((item) => item.enabled && item.main)
                 .length,
             subAgentEnabled: list.filter(
-                (item) => item.enabled && hasSubAgentAccess(item.subAgents)
+                (item) =>
+                    item.enabled &&
+                    item.subAgent &&
+                    hasSubAgentAccess(item.subAgents)
             ).length,
             catalog: Object.fromEntries(list.map((item) => [item.name, item]))
         }
@@ -409,7 +414,7 @@ export class ChatLunaAgentPermissionService {
 
     canUseTool(info: SubAgentInfo, name: string): boolean {
         const tool = this.getTool(name)
-        if (!tool?.enabled) {
+        if (!tool?.enabled || !tool.subAgent) {
             return false
         }
 

--- a/packages/extension-agent/src/service/permissions.ts
+++ b/packages/extension-agent/src/service/permissions.ts
@@ -183,7 +183,7 @@ export class ChatLunaAgentPermissionService {
                     description: item.description,
                     enabled: cfg.enabled,
                     main: cfg.main,
-                    subAgent: cfg.subAgent,
+                    subAgent: cfg.subAgent ?? true,
                     chatlunaEnabled: cfg.chatluna,
                     characterEnabled: cfg.character,
                     characterGroupEnabled: cfg.characterGroup,

--- a/packages/extension-agent/src/types/tool.ts
+++ b/packages/extension-agent/src/types/tool.ts
@@ -5,6 +5,7 @@ export type ToolCharacterScope = 'all' | 'group' | 'private' | 'none'
 export interface ToolDefaultAvailability {
     enabled?: boolean
     main?: boolean
+    subAgent?: boolean
     chatluna?: boolean
     characterScope?: ToolCharacterScope
 }
@@ -46,6 +47,7 @@ export function createToolDefaultAvailability(
         input.defaultEnabled != null
     const hasMain =
         input.defaultAvailability?.main != null || input.defaultMain != null
+    const hasSubAgent = input.defaultAvailability?.subAgent != null
     const hasChatluna =
         input.defaultAvailability?.chatluna != null ||
         input.defaultChatluna != null
@@ -55,7 +57,13 @@ export function createToolDefaultAvailability(
         input.defaultCharacterGroup != null ||
         input.defaultCharacterPrivate != null
 
-    if (!hasEnabled && !hasMain && !hasChatluna && !hasCharacter) {
+    if (
+        !hasEnabled &&
+        !hasMain &&
+        !hasSubAgent &&
+        !hasChatluna &&
+        !hasCharacter
+    ) {
         return undefined
     }
 
@@ -68,6 +76,10 @@ export function createToolDefaultAvailability(
 
     if (hasMain) {
         output.main = input.defaultAvailability?.main ?? input.defaultMain
+    }
+
+    if (hasSubAgent) {
+        output.subAgent = input.defaultAvailability?.subAgent
     }
 
     if (hasChatluna) {
@@ -133,6 +145,7 @@ export interface PermissionRule {
 export interface ToolItemConfig {
     enabled: boolean
     main: boolean
+    subAgent: boolean
     chatluna: boolean
     character: boolean
     characterGroup: boolean
@@ -155,6 +168,7 @@ export interface ToolInfo {
     description?: string
     enabled: boolean
     main: boolean
+    subAgent: boolean
     chatlunaEnabled: boolean
     characterEnabled: boolean
     characterGroupEnabled: boolean

--- a/packages/extension-agent/src/types/tool.ts
+++ b/packages/extension-agent/src/types/tool.ts
@@ -145,7 +145,7 @@ export interface PermissionRule {
 export interface ToolItemConfig {
     enabled: boolean
     main: boolean
-    subAgent: boolean
+    subAgent?: boolean
     chatluna: boolean
     character: boolean
     characterGroup: boolean


### PR DESCRIPTION
This pr adds a per-tool Sub Agent availability toggle so tools can be hidden from Sub Agents.

Closes https://github.com/ChatLunaLab/chatluna/issues/983

## New Features
- Add `subAgent` tool availability flag across tool types, defaults, permissions, and console UI
- Enforce `subAgent` when deciding whether a Sub Agent can use a tool

## Bug Fixes
- None

## Other Changes
- Surface Sub Agent availability in tool detail/list views

## Validation
- yarn lint-fix (0 errors, 2 existing warnings)