### PR TITLE
chore(packages): bump alpha versions

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.4.0-alpha.15",
+    "version": "1.4.0-alpha.16",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.4.0-alpha.41",
+    "version": "1.4.0-alpha.42",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-agent",
     "description": "Agent framework for ChatLuna",
-    "version": "1.0.41",
+    "version": "1.0.42",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -91,7 +91,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -67,12 +67,12 @@
         "atsc": "^2.1.0",
         "koishi": "^4.18.9",
         "koishi-plugin-adapter-onebot": "^6.8.0",
-        "koishi-plugin-chatluna-agent": "^1.0.41"
+        "koishi-plugin-chatluna-agent": "^1.0.42"
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41",
-        "koishi-plugin-chatluna-agent": "^1.0.41",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42",
+        "koishi-plugin-chatluna-agent": "^1.0.42",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-usage/package.json
+++ b/packages/extension-usage/package.json
@@ -61,7 +61,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42",
         "koishi-plugin-puppeteer": "^3.9.0"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-image-renderer",
     "description": "image renderer for chatluna",
-    "version": "1.4.0-alpha.1",
+    "version": "1.4.0-alpha.2",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "koishi": {
         "description": {

--- a/packages/service-multimodal/package.json
+++ b/packages/service-multimodal/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-multimodal-service",
     "description": "multimodal service for chatluna",
-    "version": "1.4.0-alpha.4",
+    "version": "1.4.0-alpha.5",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42",
         "koishi-plugin-ffmpeg-path": "^2.0.0"
     },
     "peerDependenciesMeta": {

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-search-service",
     "description": "search support for chatluna",
-    "version": "1.4.0-alpha.6",
+    "version": "1.4.0-alpha.7",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -70,13 +70,13 @@
     "devDependencies": {
         "atsc": "^2.1.0",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna-agent": "^1.0.41",
+        "koishi-plugin-chatluna-agent": "^1.0.42",
         "koishi-plugin-puppeteer": "^3.9.0"
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41",
-        "koishi-plugin-chatluna-agent": "^1.0.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42",
+        "koishi-plugin-chatluna-agent": "^1.0.42"
     },
     "peerDependenciesMeta": {
         "koishi-plugin-chatluna-agent": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.41"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.42"
     }
 }


### PR DESCRIPTION
This pr bumps package alpha versions and synchronizes internal dependency ranges.

## New Features
- None

## Bug Fixes
- None

## Other Changes
- Bump `koishi-plugin-chatluna` to `1.4.0-alpha.42`
- Bump agent, Gemini, image renderer, multimodal, and search package versions
- Sync ChatLuna and agent dependency ranges across workspace packages

## Validation
- yarn lint-fix (0 errors, 2 existing warnings)