### PR TITLE
fix(core): prevent recursive quote transformation

### DIFF
--- a/packages/core/src/services/message_transform.ts
+++ b/packages/core/src/services/message_transform.ts
@@ -51,7 +51,13 @@ export class MessageTransformer {
             .join()
 
         for (const element of elements) {
-            await this._processElement(session, element, message, model)
+            await this._processElement(
+                session,
+                element,
+                message,
+                model,
+                options
+            )
         }
 
         if (
@@ -256,7 +262,8 @@ export class MessageTransformer {
         session: Session,
         element: h,
         message: Message,
-        model: string
+        model: string,
+        options: MessageTransformOptions
     ) {
         const transformFunctions = this._transformFunctions.get(element.type)
 
@@ -268,8 +275,8 @@ export class MessageTransformer {
                     model,
                     message,
                     {
-                        quote: false,
-                        includeQuoteReply: true
+                        quote: options.quote,
+                        includeQuoteReply: false
                     }
                 )
             }
@@ -295,8 +302,8 @@ export class MessageTransformer {
                     model,
                     message,
                     {
-                        quote: false,
-                        includeQuoteReply: true
+                        quote: options.quote,
+                        includeQuoteReply: false
                     }
                 )
                 return
@@ -305,7 +312,7 @@ export class MessageTransformer {
 
         if (hasChildren) {
             await this.transform(session, element.children, model, message, {
-                quote: false,
+                quote: options.quote,
                 includeQuoteReply: false
             })
         }


### PR DESCRIPTION
This pr prevents nested rich-text elements from repeatedly injecting the quoted message during transformation.

Closes https://github.com/ChatLunaLab/chatluna/issues/991

## New Features
- None

## Bug Fixes
- Preserve the top-level quote option when transforming nested elements
- Disable quote reply injection for child transformations to prevent recursive expansion and V8 OOM crashes

## Other Changes
- None

## Validation
- yarn lint-fix (0 errors, 2 existing warnings)