### PR TITLE
fix(agent): stream large computer tool outputs

### DIFF
--- a/packages/extension-agent/src/computer/backends/local/index.ts
+++ b/packages/extension-agent/src/computer/backends/local/index.ts
@@ -17,6 +17,7 @@ import {
 } from '../../types'
 import { buildPosixBackgroundCommand } from '../types'
 import { FileStore } from './store'
+import { LocalOutputCollector } from './output'
 import {
     ResolvedShellCommand,
     resolveInteractiveShellCommand,
@@ -237,8 +238,7 @@ async function runChildProcess(
     timeout: number
 ): Promise<ExecuteResult> {
     return await new Promise<ExecuteResult>((resolve, reject) => {
-        const stdoutChunks: Buffer[] = []
-        const stderrChunks: Buffer[] = []
+        const output = new LocalOutputCollector('bash')
         const child = spawn(shell.file, shell.args, {
             cwd,
             env,
@@ -248,66 +248,93 @@ async function runChildProcess(
         })
 
         let done = false
-        const finish = (result: ExecuteResult) => {
-            if (done) {
-                return
-            }
+        let timedOut = false
+        let hasOutput = false
+        let hasStderr = false
+        let stdout = ''
+        let stderr = ''
+        const pending = new Set<Promise<void>>()
+        const append = (stream: NodeJS.ReadableStream, text: string) => {
+            stream.pause()
+            const task = output.append(text).finally(() => {
+                pending.delete(task)
+                stream.resume()
+            })
+            pending.add(task)
+            task.catch((err) => {
+                killLocalChild(child).catch(() => undefined)
+                fail(err).catch(reject)
+            })
+        }
+        const finish = async (result: ExecuteResult) => {
+            if (done) return
 
             done = true
             clearTimeout(timer)
-            resolve(result)
+            try {
+                await Promise.all(pending)
+                const value = await output.finish()
+                resolve({
+                    ...result,
+                    stdout,
+                    stderr,
+                    output: {
+                        ...value,
+                        text: value.text || '(no output)'
+                    }
+                })
+            } catch (err) {
+                await output.dispose()
+                reject(err)
+            }
+        }
+        const fail = async (err: unknown) => {
+            if (done) return
+            done = true
+            clearTimeout(timer)
+            await output.dispose()
+            reject(err)
         }
         const timer =
             timeout > 0
                 ? setTimeout(() => {
-                      finish({
-                          exitCode: 1,
-                          stdout: Buffer.concat(stdoutChunks)
-                              .toString('utf8')
-                              .replace(/\r\n/g, '\n'),
-                          stderr: Buffer.concat(stderrChunks)
-                              .toString('utf8')
-                              .replace(/\r\n/g, '\n'),
-                          timedOut: true
-                      })
+                      timedOut = true
                       killLocalChild(child).catch(() => undefined)
                   }, timeout)
                 : undefined
 
-        child.stdout.on('data', (chunk: Buffer | string) => {
-            stdoutChunks.push(
-                Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
-            )
+        child.stdout.setEncoding('utf8')
+        child.stderr.setEncoding('utf8')
+        child.stdout.on('data', (text: string) => {
+            const value = text.replace(/\r\n/g, '\n')
+            stdout += value.slice(0, 8000 - stdout.length)
+            append(child.stdout, value)
+            hasOutput = true
         })
 
-        child.stderr.on('data', (chunk: Buffer | string) => {
-            stderrChunks.push(
-                Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+        child.stderr.on('data', (text: string) => {
+            const value = text.replace(/\r\n/g, '\n')
+            stderr += value.slice(0, 8000 - stderr.length)
+            append(
+                child.stderr,
+                `${hasStderr ? '' : `${hasOutput ? '\n' : ''}[stderr]\n`}${value}`
             )
+            hasOutput = true
+            hasStderr = true
         })
 
         child.on('error', (err) => {
-            if (done) {
-                return
-            }
-
-            done = true
-            clearTimeout(timer)
-            reject(err)
+            fail(err).catch(reject)
         })
 
         child.on('close', (code, signal) => {
             finish({
-                exitCode: code ?? 0,
-                stdout: Buffer.concat(stdoutChunks)
-                    .toString('utf8')
-                    .replace(/\r\n/g, '\n'),
-                stderr: Buffer.concat(stderrChunks)
-                    .toString('utf8')
-                    .replace(/\r\n/g, '\n'),
+                exitCode: timedOut ? 1 : (code ?? 0),
+                stdout,
+                stderr,
                 signal: signal ?? undefined,
-                timedOut: false
-            })
+                timedOut
+            }).catch(reject)
         })
     })
 }

--- a/packages/extension-agent/src/computer/backends/local/index.ts
+++ b/packages/extension-agent/src/computer/backends/local/index.ts
@@ -251,8 +251,16 @@ async function runChildProcess(
         let timedOut = false
         let hasOutput = false
         let hasStderr = false
-        let stdout = ''
-        let stderr = ''
+        const stdout = { value: '', truncated: false }
+        const stderr = { value: '', truncated: false }
+        const appendPreview = (
+            text: string,
+            target: { value: string; truncated: boolean }
+        ) => {
+            const remaining = 8000 - target.value.length
+            if (text.length > remaining) target.truncated = true
+            target.value += text.slice(0, remaining)
+        }
         const pending = new Set<Promise<void>>()
         const append = (stream: NodeJS.ReadableStream, text: string) => {
             stream.pause()
@@ -276,8 +284,12 @@ async function runChildProcess(
                 const value = await output.finish()
                 resolve({
                     ...result,
-                    stdout,
-                    stderr,
+                    stdout: stdout.truncated
+                        ? `${stdout.value}\n...[output truncated]`
+                        : stdout.value,
+                    stderr: stderr.truncated
+                        ? `${stderr.value}\n...[output truncated]`
+                        : stderr.value,
                     output: {
                         ...value,
                         text: value.text || '(no output)'
@@ -307,14 +319,14 @@ async function runChildProcess(
         child.stderr.setEncoding('utf8')
         child.stdout.on('data', (text: string) => {
             const value = text.replace(/\r\n/g, '\n')
-            stdout += value.slice(0, 8000 - stdout.length)
+            appendPreview(value, stdout)
             append(child.stdout, value)
             hasOutput = true
         })
 
         child.stderr.on('data', (text: string) => {
             const value = text.replace(/\r\n/g, '\n')
-            stderr += value.slice(0, 8000 - stderr.length)
+            appendPreview(value, stderr)
             append(
                 child.stderr,
                 `${hasStderr ? '' : `${hasOutput ? '\n' : ''}[stderr]\n`}${value}`
@@ -330,8 +342,8 @@ async function runChildProcess(
         child.on('close', (code, signal) => {
             finish({
                 exitCode: timedOut ? 1 : (code ?? 0),
-                stdout,
-                stderr,
+                stdout: stdout.value,
+                stderr: stderr.value,
                 signal: signal ?? undefined,
                 timedOut
             }).catch(reject)

--- a/packages/extension-agent/src/computer/backends/local/index.ts
+++ b/packages/extension-agent/src/computer/backends/local/index.ts
@@ -251,15 +251,15 @@ async function runChildProcess(
         let timedOut = false
         let hasOutput = false
         let hasStderr = false
-        const stdout = { value: '', truncated: false }
-        const stderr = { value: '', truncated: false }
+        const stdout = { text: '', truncated: false }
+        const stderr = { text: '', truncated: false }
         const appendPreview = (
             text: string,
-            target: { value: string; truncated: boolean }
+            target: { text: string; truncated: boolean }
         ) => {
-            const remaining = 8000 - target.value.length
+            const remaining = 8000 - target.text.length
             if (text.length > remaining) target.truncated = true
-            target.value += text.slice(0, remaining)
+            target.text += text.slice(0, remaining)
         }
         const pending = new Set<Promise<void>>()
         const append = (stream: NodeJS.ReadableStream, text: string) => {
@@ -285,11 +285,11 @@ async function runChildProcess(
                 resolve({
                     ...result,
                     stdout: stdout.truncated
-                        ? `${stdout.value}\n...[output truncated]`
-                        : stdout.value,
+                        ? `${stdout.text}\n...[output truncated]`
+                        : stdout.text,
                     stderr: stderr.truncated
-                        ? `${stderr.value}\n...[output truncated]`
-                        : stderr.value,
+                        ? `${stderr.text}\n...[output truncated]`
+                        : stderr.text,
                     output: {
                         ...value,
                         text: value.text || '(no output)'
@@ -342,8 +342,8 @@ async function runChildProcess(
         child.on('close', (code, signal) => {
             finish({
                 exitCode: timedOut ? 1 : (code ?? 0),
-                stdout: stdout.value,
-                stderr: stderr.value,
+                stdout: stdout.text,
+                stderr: stderr.text,
                 signal: signal ?? undefined,
                 timedOut
             }).catch(reject)

--- a/packages/extension-agent/src/computer/backends/local/output.ts
+++ b/packages/extension-agent/src/computer/backends/local/output.ts
@@ -10,6 +10,8 @@ export class LocalOutputCollector {
 
     private _length = 0
 
+    private _count = 0
+
     private _path?: string
 
     private _stream?: WriteStream
@@ -24,6 +26,10 @@ export class LocalOutputCollector {
         private readonly _name: string,
         private readonly _limit = 8000
     ) {}
+
+    get count() {
+        return this._count
+    }
 
     append(text: string) {
         if (this._result) return Promise.reject(new Error('Output is finished'))
@@ -59,10 +65,19 @@ export class LocalOutputCollector {
         return task
     }
 
+    appendLine(text: string) {
+        this._count += 1
+        return this.append(`${this._count > 1 ? '\n' : ''}${text}`)
+    }
+
     finish() {
         this._result ??= this._pending.then(async () => {
             if (!this._stream) {
-                return { text: this._text, totalLength: this._length }
+                return {
+                    text: this._text,
+                    totalLength: this._length,
+                    count: this._count
+                }
             }
 
             if (!this._stream.closed) {
@@ -78,7 +93,8 @@ export class LocalOutputCollector {
             return {
                 text: this._text,
                 outputPath: this._path,
-                totalLength: this._length
+                totalLength: this._length,
+                count: this._count
             }
         })
         return this._result

--- a/packages/extension-agent/src/computer/backends/local/output.ts
+++ b/packages/extension-agent/src/computer/backends/local/output.ts
@@ -5,6 +5,8 @@ import path from 'node:path'
 import { randomUUID } from 'node:crypto'
 import type { TextOutput } from '../../types'
 
+const OUTPUT_FILE_PREFIX = '.tmp-chatluna-'
+
 export class LocalOutputCollector {
     private _text = ''
 
@@ -44,10 +46,11 @@ export class LocalOutputCollector {
             if (!this._stream) {
                 this._path = path.join(
                     os.tmpdir(),
-                    `.tmp-chatluna-${this._name}-${Date.now()}-${randomUUID()}.txt`
+                    `${OUTPUT_FILE_PREFIX}${this._name}-${Date.now()}-${randomUUID()}.txt`
                 )
                 this._stream = createWriteStream(this._path, {
-                    encoding: 'utf8'
+                    encoding: 'utf8',
+                    mode: 0o600
                 })
                 this._stream.on('error', (err) => {
                     this._error = err
@@ -119,4 +122,30 @@ export class LocalOutputCollector {
             })
         })
     }
+}
+
+export async function cleanupExpiredOutputs(maxAgeMs: number) {
+    const dir = os.tmpdir()
+    let entries: string[]
+    try {
+        entries = await fs.readdir(dir)
+    } catch {
+        return
+    }
+    const cutoff = Date.now() - maxAgeMs
+    await Promise.all(
+        entries
+            .filter((name) => name.startsWith(OUTPUT_FILE_PREFIX))
+            .map(async (name) => {
+                const file = path.join(dir, name)
+                try {
+                    const stat = await fs.stat(file)
+                    if (stat.mtimeMs < cutoff) {
+                        await fs.rm(file, { force: true })
+                    }
+                } catch {
+                    // ignore
+                }
+            })
+    )
 }

--- a/packages/extension-agent/src/computer/backends/local/output.ts
+++ b/packages/extension-agent/src/computer/backends/local/output.ts
@@ -1,0 +1,106 @@
+import { createWriteStream, type WriteStream } from 'node:fs'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import type { TextOutput } from '../../types'
+
+export class LocalOutputCollector {
+    private _text = ''
+
+    private _length = 0
+
+    private _path?: string
+
+    private _stream?: WriteStream
+
+    private _error?: Error
+
+    private _pending = Promise.resolve()
+
+    private _result?: Promise<TextOutput>
+
+    constructor(
+        private readonly _name: string,
+        private readonly _limit = 8000
+    ) {}
+
+    append(text: string) {
+        if (this._result) return Promise.reject(new Error('Output is finished'))
+        const task = this._pending.then(async () => {
+            const length = this._length + text.length
+            if (!this._stream && length <= this._limit) {
+                this._text += text
+                this._length = length
+                return
+            }
+
+            if (!this._stream) {
+                this._path = path.join(
+                    os.tmpdir(),
+                    `.tmp-chatluna-${this._name}-${Date.now()}-${randomUUID()}.txt`
+                )
+                this._stream = createWriteStream(this._path, {
+                    encoding: 'utf8'
+                })
+                this._stream.on('error', (err) => {
+                    this._error = err
+                })
+                await this._write(this._text)
+            }
+
+            if (this._text.length < this._limit) {
+                this._text += text.slice(0, this._limit - this._text.length)
+            }
+            this._length = length
+            await this._write(text)
+        })
+        this._pending = task
+        return task
+    }
+
+    finish() {
+        this._result ??= this._pending.then(async () => {
+            if (!this._stream) {
+                return { text: this._text, totalLength: this._length }
+            }
+
+            if (!this._stream.closed) {
+                await new Promise<void>((resolve, reject) => {
+                    this._stream!.once('close', () => {
+                        if (this._error) reject(this._error)
+                        else resolve()
+                    })
+                    this._stream!.end()
+                })
+            }
+            if (this._error) throw this._error
+            return {
+                text: this._text,
+                outputPath: this._path,
+                totalLength: this._length
+            }
+        })
+        return this._result
+    }
+
+    async dispose() {
+        await this._pending.catch(() => undefined)
+        if (this._stream && !this._stream.closed) {
+            await new Promise<void>((resolve) => {
+                this._stream!.once('close', resolve)
+                this._stream!.destroy()
+            })
+        }
+        if (this._path) await fs.rm(this._path, { force: true })
+    }
+
+    private async _write(text: string) {
+        await new Promise<void>((resolve, reject) => {
+            this._stream!.write(text, (err) => {
+                if (err) reject(err)
+                else resolve()
+            })
+        })
+    }
+}

--- a/packages/extension-agent/src/computer/backends/local/output.ts
+++ b/packages/extension-agent/src/computer/backends/local/output.ts
@@ -4,6 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { randomUUID } from 'node:crypto'
 import type { TextOutput } from '../../types'
+import { logger } from '../../..'
 
 const OUTPUT_FILE_PREFIX = '.tmp-chatluna-'
 
@@ -129,7 +130,8 @@ export async function cleanupExpiredOutputs(maxAgeMs: number) {
     let entries: string[]
     try {
         entries = await fs.readdir(dir)
-    } catch {
+    } catch (err) {
+        logger.warn(`Failed to list temp directory for output cleanup: ${err}`)
         return
     }
     const cutoff = Date.now() - maxAgeMs
@@ -143,8 +145,10 @@ export async function cleanupExpiredOutputs(maxAgeMs: number) {
                     if (stat.mtimeMs < cutoff) {
                         await fs.rm(file, { force: true })
                     }
-                } catch {
-                    // ignore
+                } catch (err) {
+                    logger.warn(
+                        `Failed to clean up temporary output ${file}: ${err}`
+                    )
                 }
             })
     )

--- a/packages/extension-agent/src/computer/backends/local/store.ts
+++ b/packages/extension-agent/src/computer/backends/local/store.ts
@@ -10,6 +10,7 @@ import which from 'which'
 import { LocalBackendConfig } from '../../../types'
 import type { FileContent, TextOutput } from '../../types'
 import { LocalOutputCollector } from './output'
+import { logger } from '../../..'
 
 const rg = which.sync('rg', { nothrow: true })
 const INTERNAL_IGNORES = ['**/.tmp-chatluna-*']
@@ -144,6 +145,7 @@ export class FileStore implements BaseFileStore {
             let child: ChildProcessWithoutNullStreams | undefined
             let closed: Promise<number> | undefined
             let spawnError: Error | undefined
+            let count = 0
             try {
                 child = spawn(rg, args, {
                     cwd: dir,
@@ -161,7 +163,6 @@ export class FileStore implements BaseFileStore {
                     })
                     child.on('close', (code) => resolve(code ?? 0))
                 })
-                let count = 0
                 for await (const line of createInterface({
                     input: child.stdout,
                     crlfDelay: Infinity
@@ -212,10 +213,11 @@ export class FileStore implements BaseFileStore {
                     child.kill()
                 }
                 await closed
-                await output.dispose()
-                if (process.env['CHATLUNA_AGENT_DEBUG']) {
-                    console.debug(err)
+                if (count > 0) {
+                    return { ...(await output.finish()), count }
                 }
+                await output.dispose()
+                logger.warn(err)
             }
         }
 
@@ -229,28 +231,25 @@ export class FileStore implements BaseFileStore {
                 if (this._shouldIgnore(file)) continue
                 if (include && !this._matchPattern(file, include)) continue
 
-                const lines = createInterface({
-                    input: createReadStream(file),
-                    crlfDelay: Infinity
-                })[Symbol.asyncIterator]()
                 let lineNumber = 0
-                while (true) {
-                    const next = await lines.next().catch((err) => {
-                        if (process.env['CHATLUNA_AGENT_DEBUG']) {
-                            console.debug(err)
+                try {
+                    for await (const line of createInterface({
+                        input: createReadStream(file),
+                        crlfDelay: Infinity
+                    })) {
+                        lineNumber += 1
+                        if (regex.test(line)) {
+                            await output.append(
+                                `${count > 0 ? '\n' : ''}${file}:${lineNumber}:${line}`
+                            )
+                            count += 1
                         }
-                        return undefined
-                    })
-                    if (!next || next.done) break
-
-                    lineNumber += 1
-                    if (regex.test(next.value)) {
-                        await output.append(
-                            `${count > 0 ? '\n' : ''}${file}:${lineNumber}:${next.value}`
-                        )
-                        count += 1
+                        regex.lastIndex = 0
                     }
-                    regex.lastIndex = 0
+                } catch (err) {
+                    if (process.env['CHATLUNA_AGENT_DEBUG']) {
+                        console.debug(err)
+                    }
                 }
             }
 
@@ -297,6 +296,7 @@ export class FileStore implements BaseFileStore {
             let child: ChildProcessWithoutNullStreams | undefined
             let closed: Promise<number> | undefined
             let spawnError: Error | undefined
+            let count = 0
             try {
                 child = spawn(rg, args, {
                     cwd: dir,
@@ -316,7 +316,6 @@ export class FileStore implements BaseFileStore {
                 })
                 child.stdout.setEncoding('utf8')
                 let rest = ''
-                let count = 0
                 for await (const chunk of child.stdout) {
                     const files = `${rest}${chunk}`.split('\0')
                     rest = files.pop()!
@@ -331,6 +330,11 @@ export class FileStore implements BaseFileStore {
 
                 const exitCode = await closed
                 if (spawnError) throw spawnError
+                if (exitCode === 1) {
+                    await output.dispose()
+                    return []
+                }
+
                 if (exitCode !== 0) {
                     throw new Error(
                         stderr.trim() || `ripgrep exited with ${exitCode}`
@@ -351,10 +355,11 @@ export class FileStore implements BaseFileStore {
                     child.kill()
                 }
                 await closed
-                await output.dispose()
-                if (process.env['CHATLUNA_AGENT_DEBUG']) {
-                    console.debug(err)
+                if (count > 0) {
+                    return { ...(await output.finish()), count }
                 }
+                await output.dispose()
+                logger.warn(err)
             }
         }
 

--- a/packages/extension-agent/src/computer/backends/local/store.ts
+++ b/packages/extension-agent/src/computer/backends/local/store.ts
@@ -342,14 +342,20 @@ export class FileStore implements BaseFileStore {
         }
     }
 
-    private async *_walk(dirPath: string): AsyncGenerator<string> {
+    private async *_walk(
+        dirPath: string,
+        seen = new Set<string>()
+    ): AsyncGenerator<string> {
+        const real = await fs.realpath(dirPath).catch(() => dirPath)
+        if (seen.has(real)) return
+        seen.add(real)
         try {
             for await (const entry of await fs.opendir(dirPath)) {
                 const fullPath = path.join(dirPath, entry.name)
                 if (this._shouldIgnore(fullPath)) continue
 
                 if (entry.isDirectory()) {
-                    yield* this._walk(fullPath)
+                    yield* this._walk(fullPath, seen)
                     continue
                 }
 
@@ -363,7 +369,7 @@ export class FileStore implements BaseFileStore {
                 try {
                     const stat = await fs.stat(fullPath)
                     if (stat.isDirectory()) {
-                        yield* this._walk(fullPath)
+                        yield* this._walk(fullPath, seen)
                         continue
                     }
 

--- a/packages/extension-agent/src/computer/backends/local/store.ts
+++ b/packages/extension-agent/src/computer/backends/local/store.ts
@@ -305,16 +305,38 @@ export class FileStore implements BaseFileStore {
                 })
                 child.on('close', (code) => resolve(code ?? 0))
             })
-            await consume(child.stdout)
-            const exitCode = await closed
-            if (spawnError) throw spawnError
-            if (exitCode === 1) return false
-            if (exitCode !== 0) {
-                throw new Error(
-                    stderr.trim() || `ripgrep exited with ${exitCode}`
-                )
+            const timeout = this._cfg.commandTimeoutMs
+            let timedOut = false
+            const timer =
+                timeout > 0
+                    ? setTimeout(() => {
+                          timedOut = true
+                          if (
+                              child &&
+                              child.exitCode == null &&
+                              child.signalCode == null
+                          ) {
+                              child.kill()
+                          }
+                      }, timeout)
+                    : undefined
+            try {
+                await consume(child.stdout)
+                const exitCode = await closed
+                if (spawnError) throw spawnError
+                if (timedOut) {
+                    throw new Error(`ripgrep timed out after ${timeout}ms`)
+                }
+                if (exitCode === 1) return false
+                if (exitCode !== 0) {
+                    throw new Error(
+                        stderr.trim() || `ripgrep exited with ${exitCode}`
+                    )
+                }
+                return true
+            } finally {
+                if (timer) clearTimeout(timer)
             }
-            return true
         } catch (err) {
             if (child && child.exitCode == null && child.signalCode == null) {
                 child.kill()

--- a/packages/extension-agent/src/computer/backends/local/store.ts
+++ b/packages/extension-agent/src/computer/backends/local/store.ts
@@ -5,6 +5,7 @@ import { createReadStream } from 'node:fs'
 import fs from 'fs/promises'
 import path from 'path'
 import { createInterface } from 'node:readline'
+import type { Readable } from 'node:stream'
 import micromatch from 'micromatch'
 import which from 'which'
 import { LocalBackendConfig } from '../../../types'
@@ -142,94 +143,51 @@ export class FileStore implements BaseFileStore {
             args.push('-e', pattern, '.')
 
             const output = new LocalOutputCollector('grep')
-            let child: ChildProcessWithoutNullStreams | undefined
-            let closed: Promise<number> | undefined
-            let spawnError: Error | undefined
-            let count = 0
             try {
-                child = spawn(rg, args, {
-                    cwd: dir,
-                    stdio: ['ignore', 'pipe', 'pipe'],
-                    windowsHide: true
+                const found = await this._runRg(args, dir, async (stdout) => {
+                    for await (const line of createInterface({
+                        input: stdout,
+                        crlfDelay: Infinity
+                    })) {
+                        const item = JSON.parse(line)
+                        if (item.type !== 'match') continue
+
+                        const raw = item.data.path.text as string | undefined
+                        if (!raw) continue
+
+                        const file = path.resolve(dir, raw)
+                        if (this._shouldIgnore(file)) continue
+                        if (include && !this._matchPattern(file, include))
+                            continue
+
+                        const text = (
+                            (item.data.lines.text as string | undefined) || ''
+                        ).replace(/\r?\n$/, '')
+                        await output.appendLine(
+                            `${file}:${item.data.line_number}:${text}`
+                        )
+                    }
                 })
-                let stderr = ''
-                child.stderr.setEncoding('utf8')
-                child.stderr.on('data', (text: string) => {
-                    stderr += text.slice(0, 8000 - stderr.length)
-                })
-                closed = new Promise<number>((resolve) => {
-                    child!.on('error', (err) => {
-                        spawnError = err
-                    })
-                    child.on('close', (code) => resolve(code ?? 0))
-                })
-                for await (const line of createInterface({
-                    input: child.stdout,
-                    crlfDelay: Infinity
-                })) {
-                    const item = JSON.parse(line)
-                    if (item.type !== 'match') continue
-
-                    const raw = item.data.path.text as string | undefined
-                    if (!raw) continue
-
-                    const file = path.resolve(dir, raw)
-                    if (this._shouldIgnore(file)) continue
-                    if (include && !this._matchPattern(file, include)) continue
-
-                    const text = (
-                        (item.data.lines.text as string | undefined) || ''
-                    ).replace(/\r?\n$/, '')
-                    await output.append(
-                        `${count > 0 ? '\n' : ''}${file}:${item.data.line_number}:${text}`
-                    )
-                    count += 1
-                }
-
-                const exitCode = await closed
-                if (spawnError) throw spawnError
-                if (exitCode === 1) {
+                if (!found) {
                     await output.dispose()
                     return []
                 }
-
-                if (exitCode !== 0) {
-                    throw new Error(
-                        stderr.trim() || `ripgrep exited with ${exitCode}`
-                    )
-                }
-
-                if (count < 1) {
-                    await output.dispose()
-                    return []
-                }
-                return { ...(await output.finish()), count }
+                return await output.finish()
             } catch (err) {
-                if (
-                    child &&
-                    child.exitCode == null &&
-                    child.signalCode == null
-                ) {
-                    child.kill()
-                }
-                await closed
-                if (count > 0) {
-                    return { ...(await output.finish()), count }
+                if (output.count > 0) {
+                    return await output.finish()
                 }
                 await output.dispose()
                 logger.warn(err)
             }
         }
 
-        const output = new LocalOutputCollector('grep')
         const regex = new RegExp(pattern, 'gm')
-        let count = 0
-        try {
-            for await (const file of stat.isDirectory()
-                ? this._walk(dir)
-                : [dir]) {
-                if (this._shouldIgnore(file)) continue
-                if (include && !this._matchPattern(file, include)) continue
+        return await this._scanFallback(
+            'grep',
+            stat.isDirectory() ? this._walk(dir) : [dir],
+            async (output, file) => {
+                if (include && !this._matchPattern(file, include)) return
 
                 let lineNumber = 0
                 try {
@@ -239,10 +197,9 @@ export class FileStore implements BaseFileStore {
                     })) {
                         lineNumber += 1
                         if (regex.test(line)) {
-                            await output.append(
-                                `${count > 0 ? '\n' : ''}${file}:${lineNumber}:${line}`
+                            await output.appendLine(
+                                `${file}:${lineNumber}:${line}`
                             )
-                            count += 1
                         }
                         regex.lastIndex = 0
                     }
@@ -252,16 +209,7 @@ export class FileStore implements BaseFileStore {
                     }
                 }
             }
-
-            if (count < 1) {
-                await output.dispose()
-                return []
-            }
-            return { ...(await output.finish()), count }
-        } catch (err) {
-            await output.dispose()
-            throw err
-        }
+        )
     }
 
     async glob(pattern: string, searchPath?: string) {
@@ -293,89 +241,101 @@ export class FileStore implements BaseFileStore {
             args.push('.')
 
             const output = new LocalOutputCollector('glob')
-            let child: ChildProcessWithoutNullStreams | undefined
-            let closed: Promise<number> | undefined
-            let spawnError: Error | undefined
-            let count = 0
             try {
-                child = spawn(rg, args, {
-                    cwd: dir,
-                    stdio: ['ignore', 'pipe', 'pipe'],
-                    windowsHide: true
-                })
-                let stderr = ''
-                child.stderr.setEncoding('utf8')
-                child.stderr.on('data', (text: string) => {
-                    stderr += text.slice(0, 8000 - stderr.length)
-                })
-                closed = new Promise<number>((resolve) => {
-                    child!.on('error', (err) => {
-                        spawnError = err
-                    })
-                    child.on('close', (code) => resolve(code ?? 0))
-                })
-                child.stdout.setEncoding('utf8')
-                let rest = ''
-                for await (const chunk of child.stdout) {
-                    const files = `${rest}${chunk}`.split('\0')
-                    rest = files.pop()!
-                    for (const raw of files) {
-                        const file = path.resolve(dir, raw)
-                        if (this._shouldIgnore(file)) continue
-                        if (!this._matchPattern(file, pattern)) continue
-                        await output.append(`${count > 0 ? '\n' : ''}${file}`)
-                        count += 1
+                const found = await this._runRg(args, dir, async (stdout) => {
+                    let rest = ''
+                    for await (const chunk of stdout) {
+                        const files = `${rest}${chunk}`.split('\0')
+                        rest = files.pop()!
+                        for (const raw of files) {
+                            const file = path.resolve(dir, raw)
+                            if (this._shouldIgnore(file)) continue
+                            if (!this._matchPattern(file, pattern)) continue
+                            await output.appendLine(file)
+                        }
                     }
-                }
-
-                const exitCode = await closed
-                if (spawnError) throw spawnError
-                if (exitCode === 1) {
+                })
+                if (!found) {
                     await output.dispose()
                     return []
                 }
-
-                if (exitCode !== 0) {
-                    throw new Error(
-                        stderr.trim() || `ripgrep exited with ${exitCode}`
-                    )
-                }
-
-                if (count < 1) {
-                    await output.dispose()
-                    return []
-                }
-                return { ...(await output.finish()), count }
+                return await output.finish()
             } catch (err) {
-                if (
-                    child &&
-                    child.exitCode == null &&
-                    child.signalCode == null
-                ) {
-                    child.kill()
-                }
-                await closed
-                if (count > 0) {
-                    return { ...(await output.finish()), count }
+                if (output.count > 0) {
+                    return await output.finish()
                 }
                 await output.dispose()
                 logger.warn(err)
             }
         }
 
-        const output = new LocalOutputCollector('glob')
-        let count = 0
+        return await this._scanFallback(
+            'glob',
+            this._walk(dir),
+            async (output, file) => {
+                if (!this._matchPattern(file, pattern)) return
+                await output.appendLine(file)
+            }
+        )
+    }
+
+    private async _runRg(
+        args: string[],
+        dir: string,
+        consume: (stdout: Readable) => Promise<void>
+    ): Promise<boolean> {
+        let child: ChildProcessWithoutNullStreams | undefined
+        let closed: Promise<number> | undefined
+        let spawnError: Error | undefined
         try {
-            for await (const file of this._walk(dir)) {
-                if (!this._matchPattern(file, pattern)) continue
-                await output.append(`${count > 0 ? '\n' : ''}${file}`)
-                count += 1
+            child = spawn(rg, args, {
+                cwd: dir,
+                stdio: ['ignore', 'pipe', 'pipe'],
+                windowsHide: true
+            })
+            let stderr = ''
+            child.stderr.setEncoding('utf8')
+            child.stderr.on('data', (text: string) => {
+                stderr += text.slice(0, 8000 - stderr.length)
+            })
+            child.stdout.setEncoding('utf8')
+            closed = new Promise<number>((resolve) => {
+                child!.on('error', (err) => {
+                    spawnError = err
+                })
+                child.on('close', (code) => resolve(code ?? 0))
+            })
+            await consume(child.stdout)
+            const exitCode = await closed
+            if (spawnError) throw spawnError
+            if (exitCode === 1) return false
+            if (exitCode !== 0) {
+                throw new Error(
+                    stderr.trim() || `ripgrep exited with ${exitCode}`
+                )
             }
-            if (count < 1) {
-                await output.dispose()
-                return []
+            return true
+        } catch (err) {
+            if (child && child.exitCode == null && child.signalCode == null) {
+                child.kill()
             }
-            return { ...(await output.finish()), count }
+            await closed
+            throw err
+        }
+    }
+
+    private async _scanFallback(
+        name: string,
+        files: AsyncIterable<string> | Iterable<string>,
+        collect: (output: LocalOutputCollector, file: string) => Promise<void>
+    ): Promise<TextOutput> {
+        const output = new LocalOutputCollector(name)
+        try {
+            for await (const file of files) {
+                if (this._shouldIgnore(file)) continue
+                await collect(output, file)
+            }
+            return await output.finish()
         } catch (err) {
             await output.dispose()
             throw err

--- a/packages/extension-agent/src/computer/backends/local/store.ts
+++ b/packages/extension-agent/src/computer/backends/local/store.ts
@@ -1,14 +1,18 @@
 /** @module computer/backends/local/store */
 
-import { spawn } from 'node:child_process'
+import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process'
+import { createReadStream } from 'node:fs'
 import fs from 'fs/promises'
 import path from 'path'
+import { createInterface } from 'node:readline'
 import micromatch from 'micromatch'
 import which from 'which'
 import { LocalBackendConfig } from '../../../types'
-import type { FileContent } from '../../types'
+import type { FileContent, TextOutput } from '../../types'
+import { LocalOutputCollector } from './output'
 
 const rg = which.sync('rg', { nothrow: true })
+const INTERNAL_IGNORES = ['**/.tmp-chatluna-*']
 
 export interface BaseFileStore {
     readFile(filePath: string, offset?: number, limit?: number): Promise<string>
@@ -23,8 +27,8 @@ export interface BaseFileStore {
         pattern: string,
         searchPath?: string,
         include?: string
-    ): Promise<string[]>
-    glob(pattern: string, searchPath?: string): Promise<string[]>
+    ): Promise<string[] | TextOutput>
+    glob(pattern: string, searchPath?: string): Promise<string[] | TextOutput>
     readonly scope: string
     isInScope(filePath: string): boolean
 }
@@ -130,106 +134,135 @@ export class FileStore implements BaseFileStore {
                 args.push('-g', include)
             }
 
-            for (const item of this._cfg.ignores) {
+            for (const item of [...this._cfg.ignores, ...INTERNAL_IGNORES]) {
                 args.push('-g', `!${item}`)
             }
 
             args.push('-e', pattern, '.')
 
+            const output = new LocalOutputCollector('grep')
+            let child: ChildProcessWithoutNullStreams | undefined
+            let closed: Promise<number> | undefined
+            let spawnError: Error | undefined
             try {
-                const result = await runProcess(rg, args, dir)
-                if (result.exitCode === 1) {
-                    return []
-                }
-
-                if (result.exitCode !== 0) {
-                    throw new Error(
-                        result.stderr ||
-                            `ripgrep exited with ${result.exitCode}`
-                    )
-                }
-
-                const matched = new Map<string, string[]>()
-                for (const line of result.stdout.split('\n')) {
-                    if (!line) {
-                        continue
-                    }
-
+                child = spawn(rg, args, {
+                    cwd: dir,
+                    stdio: ['ignore', 'pipe', 'pipe'],
+                    windowsHide: true
+                })
+                let stderr = ''
+                child.stderr.setEncoding('utf8')
+                child.stderr.on('data', (text: string) => {
+                    stderr += text.slice(0, 8000 - stderr.length)
+                })
+                closed = new Promise<number>((resolve) => {
+                    child!.on('error', (err) => {
+                        spawnError = err
+                    })
+                    child.on('close', (code) => resolve(code ?? 0))
+                })
+                let count = 0
+                for await (const line of createInterface({
+                    input: child.stdout,
+                    crlfDelay: Infinity
+                })) {
                     const item = JSON.parse(line)
-                    if (item.type !== 'match') {
-                        continue
-                    }
+                    if (item.type !== 'match') continue
 
                     const raw = item.data.path.text as string | undefined
-                    if (!raw) {
-                        continue
-                    }
+                    if (!raw) continue
 
                     const file = path.resolve(dir, raw)
-                    if (this._shouldIgnore(file)) {
-                        continue
-                    }
-
-                    if (include && !this._matchPattern(file, include)) {
-                        continue
-                    }
+                    if (this._shouldIgnore(file)) continue
+                    if (include && !this._matchPattern(file, include)) continue
 
                     const text = (
                         (item.data.lines.text as string | undefined) || ''
                     ).replace(/\r?\n$/, '')
-                    if (!matched.has(file)) {
-                        matched.set(file, [])
-                    }
-                    matched
-                        .get(file)
-                        .push(`${file}:${item.data.line_number}:${text}`)
+                    await output.append(
+                        `${count > 0 ? '\n' : ''}${file}:${item.data.line_number}:${text}`
+                    )
+                    count += 1
                 }
 
-                const files = await sortByMtime([...matched.keys()])
-                return files.flatMap((f) => matched.get(f) || [])
+                const exitCode = await closed
+                if (spawnError) throw spawnError
+                if (exitCode === 1) {
+                    await output.dispose()
+                    return []
+                }
+
+                if (exitCode !== 0) {
+                    throw new Error(
+                        stderr.trim() || `ripgrep exited with ${exitCode}`
+                    )
+                }
+
+                if (count < 1) {
+                    await output.dispose()
+                    return []
+                }
+                return { ...(await output.finish()), count }
             } catch (err) {
+                if (
+                    child &&
+                    child.exitCode == null &&
+                    child.signalCode == null
+                ) {
+                    child.kill()
+                }
+                await closed
+                await output.dispose()
                 if (process.env['CHATLUNA_AGENT_DEBUG']) {
                     console.debug(err)
                 }
             }
         }
 
-        const files = stat.isDirectory()
-            ? await this._findFiles(dir, include)
-            : include == null || this._matchPattern(dir, include)
-              ? [dir]
-              : []
-
+        const output = new LocalOutputCollector('grep')
         const regex = new RegExp(pattern, 'gm')
-        const matched = new Map<string, string[]>()
+        let count = 0
+        try {
+            for await (const file of stat.isDirectory()
+                ? this._walk(dir)
+                : [dir]) {
+                if (this._shouldIgnore(file)) continue
+                if (include && !this._matchPattern(file, include)) continue
 
-        for (const file of files) {
-            if (this._shouldIgnore(file)) {
-                continue
-            }
+                const lines = createInterface({
+                    input: createReadStream(file),
+                    crlfDelay: Infinity
+                })[Symbol.asyncIterator]()
+                let lineNumber = 0
+                while (true) {
+                    const next = await lines.next().catch((err) => {
+                        if (process.env['CHATLUNA_AGENT_DEBUG']) {
+                            console.debug(err)
+                        }
+                        return undefined
+                    })
+                    if (!next || next.done) break
 
-            const content = await fs.readFile(file, 'utf-8').catch(() => null)
-            if (content == null) {
-                continue
-            }
-
-            const lines = content.split('\n')
-            const list: string[] = []
-            for (let idx = 0; idx < lines.length; idx++) {
-                if (regex.test(lines[idx])) {
-                    list.push(`${file}:${idx + 1}:${lines[idx]}`)
+                    lineNumber += 1
+                    if (regex.test(next.value)) {
+                        await output.append(
+                            `${count > 0 ? '\n' : ''}${file}:${lineNumber}:${next.value}`
+                        )
+                        count += 1
+                    }
+                    regex.lastIndex = 0
                 }
-                regex.lastIndex = 0
             }
 
-            if (list.length > 0) {
-                matched.set(file, list)
+            if (count < 1) {
+                await output.dispose()
+                return []
             }
+            return { ...(await output.finish()), count }
+        } catch (err) {
+            await output.dispose()
+            throw err
         }
-
-        return (await sortByMtime([...matched.keys()])).flatMap(
-            (f) => matched.get(f) || []
-        )
     }
 
     async glob(pattern: string, searchPath?: string) {
@@ -254,99 +287,132 @@ export class FileStore implements BaseFileStore {
             ]
 
             args.push('-g', pattern)
-            for (const item of this._cfg.ignores) {
+            for (const item of [...this._cfg.ignores, ...INTERNAL_IGNORES]) {
                 args.push('-g', `!${item}`)
             }
 
             args.push('.')
 
+            const output = new LocalOutputCollector('glob')
+            let child: ChildProcessWithoutNullStreams | undefined
+            let closed: Promise<number> | undefined
+            let spawnError: Error | undefined
             try {
-                const result = await runProcess(rg, args, dir)
-                if (result.exitCode !== 0) {
+                child = spawn(rg, args, {
+                    cwd: dir,
+                    stdio: ['ignore', 'pipe', 'pipe'],
+                    windowsHide: true
+                })
+                let stderr = ''
+                child.stderr.setEncoding('utf8')
+                child.stderr.on('data', (text: string) => {
+                    stderr += text.slice(0, 8000 - stderr.length)
+                })
+                closed = new Promise<number>((resolve) => {
+                    child!.on('error', (err) => {
+                        spawnError = err
+                    })
+                    child.on('close', (code) => resolve(code ?? 0))
+                })
+                child.stdout.setEncoding('utf8')
+                let rest = ''
+                let count = 0
+                for await (const chunk of child.stdout) {
+                    const files = `${rest}${chunk}`.split('\0')
+                    rest = files.pop()!
+                    for (const raw of files) {
+                        const file = path.resolve(dir, raw)
+                        if (this._shouldIgnore(file)) continue
+                        if (!this._matchPattern(file, pattern)) continue
+                        await output.append(`${count > 0 ? '\n' : ''}${file}`)
+                        count += 1
+                    }
+                }
+
+                const exitCode = await closed
+                if (spawnError) throw spawnError
+                if (exitCode !== 0) {
                     throw new Error(
-                        result.stderr ||
-                            `ripgrep exited with ${result.exitCode}`
+                        stderr.trim() || `ripgrep exited with ${exitCode}`
                     )
                 }
 
-                return sortByMtime(
-                    result.stdout
-                        .split('\0')
-                        .filter(Boolean)
-                        .map((file) => path.resolve(dir, file))
-                        .filter(
-                            (file) =>
-                                !this._shouldIgnore(file) &&
-                                this._matchPattern(file, pattern)
-                        )
-                )
+                if (count < 1) {
+                    await output.dispose()
+                    return []
+                }
+                return { ...(await output.finish()), count }
             } catch (err) {
+                if (
+                    child &&
+                    child.exitCode == null &&
+                    child.signalCode == null
+                ) {
+                    child.kill()
+                }
+                await closed
+                await output.dispose()
                 if (process.env['CHATLUNA_AGENT_DEBUG']) {
                     console.debug(err)
                 }
             }
         }
 
-        return sortByMtime(await this._findFiles(dir, pattern))
+        const output = new LocalOutputCollector('glob')
+        let count = 0
+        try {
+            for await (const file of this._walk(dir)) {
+                if (!this._matchPattern(file, pattern)) continue
+                await output.append(`${count > 0 ? '\n' : ''}${file}`)
+                count += 1
+            }
+            if (count < 1) {
+                await output.dispose()
+                return []
+            }
+            return { ...(await output.finish()), count }
+        } catch (err) {
+            await output.dispose()
+            throw err
+        }
     }
 
-    private async _findFiles(
-        dirPath: string,
-        pattern?: string
-    ): Promise<string[]> {
+    private async *_walk(dirPath: string): AsyncGenerator<string> {
         try {
-            const entries = await fs.readdir(dirPath, { withFileTypes: true })
-            const results: string[] = []
-
-            for (const entry of entries) {
+            for await (const entry of await fs.opendir(dirPath)) {
                 const fullPath = path.join(dirPath, entry.name)
-                if (this._shouldIgnore(fullPath)) {
-                    continue
-                }
+                if (this._shouldIgnore(fullPath)) continue
 
                 if (entry.isDirectory()) {
-                    results.push(...(await this._findFiles(fullPath, pattern)))
+                    yield* this._walk(fullPath)
                     continue
                 }
 
                 if (entry.isFile()) {
-                    if (!pattern || this._matchPattern(fullPath, pattern)) {
-                        results.push(fullPath)
-                    }
+                    yield fullPath
                     continue
                 }
 
-                if (!entry.isSymbolicLink()) {
-                    continue
-                }
+                if (!entry.isSymbolicLink()) continue
 
                 try {
                     const stat = await fs.stat(fullPath)
                     if (stat.isDirectory()) {
-                        results.push(
-                            ...(await this._findFiles(fullPath, pattern))
-                        )
+                        yield* this._walk(fullPath)
                         continue
                     }
 
-                    if (stat.isFile()) {
-                        if (!pattern || this._matchPattern(fullPath, pattern)) {
-                            results.push(fullPath)
-                        }
-                    }
+                    if (stat.isFile()) yield fullPath
                 } catch (err) {
                     if (process.env['CHATLUNA_AGENT_DEBUG']) {
                         console.debug(err)
                     }
                 }
             }
-
-            return results
         } catch (err) {
             if (process.env['CHATLUNA_AGENT_DEBUG']) {
                 console.debug(err)
             }
-            return []
         }
     }
 
@@ -362,62 +428,14 @@ export class FileStore implements BaseFileStore {
     }
 
     private _shouldIgnore(filePath: string) {
-        if (this._cfg.ignores.length === 0) {
-            return false
-        }
         return micromatch.isMatch(
             path
                 .relative(this._cfg.scopePath || process.cwd(), filePath)
                 .replace(/\\/g, '/'),
-            this._cfg.ignores,
+            [...this._cfg.ignores, ...INTERNAL_IGNORES],
             { dot: true }
         )
     }
-}
-
-function runProcess(file: string, args: string[], cwd: string) {
-    return new Promise<{
-        exitCode: number
-        stdout: string
-        stderr: string
-    }>((resolve, reject) => {
-        const stdout: Buffer[] = []
-        const stderr: Buffer[] = []
-        const child = spawn(file, args, {
-            cwd,
-            stdio: ['ignore', 'pipe', 'pipe'],
-            windowsHide: true
-        })
-
-        child.stdout.on('data', (chunk: Buffer | string) => {
-            stdout.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
-        })
-
-        child.stderr.on('data', (chunk: Buffer | string) => {
-            stderr.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
-        })
-
-        child.on('error', reject)
-        child.on('close', (code) => {
-            resolve({
-                exitCode: code ?? 0,
-                stdout: Buffer.concat(stdout).toString('utf8'),
-                stderr: Buffer.concat(stderr).toString('utf8').trim()
-            })
-        })
-    })
-}
-
-async function sortByMtime(files: string[]) {
-    const list = await Promise.all(
-        files.map(async (file) => ({
-            path: file,
-            mtime: (await fs.stat(file).catch(() => null))?.mtimeMs ?? 0
-        }))
-    )
-
-    list.sort((a, b) => b.mtime - a.mtime)
-    return list.map((item) => item.path)
 }
 
 function replaceSubstring(

--- a/packages/extension-agent/src/computer/tools/base.ts
+++ b/packages/extension-agent/src/computer/tools/base.ts
@@ -6,7 +6,7 @@
 import { StructuredTool } from '@langchain/core/tools'
 import type { ChatLunaToolRunnable } from 'koishi-plugin-chatluna/llm-core/platform/types'
 import { logger } from '../..'
-import type { ComputerSessionApi } from '../types'
+import type { ComputerSessionApi, TextOutput } from '../types'
 import type { ChatLunaAgentComputerService } from '../../service/computer'
 
 /** Computer 工具抽象基类。 */
@@ -31,12 +31,15 @@ export abstract class ComputerToolBase extends StructuredTool {
     protected async formatLargeResult(
         session: ComputerSessionApi,
         name: string,
-        text: string,
+        text: string | TextOutput,
         limit = 8000
     ) {
         return await this.computer.ctx.chatluna_agent.truncateTextOutput({
             name,
-            text,
+            text: typeof text === 'string' ? text : text.text,
+            outputPath: typeof text === 'string' ? undefined : text.outputPath,
+            totalLength:
+                typeof text === 'string' ? undefined : text.totalLength,
             limit,
             session
         })

--- a/packages/extension-agent/src/computer/tools/base.ts
+++ b/packages/extension-agent/src/computer/tools/base.ts
@@ -31,15 +31,18 @@ export abstract class ComputerToolBase extends StructuredTool {
     protected async formatLargeResult(
         session: ComputerSessionApi,
         name: string,
-        text: string | TextOutput,
+        text: string | string[] | TextOutput,
         limit = 8000
     ) {
+        const value =
+            typeof text === 'string'
+                ? { text }
+                : Array.isArray(text)
+                  ? { text: text.join('\n') }
+                  : text
         return await this.computer.ctx.chatluna_agent.truncateTextOutput({
             name,
-            text: typeof text === 'string' ? text : text.text,
-            outputPath: typeof text === 'string' ? undefined : text.outputPath,
-            totalLength:
-                typeof text === 'string' ? undefined : text.totalLength,
+            ...value,
             limit,
             session
         })

--- a/packages/extension-agent/src/computer/tools/bash.ts
+++ b/packages/extension-agent/src/computer/tools/bash.ts
@@ -198,7 +198,7 @@ When to use:
                 const output = await this.formatLargeResult(
                     computer,
                     'bash',
-                    formatExecuteResult(result)
+                    result.output ?? formatExecuteResult(result)
                 )
                 return this.withBackend(
                     computer,
@@ -209,7 +209,7 @@ When to use:
             const output = await this.formatLargeResult(
                 computer,
                 'bash',
-                formatExecuteResult(result)
+                result.output ?? formatExecuteResult(result)
             )
 
             if (result.signal) {

--- a/packages/extension-agent/src/computer/tools/glob.ts
+++ b/packages/extension-agent/src/computer/tools/glob.ts
@@ -38,7 +38,7 @@ export class GlobTool extends ComputerToolBase {
             const results = await computer.glob(input.pattern, input.path)
             const count = Array.isArray(results)
                 ? results.length
-                : (results.count ?? 0)
+                : results.count
             if (count < 1) {
                 return 'No files matched.'
             }
@@ -46,11 +46,7 @@ export class GlobTool extends ComputerToolBase {
             this.log(computer, `找到 ${count} 个文件`)
             return this.withBackend(
                 computer,
-                await this.formatLargeResult(
-                    computer,
-                    'glob',
-                    Array.isArray(results) ? results.join('\n') : results
-                )
+                await this.formatLargeResult(computer, 'glob', results)
             )
         } catch (err) {
             return this.formatResult(

--- a/packages/extension-agent/src/computer/tools/glob.ts
+++ b/packages/extension-agent/src/computer/tools/glob.ts
@@ -10,7 +10,7 @@ export class GlobTool extends ComputerToolBase {
 
     description = `Fast file pattern matching tool that works with any codebase size.
 - Supports glob patterns like "**/*.js" or "src/**/*.ts"
-- Returns matching file paths sorted by modification time`
+- Returns matching file paths in search traversal order`
 
     schema = z.object({
         pattern: z
@@ -36,17 +36,20 @@ export class GlobTool extends ComputerToolBase {
 
         try {
             const results = await computer.glob(input.pattern, input.path)
-            if (results.length < 1) {
+            const count = Array.isArray(results)
+                ? results.length
+                : (results.count ?? 0)
+            if (count < 1) {
                 return 'No files matched.'
             }
 
-            this.log(computer, `找到 ${results.length} 个文件`)
+            this.log(computer, `找到 ${count} 个文件`)
             return this.withBackend(
                 computer,
                 await this.formatLargeResult(
                     computer,
                     'glob',
-                    results.join('\n')
+                    Array.isArray(results) ? results.join('\n') : results
                 )
             )
         } catch (err) {

--- a/packages/extension-agent/src/computer/tools/grep.ts
+++ b/packages/extension-agent/src/computer/tools/grep.ts
@@ -52,7 +52,7 @@ export class GrepTool extends ComputerToolBase {
             )
             const count = Array.isArray(results)
                 ? results.length
-                : (results.count ?? 0)
+                : results.count
             if (count < 1) {
                 return 'No matches found.'
             }
@@ -60,11 +60,7 @@ export class GrepTool extends ComputerToolBase {
             this.log(computer, `找到 ${count} 条匹配`)
             return this.withBackend(
                 computer,
-                await this.formatLargeResult(
-                    computer,
-                    'grep',
-                    Array.isArray(results) ? results.join('\n') : results
-                )
+                await this.formatLargeResult(computer, 'grep', results)
             )
         } catch (err) {
             return this.formatResult(

--- a/packages/extension-agent/src/computer/tools/grep.ts
+++ b/packages/extension-agent/src/computer/tools/grep.ts
@@ -12,7 +12,7 @@ export class GrepTool extends ComputerToolBase {
 - Searches file contents using regular expressions
 - Supports full regex syntax (eg. "log.*Error", "function\\s+\\w+", etc.)
 - Filter files by glob pattern with the include parameter (eg. "*.js", "*.{ts,tsx}")
-- Returns file paths and line numbers with at least one match, sorted by modification time`
+- Returns file paths and line numbers in search traversal order`
 
     schema = z.object({
         pattern: z
@@ -50,17 +50,20 @@ export class GrepTool extends ComputerToolBase {
                 input.path,
                 input.include
             )
-            if (results.length < 1) {
+            const count = Array.isArray(results)
+                ? results.length
+                : (results.count ?? 0)
+            if (count < 1) {
                 return 'No matches found.'
             }
 
-            this.log(computer, `找到 ${results.length} 条匹配`)
+            this.log(computer, `找到 ${count} 条匹配`)
             return this.withBackend(
                 computer,
                 await this.formatLargeResult(
                     computer,
                     'grep',
-                    results.join('\n')
+                    Array.isArray(results) ? results.join('\n') : results
                 )
             )
         } catch (err) {

--- a/packages/extension-agent/src/computer/types.ts
+++ b/packages/extension-agent/src/computer/types.ts
@@ -8,7 +8,7 @@ export interface TextOutput {
     text: string
     outputPath?: string
     totalLength: number
-    count?: number
+    count: number
 }
 
 export interface ComputerSessionApi {

--- a/packages/extension-agent/src/computer/types.ts
+++ b/packages/extension-agent/src/computer/types.ts
@@ -4,6 +4,13 @@ import { ComputerBackendType, ComputerCapability } from '../types'
 
 export type FileContent = string | Uint8Array
 
+export interface TextOutput {
+    text: string
+    outputPath?: string
+    totalLength: number
+    count?: number
+}
+
 export interface ComputerSessionApi {
     readonly backend: ComputerBackendType
     readonly sessionId: string
@@ -27,8 +34,8 @@ export interface ComputerSessionApi {
         pattern: string,
         searchPath?: string,
         include?: string
-    ): Promise<string[]>
-    glob(pattern: string, searchPath?: string): Promise<string[]>
+    ): Promise<string[] | TextOutput>
+    glob(pattern: string, searchPath?: string): Promise<string[] | TextOutput>
     execute(command: string, options?: ExecuteOptions): Promise<ExecuteResult>
     readAsset?(path: string): Promise<string>
     openAsset(path: string): Promise<OpenAssetResult>
@@ -64,6 +71,7 @@ export interface ExecuteResult {
     stderr: string
     signal?: string
     timedOut: boolean
+    output?: TextOutput
 }
 
 export interface EditResult {

--- a/packages/extension-agent/src/index.ts
+++ b/packages/extension-agent/src/index.ts
@@ -10,6 +10,7 @@ import * as webui from './webui'
 import * as mcpCommands from './commands/mcp'
 import * as agentCommands from './commands/agent'
 import * as taskCommands from './commands/task'
+import { cleanupExpiredOutputs } from './computer/backends/local/output'
 
 export * from './types'
 
@@ -26,6 +27,17 @@ export async function apply(ctx: Context, config: Config) {
         config: await readConfig(ctx),
         plugin
     })
+
+    ctx.setInterval(
+        () => {
+            cleanupExpiredOutputs(60 * 60 * 1000).catch((err) => {
+                logger.warn(
+                    `Failed to clean up expired temporary outputs: ${err}`
+                )
+            })
+        },
+        10 * 60 * 1000
+    )
 
     ctx.plugin(webui)
     ctx.plugin(mcpCommands)

--- a/packages/extension-agent/src/index.ts
+++ b/packages/extension-agent/src/index.ts
@@ -31,9 +31,7 @@ export async function apply(ctx: Context, config: Config) {
     ctx.setInterval(
         () => {
             cleanupExpiredOutputs(60 * 60 * 1000).catch((err) => {
-                logger.warn(
-                    `Failed to clean up expired temporary outputs: ${err}`
-                )
+                logger.error(err)
             })
         },
         10 * 60 * 1000

--- a/packages/extension-agent/src/service/computer.ts
+++ b/packages/extension-agent/src/service/computer.ts
@@ -741,7 +741,13 @@ export class ChatLunaAgentComputerService {
         input: { pattern: string; path?: string; backend?: ComputerBackendType }
     ) {
         const session = await this.getOrCreateUiSession(clientId, input.backend)
-        return await session.glob(input.pattern, input.path)
+        const result = await session.glob(input.pattern, input.path)
+        if (Array.isArray(result)) return result
+        const end = result.outputPath
+            ? result.text.lastIndexOf('\n')
+            : undefined
+        const text = end == null ? result.text : result.text.slice(0, end + 1)
+        return text.split('\n').filter(Boolean)
     }
 
     async getHomeForUi(clientId: string, backend?: ComputerBackendType) {

--- a/packages/extension-agent/src/service/computer.ts
+++ b/packages/extension-agent/src/service/computer.ts
@@ -746,7 +746,10 @@ export class ChatLunaAgentComputerService {
         const end = result.outputPath
             ? result.text.lastIndexOf('\n')
             : undefined
-        const text = end == null ? result.text : result.text.slice(0, end + 1)
+        const text =
+            end != null && end >= 0
+                ? result.text.slice(0, end + 1)
+                : result.text
         return text.split('\n').filter(Boolean)
     }
 

--- a/packages/extension-agent/src/service/index.ts
+++ b/packages/extension-agent/src/service/index.ts
@@ -611,9 +611,20 @@ export class ChatLunaAgentService extends Service {
         limit?: number
         session?: ComputerSessionApi
         outputDir?: string
+        outputPath?: string
+        totalLength?: number
     }) {
         const limit = input.limit ?? 8000
-        if (input.text.length <= limit) return input.text
+        const length = input.totalLength ?? input.text.length
+        if (length <= limit) return input.text
+
+        if (input.outputPath) {
+            return `${truncateOutput(input.text, limit)}
+
+Output too large (${length} chars). Full output saved to: ${input.outputPath}
+Use file_read with this path plus offset/limit to inspect more.
+`
+        }
 
         if (input.session) {
             const dir = (await input.session.getTempDir()).replace(

--- a/packages/extension-agent/src/service/index.ts
+++ b/packages/extension-agent/src/service/index.ts
@@ -618,57 +618,35 @@ export class ChatLunaAgentService extends Service {
         const length = input.totalLength ?? input.text.length
         if (length <= limit) return input.text
 
-        if (input.outputPath) {
-            return `${truncateOutput(input.text, limit)}
-
-Output too large (${length} chars). Full output saved to: ${input.outputPath}
-Use file_read with this path plus offset/limit to inspect more.
-`
-        }
-
-        if (input.session) {
-            const dir = (await input.session.getTempDir()).replace(
-                /[\\/]+$/,
-                ''
-            )
+        const preview = truncateOutput(input.text, limit)
+        let saved = input.outputPath
+        if (!saved) {
+            const dir = input.session
+                ? (await input.session.getTempDir()).replace(/[\\/]+$/, '')
+                : (input.outputDir ??
+                  resolve(os.tmpdir(), 'chatluna', 'truncation'))
             const filePath = `${dir}/${input.name}-${Date.now()}-${randomUUID()}.txt`
-
             try {
-                await input.session.writeFile(filePath, input.text)
-                return `${truncateOutput(input.text, limit)}
-
-Output too large (${input.text.length} chars). Full output saved to: ${filePath}
-Use file_read with this path plus offset/limit to inspect more.
-`
+                if (input.session) {
+                    await input.session.writeFile(filePath, input.text)
+                } else {
+                    await mkdir(dir, { recursive: true })
+                    await writeFile(filePath, input.text, 'utf-8')
+                }
+                saved = filePath
             } catch (err) {
                 logger.warn(err)
-                return `${truncateOutput(input.text, limit)}
+                return `${preview}
 
-Output too large (${input.text.length} chars). Failed to save full output: ${getErrorMessage(err)}`
+Output too large (${length} chars). Failed to save full output: ${getErrorMessage(err)}`
             }
         }
 
-        const dir =
-            input.outputDir ?? resolve(os.tmpdir(), 'chatluna', 'truncation')
-        const filePath = join(
-            dir,
-            `${input.name}-${Date.now()}-${randomUUID()}.txt`
-        )
+        return `${preview}
 
-        try {
-            await mkdir(dir, { recursive: true })
-            await writeFile(filePath, input.text, 'utf-8')
-            return `${truncateOutput(input.text, limit)}
-
-Output too large (${input.text.length} chars). Full output saved to: ${filePath}
+Output too large (${length} chars). Full output saved to: ${saved}
 Use file_read with this path plus offset/limit to inspect more.
 `
-        } catch (err) {
-            logger.warn(err)
-            return `${truncateOutput(input.text, limit)}
-
-Output too large (${input.text.length} chars). Failed to save full output: ${getErrorMessage(err)}`
-        }
     }
 
     async updateConfigPath(


### PR DESCRIPTION
This pr prevents large local computer-tool output from being accumulated entirely in memory.

## New Features
- Add a local output collector that keeps an 8,000-character preview and streams larger output to a temporary file
- Return full-output paths for oversized bash, grep, and glob results

## Bug Fixes
- Stream ripgrep, glob, fallback grep, stdout, and stderr processing to avoid OOM failures on large output
- Apply backpressure while persisting child-process output
- Exclude ChatLuna output temp files from local searches

## Other Changes
- Update computer output types and UI glob adaptation for streamed results
- Preserve traversal order instead of sorting all matches by modification time

## Validation
- yarn lint-fix (0 errors, 2 existing warnings)
- yarn fast-build extension-agent