### PR TITLE
fix(search): report google-web captcha blocks as failures

### DIFF
--- a/packages/service-search/src/provide.ts
+++ b/packages/service-search/src/provide.ts
@@ -16,6 +16,10 @@ export abstract class SearchProvider {
         protected _plugin: ChatLunaPlugin
     ) {}
 
+    /**
+     * Search for results. Implementations must throw an `Error` (not a raw
+     * value) when a request fails, so callers can rely on `error.message`.
+     */
     abstract search(query: string, limit: number): Promise<SearchResult[]>
 
     abstract name: string
@@ -88,8 +92,7 @@ export class SearchManager {
             } catch (error) {
                 failures.push({
                     name: provider.name,
-                    reason:
-                        error instanceof Error ? error.message : String(error)
+                    reason: (error as Error).message
                 })
                 logger.error(
                     `Error searching with provider ${provider.name}:`,

--- a/packages/service-search/src/provide.ts
+++ b/packages/service-search/src/provide.ts
@@ -69,15 +69,7 @@ export class SearchManager {
 
         if (providers.length === 1) {
             // 一个源就不用分了，直接返回
-            try {
-                return await providers[0].search(query, limit)
-            } catch (error) {
-                logger.error(
-                    `Error searching with provider ${providers[0].name}:`,
-                    error
-                )
-                return []
-            }
+            return await providers[0].search(query, limit)
         }
 
         const searchResults: SearchResult[] = []
@@ -87,11 +79,14 @@ export class SearchManager {
                 ? Math.max(1, Math.round(limit / providers.length))
                 : limit
 
+        let failedCount = 0
+
         const searchPromises = providers.map(async (provider) => {
             try {
                 const results = await provider.search(query, signalLimit)
                 searchResults.push(...results)
             } catch (error) {
+                failedCount += 1
                 logger.error(
                     `Error searching with provider ${provider.name}:`,
                     error
@@ -100,6 +95,10 @@ export class SearchManager {
         })
 
         await Promise.all(searchPromises)
+
+        if (failedCount === providers.length) {
+            throw new Error('All search providers failed')
+        }
 
         if (searchResults.length > limit) {
             return this._reRankResults(query, searchResults, limit)

--- a/packages/service-search/src/provide.ts
+++ b/packages/service-search/src/provide.ts
@@ -79,14 +79,18 @@ export class SearchManager {
                 ? Math.max(1, Math.round(limit / providers.length))
                 : limit
 
-        let failedCount = 0
+        const failures: { name: string; reason: string }[] = []
 
         const searchPromises = providers.map(async (provider) => {
             try {
                 const results = await provider.search(query, signalLimit)
                 searchResults.push(...results)
             } catch (error) {
-                failedCount += 1
+                failures.push({
+                    name: provider.name,
+                    reason:
+                        error instanceof Error ? error.message : String(error)
+                })
                 logger.error(
                     `Error searching with provider ${provider.name}:`,
                     error
@@ -96,8 +100,12 @@ export class SearchManager {
 
         await Promise.all(searchPromises)
 
-        if (failedCount === providers.length) {
-            throw new Error('All search providers failed')
+        if (failures.length === providers.length) {
+            throw new Error(
+                `All search providers failed: ${failures
+                    .map((f) => `${f.name} (${f.reason})`)
+                    .join('; ')}`
+            )
         }
 
         if (searchResults.length > limit) {

--- a/packages/service-search/src/providers/google_web.ts
+++ b/packages/service-search/src/providers/google_web.ts
@@ -23,15 +23,15 @@ class GoogleWebSearchProvider extends SearchProvider {
                     timeout: this.config.browserTimeout
                 }
             )
-            const finalUrl = page.url()
+            const finalUrl = new URL(page.url())
             if (response && response.status() >= 400) {
                 throw new Error(
                     `google-web request failed with HTTP ${response.status()}`
                 )
             }
             if (
-                finalUrl.includes('/sorry/') ||
-                finalUrl.includes('consent.google.com')
+                finalUrl.pathname.includes('/sorry/') ||
+                finalUrl.hostname === 'consent.google.com'
             ) {
                 throw new Error(
                     'google-web request blocked by captcha or consent page'
@@ -67,10 +67,15 @@ function readGoogleResults() {
         .filter((r) => r.url && r.title)
 
     if (results.length > 0) return results
-    if (!document.querySelector('#search')) {
-        throw new Error('google-web page structure changed or blocked')
+
+    const stats = document.querySelector('#result-stats')?.textContent ?? ''
+    if (
+        document.querySelector('.obcontainer') ||
+        /about 0 results|did not match any/i.test(stats)
+    ) {
+        return []
     }
-    return []
+    throw new Error('google-web page structure changed or blocked')
 }
 
 export function apply(

--- a/packages/service-search/src/providers/google_web.ts
+++ b/packages/service-search/src/providers/google_web.ts
@@ -12,7 +12,7 @@ class GoogleWebSearchProvider extends SearchProvider {
         const page = await this.ctx.puppeteer.page()
 
         try {
-            await page.goto(
+            const response = await page.goto(
                 `https://www.google.com.hk/search?q=${encodeURIComponent(
                     query
                 )}&oq=${encodeURIComponent(
@@ -23,6 +23,20 @@ class GoogleWebSearchProvider extends SearchProvider {
                     timeout: this.config.browserTimeout
                 }
             )
+            const finalUrl = page.url()
+            if (response && response.status() >= 400) {
+                throw new Error(
+                    `google-web request failed with HTTP ${response.status()}`
+                )
+            }
+            if (
+                finalUrl.includes('/sorry/') ||
+                finalUrl.includes('consent.google.com')
+            ) {
+                throw new Error(
+                    'google-web request blocked by captcha or consent page'
+                )
+            }
             return (await page.evaluate(readGoogleResults)).slice(0, limit)
         } finally {
             await page.close()
@@ -37,7 +51,7 @@ class GoogleWebSearchProvider extends SearchProvider {
 }
 
 function readGoogleResults() {
-    return Array.from(document.querySelectorAll('#search a > h3'))
+    const results = Array.from(document.querySelectorAll('#search a > h3'))
         .map((h3) => {
             const a = h3.closest('a')
             return {
@@ -51,6 +65,12 @@ function readGoogleResults() {
             }
         })
         .filter((r) => r.url && r.title)
+
+    if (results.length > 0) return results
+    if (!document.querySelector('#search')) {
+        throw new Error('google-web page structure changed or blocked')
+    }
+    return []
 }
 
 export function apply(


### PR DESCRIPTION
This pr stops Google (Web) captcha/429 pages from being reported as empty search results.

Closes https://github.com/ChatLunaLab/chatluna/issues/995

## New Features
- None

## Bug Fixes
- Google (Web) provider throws a clear error on HTTP >= 400, `/sorry/`, or consent pages instead of returning an empty list
- `readGoogleResults` throws when the search container is missing so blocked/changed pages are not mistaken for "no results"
- `SearchManager` propagates failures when the single provider or all providers fail, instead of returning `[]`

## Other Changes
- None

## Validation
- yarn lint-fix (0 errors, 2 existing warnings)
- yarn fast-build service-search