### PR TITLE
fix(core): hydrate database user on virtual sessions from routing invocations

### DIFF
--- a/packages/core/src/utils/virtual_session.ts
+++ b/packages/core/src/utils/virtual_session.ts
@@ -1,4 +1,4 @@
-import { h, type Session, type Universal } from 'koishi'
+import { h, type Session, type Universal, type User } from 'koishi'
 import { transformMessageContentToElements } from 'koishi-plugin-chatluna/utils/koishi'
 import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
 
@@ -46,5 +46,15 @@ export async function buildVirtualSession(
         }
     }
 
-    return bot.session(event)
+    const session = bot.session(event)
+    const userFields = new Set<User.Field>([
+        'id',
+        'flag',
+        'authority',
+        'permissions',
+        'locales'
+    ])
+    bot.ctx.emit('before-attach-user', session, userFields)
+    await session.observeUser(userFields)
+    return session
 }


### PR DESCRIPTION
## Problem

`ctx.chatluna.invoke({ routing: ... })` creates a virtual Koishi `Session` from `routing.userId`, but the session never loads the database-backed Koishi user record. As a result `session.user` is only `{ id, name }` and synchronous tool `authorization(session)` callbacks see `authority = 0`.

This breaks scheduled/manual Trigger runs: the task tool allowlist is correct, but tools that gate on `session.user.authority` (e.g. `koishi-plugin-qzone` requiring authority >= 1) are removed before the model can call them.

## Fix

`buildVirtualSession()` now hydrates the user exactly like koishi's attach-user middleware (`@koishijs/core/src/middleware.ts`):

- observe the standard field set `id / flag / authority / permissions / locales`
- emit `before-attach-user` so plugins can extend the observed fields
- `await session.observeUser(userFields)` before returning

Authority comes from Koishi's database, so callers cannot forge it.

Closes #1007