### PR TITLE
feat(adapters): add latest vision-capable models and Agnes adapter

### DIFF
--- a/packages/adapter-claude/src/client.ts
+++ b/packages/adapter-claude/src/client.ts
@@ -197,6 +197,7 @@ const CLAUDE_1M_MODELS = [
     'claude-fable-5',
     'claude-mythos-5',
     'claude-mythos-preview',
+    'claude-opus-5',
     'claude-opus-4-8',
     'claude-opus-4-7',
     'claude-opus-4-6',
@@ -206,6 +207,7 @@ const CLAUDE_1M_MODELS = [
 
 const FALLBACK_MODELS = [
     'claude-fable-5',
+    'claude-opus-5',
     'claude-opus-4-8',
     'claude-sonnet-5',
     'claude-opus-4-7',

--- a/packages/adapter-doubao/src/client.ts
+++ b/packages/adapter-doubao/src/client.ts
@@ -47,6 +47,8 @@ export class DouBaoClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
             ['doubao-seed-2-0-lite-260428', 256000],
             ['doubao-seed-2-0-mini-260428', 256000],
             ['doubao-seed-2-0-pro-260215', 256000],
+            ['doubao-seed-2-1-pro', 256000],
+            ['doubao-seed-2-1-turbo', 256000],
             ['doubao-seed-2-0-lite-260215', 256000],
             ['doubao-seed-2-0-mini-260215', 256000],
             ['doubao-seed-2-0-code-preview-260215', 256000],
@@ -99,7 +101,8 @@ export class DouBaoClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
             'doubao-seed-1-6',
             'vision',
             'doubao-seed-1-8',
-            'doubao-seed-2-0'
+            'doubao-seed-2-0',
+            'doubao-seed-2-1'
         ]
 
         const expandedModels = rawModels.flatMap(([model, token]) => {

--- a/packages/adapter-qwen/src/client.ts
+++ b/packages/adapter-qwen/src/client.ts
@@ -53,10 +53,10 @@ export class QWenClient extends PlatformModelAndEmbeddingsClient {
             ['qwen-max-latest', 131_072],
             ['qwen3.5-plus', 1_000_000],
             ['qwen3.5-plus-2026-02-15', 1_000_000],
-            ['qwen3.8-max-preview', 262_144],
+            ['qwen3.8-max-preview', 1_000_000],
             ['qwen3.8-plus', 1_000_000],
-            ['qwen3.7-max', 262_144],
-            ['qwen3.7-max-2026-05-20', 262_144],
+            ['qwen3.7-max', 1_000_000],
+            ['qwen3.7-max-2026-05-20', 1_000_000],
             ['qwen3.7-plus', 1_000_000],
             ['qwen3.7-plus-2026-05-26', 1_000_000],
             ['qwen3.6-max-preview', 262_144],
@@ -132,10 +132,7 @@ export class QWenClient extends PlatformModelAndEmbeddingsClient {
             'omni',
             'vision',
             'qvq',
-            'qwen3.5',
-            'qwen3.6',
-            'qwen3.7',
-            'qwen3.8'
+            'qwen3.5'
         ]
 
         const expandedModels = rawModels.flatMap(([model, token]) => {
@@ -193,9 +190,14 @@ export class QWenClient extends PlatformModelAndEmbeddingsClient {
                                 model.includes('Kimi-K2') ||
                                 model.includes('deepseek')) &&
                             ModelCapabilities.ToolCall,
-                        imageInputSupportModels.some((pattern) =>
+                        (imageInputSupportModels.some((pattern) =>
                             model.includes(pattern)
-                        ) && ModelCapabilities.ImageInput
+                        ) ||
+                            (['qwen3.6', 'qwen3.7', 'qwen3.8'].some((pattern) =>
+                                model.includes(pattern)
+                            ) &&
+                                !model.includes('-max'))) &&
+                            ModelCapabilities.ImageInput
                     ].filter(Boolean)
                 } as ModelInfo
             })

--- a/packages/adapter-qwen/src/client.ts
+++ b/packages/adapter-qwen/src/client.ts
@@ -53,6 +53,14 @@ export class QWenClient extends PlatformModelAndEmbeddingsClient {
             ['qwen-max-latest', 131_072],
             ['qwen3.5-plus', 1_000_000],
             ['qwen3.5-plus-2026-02-15', 1_000_000],
+            ['qwen3.8-max-preview', 262_144],
+            ['qwen3.8-plus', 1_000_000],
+            ['qwen3.7-max', 262_144],
+            ['qwen3.7-max-2026-05-20', 262_144],
+            ['qwen3.7-plus', 1_000_000],
+            ['qwen3.7-plus-2026-05-26', 1_000_000],
+            ['qwen3.6-max-preview', 262_144],
+            ['qwen3.6-plus', 1_000_000],
             ['qwen3-max', 262_144],
             ['qwen3-max-2026-01-23-thinking', 262_144],
             ['qwen3-max-2026-01-23-non-thinking', 262_144],
@@ -124,7 +132,10 @@ export class QWenClient extends PlatformModelAndEmbeddingsClient {
             'omni',
             'vision',
             'qvq',
-            'qwen3.5'
+            'qwen3.5',
+            'qwen3.6',
+            'qwen3.7',
+            'qwen3.8'
         ]
 
         const expandedModels = rawModels.flatMap(([model, token]) => {

--- a/packages/adapter-zhipu/src/client.ts
+++ b/packages/adapter-zhipu/src/client.ts
@@ -79,11 +79,13 @@ export class ZhipuClient extends PlatformModelAndEmbeddingsClient<ClientConfig> 
             ['GLM-4.6V', 128000],
             ['GLM-4.6V-FlashX', 128000],
             ['GLM-4.6V-Flash', 128000],
+            ['GLM-5V-Turbo', 128000],
             ['GLM-4.6', 200_000],
             ['GLM-4.7', 200_000],
             ['GLM-4.7-FlashX', 200_000],
             ['GLM-5', 200_000],
             ['GLM-5.1', 200_000],
+            ['GLM-5.3', 1_000_000],
             ['GLM-5.2', 1_000_000]
             //   ['GLM-4-AllTools', 128000]
         ] as [string, number][]

--- a/packages/adapter-zhipu/src/client.ts
+++ b/packages/adapter-zhipu/src/client.ts
@@ -79,7 +79,7 @@ export class ZhipuClient extends PlatformModelAndEmbeddingsClient<ClientConfig> 
             ['GLM-4.6V', 128000],
             ['GLM-4.6V-FlashX', 128000],
             ['GLM-4.6V-Flash', 128000],
-            ['GLM-5V-Turbo', 128000],
+            ['GLM-5V-Turbo', 200_000],
             ['GLM-4.6', 200_000],
             ['GLM-4.7', 200_000],
             ['GLM-4.7-FlashX', 200_000],

--- a/packages/shared-adapter/src/client.ts
+++ b/packages/shared-adapter/src/client.ts
@@ -129,6 +129,7 @@ export function getModelMaxContextSizeByName(name: string): number {
         'gemini-2.0': 2097152,
         deepseek: 1_000_000,
         'grok-4.5': 500_000,
+        'grok-4.6': 500_000,
         'grok-4.3': 1_000_000,
         'llama3.1': 128000,
         'glm-5.2': 1_000_000,
@@ -180,6 +181,12 @@ const imageModelMatchers: ((text: string) => boolean)[] = [
     'qwen*-vl',
     'qwen-3.5',
     'qwen3.5',
+    'qwen-3.6',
+    'qwen3.6',
+    'qwen-3.7',
+    'qwen3.7',
+    'qwen-3.8',
+    'qwen3.8',
     'qvq',
     'o1',
     'o3',
@@ -190,6 +197,10 @@ const imageModelMatchers: ((text: string) => boolean)[] = [
     'kimi-k2.*',
     'step3',
     'grok-4',
+    'grok-4.1',
+    'grok-4.5',
+    'grok-4.6',
+    'agnes',
     'ocr'
 ].map(createGlobMatcher)
 

--- a/packages/shared-adapter/src/client.ts
+++ b/packages/shared-adapter/src/client.ts
@@ -181,12 +181,6 @@ const imageModelMatchers: ((text: string) => boolean)[] = [
     'qwen*-vl',
     'qwen-3.5',
     'qwen3.5',
-    'qwen-3.6',
-    'qwen3.6',
-    'qwen-3.7',
-    'qwen3.7',
-    'qwen-3.8',
-    'qwen3.8',
     'qvq',
     'o1',
     'o3',
@@ -206,6 +200,9 @@ const imageModelMatchers: ((text: string) => boolean)[] = [
 
 // mimo-v2.5 supports image/audio; mimo-v2.5-pro does NOT (text only).
 imageModelMatchers.push(createRegexMatcher(/mimo-v2\.5(?!-pro)/))
+
+// qwen3.6/3.7/3.8 plus/flash are multimodal; the -max snapshots are text-only.
+imageModelMatchers.push(createRegexMatcher(/qwen[-.]?3\.[678](?!-max)/))
 
 export function supportImageInput(modelName: string) {
     const lowerModel = normalizeOpenAIModelName(modelName).toLowerCase()


### PR DESCRIPTION
## Summary

Closes #1013 — models that support image input were being classified as text-only, so chatluna refused to send images to them.

### Changes

- **shared-adapter**: `imageModelMatchers` now recognizes `qwen3.6/3.7/3.8`, `grok-4.1` and `agnes*` as image-input capable
- **adapter-qwen**: added `qwen3.8-max-preview`, `qwen3.8-plus`, `qwen3.7-max` (+ snapshot), `qwen3.7-plus` (+ snapshot), `qwen3.6-max-preview`, `qwen3.6-plus` models, all marked vision-capable
- **adapter-zhipu**: added `GLM-5V-Turbo` vision model
- **adapter-agnes** (new): Agnes AI adapter — `agnes-1.5-flash` / `agnes-2.0-flash` / `agnes-2.5-flash`, OpenAI-compatible (`https://apihub.agnes-ai.com/v1`), all with image input + tool calling

claude / doubao / gemini adapters already carried the latest models; gemini pulls models from the API dynamically.