### PR TITLE
fix(adapters): replace stale relay-site links with moyuu

### DIFF
--- a/packages/adapter-gemini/src/index.ts
+++ b/packages/adapter-gemini/src/index.ts
@@ -140,11 +140,11 @@ export const usage = `
 
 **如果你没有可用的 Gemini 格式 API，请前往以下地址注册：**
 
-[https://api.bltcy.ai/register](https://api.bltcy.ai/register?aff=ec5e312997)
+[https://moyuu.cc/register?aff=vhqh](https://moyuu.cc/register?aff=vhqh)
 
 完成后记得填写：
 - API Key：从注册的账号中复制
-- API 请求地址：\`https://api.bltcy.ai/v1beta\`
+- API 请求地址：\`https://moyuu.cc/v1beta\`
 `
 
 export const inject = {

--- a/packages/adapter-openai-like/src/index.ts
+++ b/packages/adapter-openai-like/src/index.ts
@@ -182,11 +182,11 @@ export const usage = `
 
 **如果你没有可用的 OpenAI 格式 API，请前往以下地址注册：**
 
-[https://api.bltcy.ai/register](https://api.bltcy.ai/register?aff=ec5e312997)
+[https://moyuu.cc/register?aff=vhqh](https://moyuu.cc/register?aff=vhqh)
 
 完成后记得填写：
 - API Key：从注册的账号中复制
-- API 请求地址：\`https://api.bltcy.ai/v1\`
+- API 请求地址：\`https://moyuu.cc/v1\`
 `
 
 export const inject = {

--- a/packages/adapter-openai/src/index.ts
+++ b/packages/adapter-openai/src/index.ts
@@ -115,11 +115,11 @@ export const usage = `
 
 **如果你没有可用的 OpenAI 格式 API，请前往以下地址注册：**
 
-[https://api.bltcy.ai/register](https://api.bltcy.ai/register?aff=ec5e312997)
+[https://moyuu.cc/register?aff=vhqh](https://moyuu.cc/register?aff=vhqh)
 
 完成后记得填写：
 - API Key：从注册的账号中复制
-- API 请求地址：\`https://api.bltcy.ai/v1\`
+- API 请求地址：\`https://moyuu.cc/v1\`
 `
 
 export const inject = {


### PR DESCRIPTION
Closes #1004

The openai / openai-like / gemini adapter usage descriptions still pointed at the outdated `api.bltcy.ai` relay. Both the registration link and the API endpoint are updated to moyuu:

- registration: `https://moyuu.cc/register?aff=vhqh`
- endpoints: `https://moyuu.cc/v1` (openai, openai-like) and `https://moyuu.cc/v1beta` (gemini)