### PR TITLE
fix(core): handle empty preset yaml files gracefully

### DIFF
--- a/packages/core/src/llm-core/prompt/preset_prompt_parse.ts
+++ b/packages/core/src/llm-core/prompt/preset_prompt_parse.ts
@@ -57,6 +57,10 @@ function createMessage(
 function loadYamlPreset(rawText: string): PresetTemplate {
     const rawJson = load(rawText) as RawPreset
 
+    if (!rawJson) {
+        return EMPTY_PRESET
+    }
+
     let loreBooks: PresetTemplate['loreBooks'] | undefined = {
         items: []
     }

--- a/packages/core/src/preset.ts
+++ b/packages/core/src/preset.ts
@@ -2,6 +2,7 @@ import fs from 'fs/promises'
 import { watch } from 'fs'
 import { Context, Logger, Schema } from 'koishi'
 import {
+    EMPTY_PRESET,
     loadPreset,
     PresetTemplate
 } from 'koishi-plugin-chatluna/llm-core/prompt'
@@ -64,6 +65,10 @@ export class PresetService {
         try {
             const rawText = await fs.readFile(filePath, 'utf-8')
             const preset = loadPreset(rawText)
+            if (preset === EMPTY_PRESET) {
+                logger.warn(`Preset ${filePath} is empty, skip`)
+                return null
+            }
             preset.path = filePath
             return preset
         } catch (e) {

--- a/packages/core/src/preset.ts
+++ b/packages/core/src/preset.ts
@@ -171,8 +171,11 @@ export class PresetService {
                     if (preset) {
                         this._updatePreset(preset)
                         logger.debug(`Updated/Added preset: ${filename}`)
-                        this._updateSchema()
+                    } else {
+                        this._removePreset(filePath)
+                        logger.debug(`Removed preset: ${filename}`)
                     }
+                    this._updateSchema()
                 } catch (e) {
                     if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
                         this._removePreset(filePath)


### PR DESCRIPTION
Fixes #1011

When a preset YAML file is empty (or contains only comments/whitespace), `js-yaml` `load()` returns `undefined`/`null`, and `loadYamlPreset` crashed with `TypeError: Cannot read properties of undefined (reading 'world_lores')`.

Changes:
- `loadYamlPreset` returns `EMPTY_PRESET` when the YAML parses to nothing
- `PresetService._loadPresetFromPath` skips empty presets with a warning instead of registering them