### PR TITLE
fix(core): use parent bindingKey when waking up agent tasks

### DIFF
--- a/packages/core/src/llm-core/agent/wakeup.ts
+++ b/packages/core/src/llm-core/agent/wakeup.ts
@@ -50,7 +50,11 @@ export function applyAgentTaskWakeup(ctx: Context, config: Config) {
             routing,
             message: content,
             messageName: 'task',
-            conversation: { type: 'existing', id: conversation.id },
+            conversation: {
+                type: 'existing',
+                id: conversation.id,
+                bindingKey: conversation.bindingKey
+            },
             delivery: 'channel',
             source: {
                 kind: 'agent-task',

--- a/packages/core/src/services/conversation.ts
+++ b/packages/core/src/services/conversation.ts
@@ -596,7 +596,7 @@ export class ConversationService {
                 await this.requireActiveTarget(
                     session,
                     input.target.id,
-                    undefined
+                    input.target.bindingKey
                 ),
                 input
             )

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -21,7 +21,7 @@ export type ChatInvocationTarget =
     | { type: 'route' }
     | { type: 'task'; key: string }
     | { type: 'fresh' }
-    | { type: 'existing'; id: string }
+    | { type: 'existing'; id: string; bindingKey?: string }
     | { type: 'ephemeral' }
 
 export interface ChatInvocationInput {


### PR DESCRIPTION
Fixes subagent background task wakeup failing with `Conversation does not belong to current route.` for non-admin users.

**Root cause**: when a background subagent task finishes, `applyAgentTaskWakeup` invokes the parent conversation via `ChatInvocationTarget` `{ type: 'existing', id }`. `prepareInvocation` → `requireActiveTarget` then re-derives the bindingKey from the wakeup session, which can differ from the parent conversation's stored bindingKey (e.g. preset lane differences). Admin users bypassed this via `checkAdmin`; regular users hit `CONVERSATION_TARGET_OUTSIDE_ROUTE`.

**Fix**: the wakeup passes the parent conversation's own `bindingKey` through `ChatInvocationTarget`, so `requireActiveTarget` resolves against the authoritative bindingKey and the permission check (`conversation.bindingKey === bindingKey`) matches. The bindingKey is still required to match, so there is no privilege escalation.