### PR TITLE
fix(core): make autoUpdateConversationModel work without rule

### DIFF
--- a/packages/core/src/services/conversation.ts
+++ b/packages/core/src/services/conversation.ts
@@ -207,7 +207,8 @@ export class ConversationService {
             fixedModel: firstDefined(constraints, 'fixedModel'),
             fixedPreset: firstDefined(constraints, 'fixedPreset'),
             fixedChatMode: firstDefined(constraints, 'fixedChatMode'),
-            autoUpdateModel: firstDefined(constraints, 'autoUpdateModel'),
+            autoUpdateModel:
+                firstDefined(constraints, 'autoUpdateModel') ?? true,
             lockConversation: firstBoolean(
                 constraints,
                 'lockConversation',


### PR DESCRIPTION
Fixes #1012

**Root cause**: the auto-update trigger in `resolve_conversation` required
`resolved.constraint.autoUpdateModel === true`, but `resolveConstraint`
defaulted `autoUpdateModel` to `undefined` when no rule was configured for the
route. So `undefined === true` was always false and the global
`autoUpdateConversationModel` switch never took effect.

**Fix**: default `autoUpdateModel` to `true` in `resolveConstraint` when no rule
sets it. The global switch now works as documented; per-route opt-out is still
possible via rule `autoUpdateModel: false` or `fixedModel`.