### PR TITLE
chore(packages): bump alpha versions

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -46,7 +46,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.48",
+        "@chatluna/v1-shared-adapter": "^1.0.49",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-claude-adapter",
     "description": "claude adapter for chatluna",
-    "version": "1.4.0-alpha.10",
+    "version": "1.4.0-alpha.11",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -47,7 +47,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.48",
+        "@chatluna/v1-shared-adapter": "^1.0.49",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-deepseek-adapter",
     "description": "deepseek adapter for chatluna",
-    "version": "1.4.0-alpha.14",
+    "version": "1.4.0-alpha.15",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.48",
+        "@chatluna/v1-shared-adapter": "^1.0.49",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-dify-adapter",
     "description": "dify adapter for chatluna",
-    "version": "1.4.0-alpha.5",
+    "version": "1.4.0-alpha.6",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.48",
+        "@chatluna/v1-shared-adapter": "^1.0.49",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-doubao-adapter",
     "description": "doubao adapter for chatluna",
-    "version": "1.4.0-alpha.8",
+    "version": "1.4.0-alpha.9",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.48",
+        "@chatluna/v1-shared-adapter": "^1.0.49",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.4.0-alpha.17",
+    "version": "1.4.0-alpha.18",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
     ],
     "dependencies": {
         "@anatine/zod-openapi": "^2.2.8",
-        "@chatluna/v1-shared-adapter": "^1.0.48",
+        "@chatluna/v1-shared-adapter": "^1.0.49",
         "@langchain/core": "^0.3.80",
         "openapi3-ts": "^4.5.0",
         "zod": "3.25.76",
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-hunyuan-adapter",
     "description": "hunyuan adapter for chatluna",
-    "version": "1.4.0-alpha.5",
+    "version": "1.4.0-alpha.6",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.48",
+        "@chatluna/v1-shared-adapter": "^1.0.49",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-ollama-adapter",
     "description": "ollama adapter for chatluna",
-    "version": "1.4.0-alpha.7",
+    "version": "1.4.0-alpha.8",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.48",
+        "@chatluna/v1-shared-adapter": "^1.0.49",
         "@langchain/core": "^0.3.80"
     },
     "devDependencies": {
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-like-adapter",
     "description": "openai style api adapter for chatluna",
-    "version": "1.4.0-alpha.13",
+    "version": "1.4.0-alpha.14",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.48",
+        "@chatluna/v1-shared-adapter": "^1.0.49",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-adapter",
     "description": "openai adapter for chatluna",
-    "version": "1.4.0-alpha.12",
+    "version": "1.4.0-alpha.13",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.48",
+        "@chatluna/v1-shared-adapter": "^1.0.49",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-qwen-adapter",
     "description": "qwen adapter for chatluna",
-    "version": "1.4.0-alpha.8",
+    "version": "1.4.0-alpha.9",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.48",
+        "@chatluna/v1-shared-adapter": "^1.0.49",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.48",
+        "@chatluna/v1-shared-adapter": "^1.0.49",
         "@langchain/core": "^0.3.80",
         "zod-to-json-schema": "3.23.5"
     },
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-spark-adapter",
     "description": "spark adapter for chatluna",
-    "version": "1.4.0-alpha.5",
+    "version": "1.4.0-alpha.6",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -61,7 +61,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.48",
+        "@chatluna/v1-shared-adapter": "^1.0.49",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-wenxin-adapter",
     "description": "wenxin adapter for chatluna",
-    "version": "1.4.0-alpha.5",
+    "version": "1.4.0-alpha.6",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.48",
+        "@chatluna/v1-shared-adapter": "^1.0.49",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-zhipu-adapter",
     "description": "zhipu(chatglm) adapter for chatluna",
-    "version": "1.4.0-alpha.7",
+    "version": "1.4.0-alpha.8",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.48",
+        "@chatluna/v1-shared-adapter": "^1.0.49",
         "@langchain/core": "^0.3.80",
         "jsonwebtoken": "^9.0.2",
         "zod": "3.25.76",
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.4.0-alpha.43",
+    "version": "1.4.0-alpha.44",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-agent",
     "description": "Agent framework for ChatLuna",
-    "version": "1.0.43",
+    "version": "1.0.44",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -91,7 +91,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-long-memory",
     "description": "long memory for chatluna",
-    "version": "1.4.0-alpha.0",
+    "version": "1.4.0-alpha.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-plugin-common",
     "description": "plugin service for agent mode of chatluna",
-    "version": "1.4.0-alpha.1",
+    "version": "1.4.0-alpha.2",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -67,12 +67,12 @@
         "atsc": "^2.1.0",
         "koishi": "^4.18.9",
         "koishi-plugin-adapter-onebot": "^6.8.0",
-        "koishi-plugin-chatluna-agent": "^1.0.43"
+        "koishi-plugin-chatluna-agent": "^1.0.44"
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43",
-        "koishi-plugin-chatluna-agent": "^1.0.43",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44",
+        "koishi-plugin-chatluna-agent": "^1.0.44",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-usage/package.json
+++ b/packages/extension-usage/package.json
@@ -61,7 +61,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44",
         "koishi-plugin-puppeteer": "^3.9.0"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "koishi": {
         "description": {

--- a/packages/service-multimodal/package.json
+++ b/packages/service-multimodal/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-multimodal-service",
     "description": "multimodal service for chatluna",
-    "version": "1.4.0-alpha.5",
+    "version": "1.4.0-alpha.6",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44",
         "koishi-plugin-ffmpeg-path": "^2.0.0"
     },
     "peerDependenciesMeta": {

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-search-service",
     "description": "search support for chatluna",
-    "version": "1.4.0-alpha.8",
+    "version": "1.4.0-alpha.9",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -70,13 +70,13 @@
     "devDependencies": {
         "atsc": "^2.1.0",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna-agent": "^1.0.43",
+        "koishi-plugin-chatluna-agent": "^1.0.44",
         "koishi-plugin-puppeteer": "^3.9.0"
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43",
-        "koishi-plugin-chatluna-agent": "^1.0.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44",
+        "koishi-plugin-chatluna-agent": "^1.0.44"
     },
     "peerDependenciesMeta": {
         "koishi-plugin-chatluna-agent": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@chatluna/v1-shared-adapter",
     "description": "chatluna shared adapter",
-    "version": "1.0.48",
+    "version": "1.0.49",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.43"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.44"
     }
 }


### PR DESCRIPTION
This pr bumps package alpha versions and synchronizes internal dependency ranges after the merged PRs below.

## Merged changes included
- #1003 fix(core): stop sub-agent streams from bubbling to parent
- #1005 feat(agent): add progressive MCP tool disclosure
- #1009 refactor(agent): unify run context and add integration harness
- #1014 fix(core): hydrate database user on virtual sessions from routing invocations
- #1015 fix(core): 修复会话模型自动更新并避免覆盖手动选定模型 (#1012)
- #1016 feat(adapters): add latest vision-capable models and Agnes adapter
- #1017 fix(adapters): replace stale relay-site links with moyuu
- #1018 fix(core): handle empty preset yaml files gracefully
- #1019 fix(core): use parent bindingKey when waking up agent tasks

## Other Changes
- Bump `koishi-plugin-chatluna` to `1.4.0-alpha.44`
- Bump `koishi-plugin-chatluna-agent` to `1.0.44`
- Bump `@chatluna/v1-shared-adapter` to `1.0.49`
- Bump the 17 affected adapters/extensions/services alpha versions
- Sync ChatLuna and agent dependency ranges across workspace packages

## Validation
- yarn fast-build (0 errors)