### PR TITLE
fix(adapters): filter empty text parts in message conversion

### DIFF
--- a/packages/adapter-claude/src/utils.ts
+++ b/packages/adapter-claude/src/utils.ts
@@ -320,10 +320,12 @@ async function processMessageContent(
         await Promise.all(
             content.map(async (message) => {
                 if (message.type === 'text') {
-                    return {
-                        type: 'text',
-                        text: message.text as string
-                    } as const
+                    return message.text.length > 0
+                        ? {
+                              type: 'text',
+                              text: message.text as string
+                          }
+                        : null
                 }
 
                 if (isMessageContentImageUrl(message)) {

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -87,7 +87,9 @@ export async function langchainMessageToGeminiMessage(
             message.additional_kwargs['thought_data'] ?? {}
         const parts =
             typeof message.content === 'string'
-                ? [{ text: message.content }]
+                ? message.content.length > 0
+                    ? [{ text: message.content }]
+                    : []
                 : await processGeminiContentParts(plugin, message.content)
 
         item.parts = [...getContextParts(thoughtData), ...parts]
@@ -359,7 +361,7 @@ async function processGeminiContentParts(
     const mappedParts = await Promise.all(
         content.map(async (part) => {
             if (isMessageContentText(part)) {
-                return { text: part.text }
+                return part.text.length > 0 ? { text: part.text } : null
             }
             if (isMessageContentImageUrl(part)) {
                 return await processGeminiImageContent(plugin, part)

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -34,7 +34,8 @@ import { logger } from 'koishi-plugin-chatluna'
 import {
     getImageMimeType,
     getMimeTypeFromSource,
-    isMessageContentImageUrl
+    isMessageContentImageUrl,
+    isMessageContentText
 } from 'koishi-plugin-chatluna/utils/string'
 import {
     isChatLunaUserMessage,
@@ -447,6 +448,9 @@ export async function langchainMessageToOpenAIMessage(
                 supportImageInputType === true
             const mappedContent = await Promise.all(
                 msg.content.map(async (content) => {
+                    if (isMessageContentText(content)) {
+                        return content.text.length > 0 ? content : null
+                    }
                     if (isMessageContentImageUrl(content)) {
                         if (!supportsImage) {
                             logger.warn(


### PR DESCRIPTION
## 问题

多模态消息转换时，空文本 part（如 `{type:'text', text:''}`）会被原样透传到模型请求中，例如 Gemini 请求里出现 `{"text":""}` 空 text part，可能导致部分 API 报错。

空 text part 的来源包括：`fileInsertPrompt` 未配置（默认空字符串）时 `read_files` 注入的多模态消息、content 为空字符串的消息等。

## 修复

在适配器消息转换层统一过滤空文本 part（最小判断 `length > 0`）：

- **shared-adapter** (`langchainMessageToOpenAIMessage`): 数组 content 中空 text part 丢弃 —— 覆盖所有 OpenAI 兼容适配器（openai / openai-like / azure-openai / deepseek / qwen / doubao / rwkv / hunyuan / spark / wenxin / zhipu）
- **adapter-gemini** (`processGeminiContentParts` + `langchainMessageToGeminiMessage`): 空 text part 丢弃；字符串 content 为空时不生成 `[{text:''}]`
- **adapter-claude** (`processMessageContent`): 空 text block 丢弃

ollama / dify 走字符串/文本提取路径，无空 part 结构问题，无需修改。

## Validation

- yarn fast-build (shared-adapter / adapter-gemini / adapter-claude) 0 errors