### PR TITLE
fix(core): guard world_lores as array when loading preset

### DIFF
--- a/packages/core/src/llm-core/prompt/preset_prompt_parse.ts
+++ b/packages/core/src/llm-core/prompt/preset_prompt_parse.ts
@@ -67,7 +67,7 @@ function loadYamlPreset(rawText: string): PresetTemplate {
 
     let authorsNote: PresetTemplate['authorsNote'] | undefined
 
-    if (rawJson.world_lores) {
+    if (rawJson.world_lores && Array.isArray(rawJson.world_lores)) {
         const config = rawJson.world_lores.find(
             isRoleBookConfig
         ) as RoleBookConfig


### PR DESCRIPTION
## 问题

在加载 preset 时，如果 YAML 中的 `world_lores` 字段不是数组（例如为 `null` 或空对象），调用 `rawJson.world_lores.find(...)` 会抛错，导致 preset 加载失败。

## 修复

在调用 `find` 前先检查 `Array.isArray(rawJson.world_lores)`，非数组时跳过 world lore 解析。

## 变更

- `packages/core/src/llm-core/prompt/preset_prompt_parse.ts`: 增加数组类型守卫