### PR TITLE
fix(adapters): enable image input for deepseek vision models

### DIFF
--- a/packages/adapter-deepseek/src/client.ts
+++ b/packages/adapter-deepseek/src/client.ts
@@ -18,11 +18,9 @@ import {
 import { DeepseekRequester } from './requester'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { Config, logger as pluginLogger } from '.'
-import {
-    getOpenAIFileHandlingConfig,
-    supportImageInput
-} from '@chatluna/v1-shared-adapter'
+import { supportImageInput } from '@chatluna/v1-shared-adapter'
 import { RunnableConfig } from '@langchain/core/runnables'
+import { deepseekFileHandlingConfig } from './utils'
 
 import type { ModelUsageReporter } from 'koishi-plugin-chatluna/llm-core/platform/usage'
 
@@ -134,7 +132,9 @@ export class DeepseekClient extends PlatformModelAndEmbeddingsClient<ClientConfi
                 temperature: this._config.temperature,
                 maxRetries: this._config.maxRetries,
                 llmType: 'deepseek',
-                fileHandlingConfig: getOpenAIFileHandlingConfig(model),
+                fileHandlingConfig: supportImageInput(model)
+                    ? deepseekFileHandlingConfig
+                    : undefined,
                 isThinkModel:
                     model.includes('reasoner') ||
                     model.includes('thinking') ||

--- a/packages/adapter-deepseek/src/client.ts
+++ b/packages/adapter-deepseek/src/client.ts
@@ -18,6 +18,10 @@ import {
 import { DeepseekRequester } from './requester'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { Config, logger as pluginLogger } from '.'
+import {
+    getOpenAIFileHandlingConfig,
+    supportImageInput
+} from '@chatluna/v1-shared-adapter'
 import { RunnableConfig } from '@langchain/core/runnables'
 
 import type { ModelUsageReporter } from 'koishi-plugin-chatluna/llm-core/platform/usage'
@@ -83,7 +87,12 @@ export class DeepseekClient extends PlatformModelAndEmbeddingsClient<ClientConfi
                         maxTokens: 1_000_000,
                         capabilities:
                             type === ModelType.llm
-                                ? [ModelCapabilities.ToolCall]
+                                ? [
+                                      ModelCapabilities.ToolCall,
+                                      supportImageInput(model)
+                                          ? ModelCapabilities.ImageInput
+                                          : null
+                                  ].filter(Boolean)
                                 : []
                     } as ModelInfo
                 })
@@ -125,6 +134,7 @@ export class DeepseekClient extends PlatformModelAndEmbeddingsClient<ClientConfi
                 temperature: this._config.temperature,
                 maxRetries: this._config.maxRetries,
                 llmType: 'deepseek',
+                fileHandlingConfig: getOpenAIFileHandlingConfig(model),
                 isThinkModel:
                     model.includes('reasoner') ||
                     model.includes('thinking') ||

--- a/packages/adapter-deepseek/src/utils.ts
+++ b/packages/adapter-deepseek/src/utils.ts
@@ -1,0 +1,13 @@
+import { FileHandlingConfig } from 'koishi-plugin-chatluna/llm-core/platform/client'
+
+// https://api-docs.deepseek.com/guides/vision
+export const deepseekFileHandlingConfig: FileHandlingConfig = {
+    supportedMimeTypes: new Set([
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'image/webp'
+    ]),
+    maxTotalSizeBytes: 48 * 1024 * 1024,
+    maxFileSizeBytes: 32 * 1024 * 1024
+}


### PR DESCRIPTION
## 问题

通过 deepseek 适配器使用官方 API 的视觉模型（如 `deepseek-v4-flash-vision-exp`，官方 API 实测支持识图）时，ChatLuna 仍然无法识别图片。

## 原因

`adapter-deepseek/src/client.ts` 的 `refreshModels()` 给所有 LLM 模型的 capabilities 只授予了 `ToolCall`，**从未授予 `ImageInput`**。即使模型名带 `vision`（`supportImageInput('deepseek-v4-flash-vision-exp')` 本应返回 true），模型能力里也没有 `image_input`，导致：

1. `read_chat_message` 中间件里 `modelInfoSupportsElement` 判定图片不支持，图片元素被替换为 `[image:<hash>]` 文本占位符，模型根本收不到图片；
2. 模型层缺少 `fileHandlingConfig`（允许的图片 MIME 类型）。

对比 openai-like 适配器，它用 `supportImageInput(model)` 决定是否授予 `ImageInput`。

## 修复

参照 openai-like 适配器的做法：

- capabilities 增加 `ImageInput`（通过共享的 `supportImageInput(model)` 判定，含 `vision` 关键字的模型自动获得图像输入能力）；
- `_createModel` 传入 `fileHandlingConfig: getOpenAIFileHandlingConfig(model)`。

## 变更

- `packages/adapter-deepseek/src/client.ts`: 为视觉模型授予 ImageInput capability 并补充 fileHandlingConfig