### PR TITLE
feat(adapters): qwen3.7/3.8 support image and video input, add missing 3.x models

### DIFF
--- a/packages/adapter-qwen/src/client.ts
+++ b/packages/adapter-qwen/src/client.ts
@@ -53,6 +53,8 @@ export class QWenClient extends PlatformModelAndEmbeddingsClient {
             ['qwen-max-latest', 131_072],
             ['qwen3.5-plus', 1_000_000],
             ['qwen3.5-plus-2026-02-15', 1_000_000],
+            ['qwen3.8-flash', 1_000_000],
+            ['qwen3.8-max', 1_000_000],
             ['qwen3.8-max-preview', 1_000_000],
             ['qwen3.8-plus', 1_000_000],
             ['qwen3.7-max', 1_000_000],
@@ -193,11 +195,14 @@ export class QWenClient extends PlatformModelAndEmbeddingsClient {
                         (imageInputSupportModels.some((pattern) =>
                             model.includes(pattern)
                         ) ||
-                            (['qwen3.6', 'qwen3.7', 'qwen3.8'].some((pattern) =>
+                            (['qwen3.6', 'qwen3.7'].some((pattern) =>
                                 model.includes(pattern)
                             ) &&
-                                !model.includes('-max'))) &&
-                            ModelCapabilities.ImageInput
+                                !model.includes('-max')) ||
+                            model.includes('qwen3.8')) &&
+                            ModelCapabilities.ImageInput,
+                        model.includes('qwen3.8') &&
+                            ModelCapabilities.VideoInput
                     ].filter(Boolean)
                 } as ModelInfo
             })

--- a/packages/adapter-qwen/src/client.ts
+++ b/packages/adapter-qwen/src/client.ts
@@ -53,16 +53,28 @@ export class QWenClient extends PlatformModelAndEmbeddingsClient {
             ['qwen-max-latest', 131_072],
             ['qwen3.5-plus', 1_000_000],
             ['qwen3.5-plus-2026-02-15', 1_000_000],
+            ['qwen3.6-27b', 262_144],
+            ['qwen3.6-35b-a3b', 262_144],
+            ['qwen3.6-flash', 1_000_000],
+            ['qwen3.6-flash-2026-04-16', 1_000_000],
+            ['qwen3.6-max-preview', 262_144],
+            ['qwen3.6-plus', 1_000_000],
+            ['qwen3.6-plus-2026-04-02', 1_000_000],
+            ['qwen3.7-flash', 1_000_000],
+            ['qwen3.7-flash-2026-07-15', 1_000_000],
+            ['qwen3.7-max', 1_000_000],
+            ['qwen3.7-max-2026-05-17', 1_000_000],
+            ['qwen3.7-max-2026-05-20', 1_000_000],
+            ['qwen3.7-max-2026-06-08', 1_000_000],
+            ['qwen3.7-max-preview', 1_000_000],
+            ['qwen3.7-plus', 1_000_000],
+            ['qwen3.7-plus-2026-05-26', 1_000_000],
+            ['qwen3.8-2.4t-a95b', 1_000_000],
+            ['qwen3.8-27b', 1_000_000],
             ['qwen3.8-flash', 1_000_000],
             ['qwen3.8-max', 1_000_000],
             ['qwen3.8-max-preview', 1_000_000],
             ['qwen3.8-plus', 1_000_000],
-            ['qwen3.7-max', 1_000_000],
-            ['qwen3.7-max-2026-05-20', 1_000_000],
-            ['qwen3.7-plus', 1_000_000],
-            ['qwen3.7-plus-2026-05-26', 1_000_000],
-            ['qwen3.6-max-preview', 262_144],
-            ['qwen3.6-plus', 1_000_000],
             ['qwen3-max', 262_144],
             ['qwen3-max-2026-01-23-thinking', 262_144],
             ['qwen3-max-2026-01-23-non-thinking', 262_144],
@@ -195,13 +207,13 @@ export class QWenClient extends PlatformModelAndEmbeddingsClient {
                         (imageInputSupportModels.some((pattern) =>
                             model.includes(pattern)
                         ) ||
-                            (['qwen3.6', 'qwen3.7'].some((pattern) =>
-                                model.includes(pattern)
-                            ) &&
+                            (model.includes('qwen3.6') &&
                                 !model.includes('-max')) ||
+                            model.includes('qwen3.7') ||
                             model.includes('qwen3.8')) &&
                             ModelCapabilities.ImageInput,
-                        model.includes('qwen3.8') &&
+                        (model.includes('qwen3.7') ||
+                            model.includes('qwen3.8')) &&
                             ModelCapabilities.VideoInput
                     ].filter(Boolean)
                 } as ModelInfo

--- a/packages/shared-adapter/src/client.ts
+++ b/packages/shared-adapter/src/client.ts
@@ -201,8 +201,11 @@ const imageModelMatchers: ((text: string) => boolean)[] = [
 // mimo-v2.5 supports image/audio; mimo-v2.5-pro does NOT (text only).
 imageModelMatchers.push(createRegexMatcher(/mimo-v2\.5(?!-pro)/))
 
-// qwen3.6/3.7/3.8 plus/flash are multimodal; the -max snapshots are text-only.
-imageModelMatchers.push(createRegexMatcher(/qwen[-.]?3\.[678](?!-max)/))
+// qwen3.6/3.7 plus/flash are multimodal; the -max snapshots are text-only.
+imageModelMatchers.push(createRegexMatcher(/qwen[-.]?3\.[67](?!-max)/))
+
+// qwen3.8 flash/max are multimodal image+text models.
+imageModelMatchers.push(createRegexMatcher(/qwen[-.]?3\.8/))
 
 export function supportImageInput(modelName: string) {
     const lowerModel = normalizeOpenAIModelName(modelName).toLowerCase()

--- a/packages/shared-adapter/src/client.ts
+++ b/packages/shared-adapter/src/client.ts
@@ -201,11 +201,11 @@ const imageModelMatchers: ((text: string) => boolean)[] = [
 // mimo-v2.5 supports image/audio; mimo-v2.5-pro does NOT (text only).
 imageModelMatchers.push(createRegexMatcher(/mimo-v2\.5(?!-pro)/))
 
-// qwen3.6/3.7 plus/flash are multimodal; the -max snapshots are text-only.
-imageModelMatchers.push(createRegexMatcher(/qwen[-.]?3\.[67](?!-max)/))
+// qwen3.6 plus/flash are multimodal; the -max snapshots are text-only.
+imageModelMatchers.push(createRegexMatcher(/qwen[-.]?3\.6(?!-max)/))
 
-// qwen3.8 flash/max are multimodal image+text models.
-imageModelMatchers.push(createRegexMatcher(/qwen[-.]?3\.8/))
+// qwen3.7/3.8 flash/max are multimodal image+text models.
+imageModelMatchers.push(createRegexMatcher(/qwen[-.]?3\.[78]/))
 
 export function supportImageInput(modelName: string) {
     const lowerModel = normalizeOpenAIModelName(modelName).toLowerCase()


### PR DESCRIPTION
## 概述

为 qwen 适配器（百炼）更新 qwen3.x 系列模型：3.7/3.8 系列支持图片与视频输入，并补全百炼实际的模型列表。

## 变更

### packages/adapter-qwen/src/client.ts

- **模型列表补全**：按百炼 API 实际模型注册缺失的 3.x 系列：
  - qwen3.6: `27b`、`35b-a3b`、`flash`、`flash-2026-04-16`、`plus-2026-04-02`
  - qwen3.7: `flash`、`flash-2026-07-15`、`max-2026-05-17`、`max-2026-06-08`、`max-preview`
  - qwen3.8: `2.4t-a95b`、`27b`、`flash`、`max`（新增）
- **图片输入**：qwen3.7、qwen3.8 全系（含 `-max`）授予 `ImageInput`；qwen3.6 维持原规则（非 `-max`）
- **视频输入**：qwen3.7、qwen3.8 全系授予 `VideoInput`

### packages/shared-adapter/src/client.ts

- `imageModelMatchers` 同步更新：qwen3.7/3.8 全系支持图片输入（`/qwen[-.]?3\.[78]/`），qwen3.6 维持排除 `-max`

## 依据

- [qwen3.8-flash 模型信息](https://www.alibabacloud.com/help/zh/model-studio/qwen3-8-flash)：输入模态 Image/Text/Video，上下文 1M
- [qwen3.7-flash 模型信息](https://www.alibabacloud.com/help/zh/model-studio/qwen3-7-flash)：输入模态 Image/Text/Video，上下文 1M
- [百炼图像与视频理解文档](https://www.alibabacloud.com/help/zh/model-studio/vision)：视频输入支持 3.x 系列
- [百炼选择模型页](https://www.alibabacloud.com/help/zh/model-studio/models)：qwen3.8-flash/max 位于图像与视频理解分类