### PR TITLE
fix(adapters): ignore empty function_call from streaming deltas

### DIFF
--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -981,7 +981,14 @@ export function convertDeltaToMessageChunk(
         function_call?: any
         reasoning_content?: string
     } = {}
-    if (delta.function_call) {
+    // Some proxies (e.g. DeepSeek V4 relays) emit an empty function_call
+    // object ({ arguments: '', name: '' }) on the final tool_calls chunk.
+    // Ignore it so the agent does not see a phantom empty tool call.
+    if (
+        delta.function_call &&
+        ((delta.function_call.name?.length ?? 0) > 0 ||
+            (delta.function_call.arguments?.length ?? 0) > 0)
+    ) {
         additionalKwargs.function_call = delta.function_call
     }
 


### PR DESCRIPTION
## 问题

群友反馈（issue #1027）：使用中转站（如 openlux）的 deepseek-v4-flash-0731 时，Agent 陷入循环，持续调用模型直到 iteration limit（105 轮）。模型每轮输出空工具调用 `tool_calls: [{"name":"","args":{}}]`。

## 根因

某些 DeepSeek V4 中转站在流式工具调用的**收尾 chunk**（`finish_reason: "tool_calls"`）里返回**空 function_call 对象**（`{"arguments":"","name":""}`），而非规范要求的 `null`（已在 openlux API 实测复现）。

ChatLuna 的 `convertDeltaToMessageChunk` 把该空对象透传进 `additional_kwargs.function_call`，而 agent 的动态解析器切换逻辑（`createOpenAIAgent`）：

```ts
const hasFunction = input.additional_kwargs?.function_call != null
if (hasTools && parser是functions) → 切到 tools
else if (hasFunction && parser是tools) → 切到 functions parser
```

检测到残留的 function_call 后把解析器从 `OpenAIToolsAgentOutputParser` 切到 `OpenAIFunctionsAgentOutputParser`，后者读取空 function_call 返回 `tool: ""` 的 AgentAction，executor 找不到空名工具，错误 observation 喂回模型后再次输出同样结果，循环直到 iteration limit。

## 修复

`packages/shared-adapter/src/utils.ts`：`convertDeltaToMessageChunk` 只在 function_call **含实际内容**（name 或 arguments 非空）时才透传，忽略空对象。

## 验证

- openlux 实测复现空 function_call chunk
- 修复后空 function_call 不再进入 `additional_kwargs`（chunks 14→13），tool_calls 正确聚合，两轮工具调用正常

Closes #1027